### PR TITLE
implements distinct accounts for vault

### DIFF
--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -691,9 +691,8 @@ pub mod pallet {
 			Ok(vault.lp_token_id)
 		}
 
-		// TODO: we can use the `VaultId` + into_sub_account to have distinct addresses per vault.
-		fn account_id(_vault: &Self::VaultId) -> Self::AccountId {
-			T::PalletId::get().into_account()
+		fn account_id(vault: &Self::VaultId) -> Self::AccountId {
+			T::PalletId::get().into_sub_account(vault)
 		}
 
 		fn create(

--- a/frame/vault/src/mocks/tests.rs
+++ b/frame/vault/src/mocks/tests.rs
@@ -11,7 +11,7 @@ use sp_runtime::{
 };
 
 pub type BlockNumber = u64;
-pub type AccountId = u32;
+pub type AccountId = u128;
 pub type Balance = u128;
 pub type Amount = i128;
 


### PR DESCRIPTION
Vault were previously sharing the same account.
This was a bug as funds should not be shared.
We were using the pallet account when computing the assets under management,
which would lead to wrong result when >1 vaults were based on the same asset.