### PR TITLE
Use NativeCurrency associated type instead of querying for native id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,6 +6535,7 @@ dependencies = [
  "num-traits",
  "orml-tokens",
  "orml-traits 0.4.1-dev (git+https://github.com/open-web3-stack/open-runtime-module-library?rev=37e42936c41dbdbaf0117c628c9eab0e06044844)",
+ "pallet-balances",
  "parity-scale-codec",
  "proptest",
  "serde",

--- a/frame/vault/Cargo.toml
+++ b/frame/vault/Cargo.toml
@@ -35,6 +35,7 @@ proptest = "0.9.6"
 serde = "1.0.119"
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "37e42936c41dbdbaf0117c628c9eab0e06044844" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "37e42936c41dbdbaf0117c628c9eab0e06044844", default-features = false }
+pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.10" }
 
 [features]
 default = ["std"]

--- a/frame/vault/src/mocks/tests.rs
+++ b/frame/vault/src/mocks/tests.rs
@@ -45,7 +45,7 @@ impl system::Config for Test {
 	type BlockLength = ();
 	type Version = ();
 	type PalletInfo = PalletInfo;
-	type AccountData = ();
+	type AccountData = pallet_balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type DbWeight = ();
@@ -53,6 +53,22 @@ impl system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = ();
 	type OnSetCode = ();
+}
+
+parameter_types! {
+	pub const BalanceExistentialDeposit: u64 = 1;
+}
+
+impl pallet_balances::Config for Test {
+	type Balance = Balance;
+	type Event = Event;
+	type DustRemoval = ();
+	type ExistentialDeposit = BalanceExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type MaxLocks = ();
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 8];
 }
 
 parameter_types! {
@@ -80,7 +96,7 @@ impl pallet_vault::Config for Test {
 	type CreationDeposit = CreationDeposit;
 	type ExistentialDeposit = ExistentialDeposit;
 	type RentPerBlock = RentPerBlock;
-	type NativeAssetId = NativeAssetId;
+	type NativeCurrency = Balances;
 	type MinimumDeposit = MinimumDeposit;
 	type MinimumWithdrawal = MinimumWithdrawal;
 	type TombstoneDuration = TombstoneDuration;
@@ -130,6 +146,7 @@ construct_runtime!(
 		Vaults: pallet_vault::{Pallet, Call, Storage, Event<T>},
 		Factory: crate::mocks::currency_factory::{Pallet, Call, Storage, Event<T>},
 		Strategy: crate::mocks::strategy::{Pallet, Call, Storage, Event<T>},
+		Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
 	}
 );
 
@@ -146,6 +163,10 @@ impl Default for ExtBuilder {
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+
+		pallet_balances::GenesisConfig::<Test> { balances: vec![(ALICE, 1000000)] }
+			.assimilate_storage(&mut t)
+			.unwrap();
 
 		orml_tokens::GenesisConfig::<Test> { balances: self.balances }
 			.assimilate_storage(&mut t)

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -800,7 +800,7 @@ impl vault::Config for Runtime {
 	type CreationDeposit = CreationDeposit;
 	type ExistentialDeposit = VaultExistentialDeposit;
 	type RentPerBlock = RentPerBlock;
-	type NativeAssetId = NativeAssetId;
+	type NativeCurrency = Balances;
 	type MinimumDeposit = VaultMinimumDeposit;
 	type MinimumWithdrawal = VaultMinimumWithdrawal;
 	type TombstoneDuration = TombstoneDuration;


### PR DESCRIPTION
A slightly nicer way to handle 2 different currency types in the vaults pallet.