### PR TITLE
CU-1kr011f - merge allocations in StrategyOverview

### DIFF
--- a/frame/vault/src/models.rs
+++ b/frame/vault/src/models.rs
@@ -2,6 +2,7 @@ use crate::Capabilities;
 use composable_traits::vault::Deposit;
 use frame_support::pallet_prelude::*;
 use scale_info::TypeInfo;
+use sp_runtime::Perquintill;
 
 #[derive(Copy, Clone, Encode, Decode, Default, Debug, PartialEq, TypeInfo)]
 pub struct VaultInfo<AccountId, Balance, CurrencyId, BlockNumber> {
@@ -14,6 +15,8 @@ pub struct VaultInfo<AccountId, Balance, CurrencyId, BlockNumber> {
 
 #[derive(Copy, Clone, Encode, Decode, Default, Debug, PartialEq, TypeInfo)]
 pub struct StrategyOverview<Balance> {
+	// The allocation of this strategy
+	pub allocation: Perquintill,
 	/// The reported balance of the strategy
 	pub balance: Balance,
 	/// Sum of all withdrawn funds.


### PR DESCRIPTION
Both Allocations and CapitaalStructure storage map were tied.
Which mean you couldn't have an allocation without having a StrategyOverview.
This was wrong for the case of the reserve, as the vault itself has an
allocation (the reserve) but no StrategyOverview.

Because of that, one could trigger a panic by asking for `available_funds` using
the vault id.
We fix this issue by merging the allocation inside the StrategyOverview and removing the allocation of the vault.