### PR TITLE
enable CI on develop branch

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - develop
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
seems like no checks were run on PRs for develop, this should enable that.