### PR TITLE
added one more check for low provider edge case

### DIFF
--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -314,6 +314,8 @@ pub mod pallet {
 		/// Too many weighted averages requested
 		DepthTooLarge,
 		ArithmeticError,
+		/// Block interval is less then stale price
+		BlockIntervalLength,
 	}
 
 	#[pallet::hooks]
@@ -373,6 +375,7 @@ pub mod pallet {
 			ensure!(max_answers >= min_answers, Error::<T>::MaxAnswersLessThanMinAnswers);
 			ensure!(threshold < Percent::from_percent(100), Error::<T>::ExceedThreshold);
 			ensure!(max_answers <= T::MaxAnswerBound::get(), Error::<T>::ExceedMaxAnswers);
+			ensure!(block_interval > T::StalePrice::get(), Error::<T>::BlockIntervalLength);
 			ensure!(
 				AssetsCount::<T>::get() < T::MaxAssetsCount::get(),
 				Error::<T>::ExceedAssetsCount

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -34,6 +34,7 @@ fn add_asset_and_info() {
 			MAX_ANSWERS,
 			BLOCK_INTERVAL
 		));
+
 		assert_ok!(Oracle::add_asset_and_info(
 			Origin::signed(account_2),
 			ASSET_ID + 1,
@@ -124,6 +125,18 @@ fn add_asset_and_info() {
 				BLOCK_INTERVAL
 			),
 			Error::<Test>::ExceedAssetsCount
+		);
+
+		assert_noop!(
+			Oracle::add_asset_and_info(
+				Origin::signed(account_2),
+				ASSET_ID,
+				THRESHOLD,
+				MIN_ANSWERS,
+				MAX_ANSWERS,
+				BLOCK_INTERVAL - 4
+			),
+			Error::<Test>::BlockIntervalLength
 		);
 	});
 }


### PR DESCRIPTION
Pretty much this ensures to avoid an edge case where stale price never triggers and the aggregation restarts. I think this is a clean and easy way to do it which is not limiting, say setting stale price to 3 and block interval to 5 on most asset IDs is completely acceptable in my eyes