### PR TITLE
Initial XCM abstraction development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6242,6 +6242,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-composable_xcm"
+version = "1.0.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-io",
+ "sp-runtime",
+ "xcm",
+]
+
+[[package]]
 name = "pallet-crowdloan-bonus"
 version = "0.0.1"
 dependencies = [
@@ -6269,7 +6282,6 @@ dependencies = [
 name = "pallet-crowdloan-rewards"
 version = "0.0.1"
 dependencies = [
- "composable-traits",
  "frame-support",
  "frame-system",
  "hex",
@@ -6993,24 +7005,6 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-vault-group"
-version = "0.1.0"
-dependencies = [
- "composable-traits",
- "frame-support",
- "frame-system",
- "pallet-balances",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec 1.7.0",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/frame/xcm/Cargo.toml
+++ b/frame/xcm/Cargo.toml
@@ -1,0 +1,33 @@
+[dependencies]
+frame-support = { branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate"  }
+frame-system = { branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate" }
+parity-scale-codec = { default-features = false, version = "2.0" }
+scale-info = { default-features = false, features = ["derive"], version = "1.0" }
+sp-runtime = { branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate" }
+xcm = { branch = "release-v0.9.12", default-features = false, git = "https://github.com/paritytech/polkadot" }
+
+[dev-dependencies]
+sp-io = { branch = "polkadot-v0.9.12", default-features = false, git = "https://github.com/paritytech/substrate" }
+
+[features]
+default = ["std"]
+std = [
+    "frame-support/std",
+    "frame-system/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-runtime/std",
+    "xcm/std"
+]
+
+[package]
+name = "pallet-composable_xcm"
+version = "1.0.0"
+authors = ["Composable Developers"]
+homepage = "https://composable.finance"
+edition = "2021"
+rust-version = "1.56"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+

--- a/frame/xcm/src/blockchain.rs
+++ b/frame/xcm/src/blockchain.rs
@@ -1,0 +1,5 @@
+mod karura;
+mod moonbeam;
+
+pub use karura::*;
+pub use moonbeam::*;

--- a/frame/xcm/src/blockchain/karura.rs
+++ b/frame/xcm/src/blockchain/karura.rs
@@ -1,0 +1,9 @@
+use crate::{IntoXcm, TransferParams};
+
+pub struct KaruraTransferParams;
+
+impl IntoXcm<(), KaruraTransferParams> for TransferParams {
+	fn into_xcm(_data: (), _from: KaruraTransferParams) -> Self {
+		Self {}
+	}
+}

--- a/frame/xcm/src/blockchain/moonbeam.rs
+++ b/frame/xcm/src/blockchain/moonbeam.rs
@@ -1,0 +1,9 @@
+use crate::{IntoXcm, TransferParams};
+
+pub struct MoonbeamTransferParams;
+
+impl IntoXcm<(), MoonbeamTransferParams> for TransferParams {
+	fn into_xcm(_data: (), _from: MoonbeamTransferParams) -> Self {
+		Self {}
+	}
+}

--- a/frame/xcm/src/lib.rs
+++ b/frame/xcm/src/lib.rs
@@ -1,0 +1,41 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod blockchain;
+mod mock;
+mod operation_params;
+mod pallet_api;
+mod tests;
+
+pub use operation_params::*;
+pub use pallet::*;
+pub use pallet_api::*;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use crate::{PalletApi, TransferParams};
+	use frame_support::traits::Hooks;
+	use xcm::v2::ExecuteXcm;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {}
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type XcmExecutor: ExecuteXcm<Self::Call>;
+	}
+
+	#[pallet::error]
+	pub enum Error<T> {}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	impl<T> PalletApi for Pallet<T> {
+		fn transfer(_params: TransferParams) {
+			todo!()
+		}
+	}
+}

--- a/frame/xcm/src/mock.rs
+++ b/frame/xcm/src/mock.rs
@@ -1,0 +1,64 @@
+#![cfg(test)]
+
+use crate::{self as composable_xcm};
+use frame_support::{construct_runtime, traits::Everything};
+use sp_runtime::{
+	testing::{Header, H256},
+	traits::IdentityLookup,
+};
+
+type AccountId = u128;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+construct_runtime!(
+	pub enum Runtime
+	where
+		Block = Block,
+		NodeBlock = Block,
+		UncheckedExtrinsic = UncheckedExtrinsic,
+	{
+		ComposableXcm: composable_xcm::{Pallet},
+		System: frame_system::{Call, Config, Event<T>, Pallet, Storage},
+	}
+);
+
+impl composable_xcm::Config for Runtime {
+	type XcmExecutor = ();
+}
+
+impl frame_system::Config for Runtime {
+	type AccountData = ();
+	type AccountId = AccountId;
+	type BaseCallFilter = Everything;
+	type BlockHashCount = ();
+	type BlockLength = ();
+	type BlockNumber = u64;
+	type BlockWeights = ();
+	type Call = Call;
+	type DbWeight = ();
+	type Event = ();
+	type Hash = H256;
+	type Hashing = sp_runtime::traits::BlakeTwo256;
+	type Header = Header;
+	type Index = u64;
+	type Lookup = IdentityLookup<AccountId>;
+	type OnKilledAccount = ();
+	type OnNewAccount = ();
+	type OnSetCode = ();
+	type Origin = Origin;
+	type PalletInfo = PalletInfo;
+	type SS58Prefix = ();
+	type SystemWeightInfo = ();
+	type Version = ();
+}
+
+#[derive(Default)]
+pub struct ExtBuilder;
+
+impl ExtBuilder {
+	pub fn build(self) -> sp_io::TestExternalities {
+		let t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+		t.into()
+	}
+}

--- a/frame/xcm/src/operation_params.rs
+++ b/frame/xcm/src/operation_params.rs
@@ -1,0 +1,5 @@
+pub struct TransferParams {}
+
+pub trait IntoXcm<D, F> {
+	fn into_xcm(data: D, from: F) -> Self;
+}

--- a/frame/xcm/src/pallet_api.rs
+++ b/frame/xcm/src/pallet_api.rs
@@ -1,0 +1,5 @@
+use crate::TransferParams;
+
+pub trait PalletApi {
+	fn transfer(params: TransferParams);
+}

--- a/frame/xcm/src/tests.rs
+++ b/frame/xcm/src/tests.rs
@@ -1,0 +1,16 @@
+#![cfg(test)]
+
+use crate::{
+	blockchain::KaruraTransferParams,
+	mock::{ComposableXcm, ExtBuilder},
+	IntoXcm, PalletApi, TransferParams,
+};
+
+#[test]
+fn karura_transfer() {
+	ExtBuilder::default().build().execute_with(|| {
+		let karura_transfer_params = KaruraTransferParams;
+		let transfer_params: TransferParams = IntoXcm::into_xcm((), karura_transfer_params);
+		ComposableXcm::transfer(transfer_params);
+	});
+}


### PR DESCRIPTION
Summary of what was understood according to `Abstraction Layer` and spoken conversations. Feel free to point any misunderstandings.

## Library/Pallet

XCM is a protocol that enables **external** communication between different parachains, which means that a library or pallet must dispatch an HTTP or WS call targeting some desired endpoint.

```
# `method` is pallet plus call encoded names
# `params` is the encoded call params

{ id: 1, method: "8ee7418a6531173d60d1f6a82d8f4d51", params: "0x..." }
```

So in order to make an abstraction around different calls of different parachains that third-party users can use, it is possible to (1) Create a client **library** using, for example, `subxt` or (2) create a pallet with the `polkadot` repository primitives.

Since it was already decided that such abstraction will be a pallet, it is important (IMO) to say **pallet** instead of **library** to avoid confusion (even though a pallet is a library)

## Parachain XCM calls

Each parachain is free to define its own set of XCM interfaces but the more-or-less general consensus is to use the `xtokens` implementation (https://github.com/open-web3-stack/open-runtime-module-library/tree/master/xtokens) where common good calls like `transfer` operations are implemented.

Although `xtokens` eases the burden of having multiple different interfaces, the majority of the calls are parachain-unique. Maybe in the future something like EIP interfaces will come to the table or `orml` will provide more common runtime calls.

## Design

There are two possible ways to design the system.

### 1. Abstract individual platform-specific operations into common structures.

```rust
// High level example

// With specific Karura parameters
struct KaruraSwap { ... };

// With generic composable parameters
struct CanonicalSwap { ... };

// Converter
trait IntoXcm<D, F> {
    fn into_xcm(data: D, from: F) -> Self;
}

impl IntoXcm<(), CanonicalSwap> for KaruraSwap { .. }

impl pallet_composable_xcm::PalletApi for Pallet {
    ...
    // After converting `KaruraSwap` to `CanonicalSwap`, callers should be able to use this method
    fn swap(swap: CanonicalSwap) {}
    ...
}
```

Public calls are defined through the `PalletApi` trait, i.e., the `Pallet` structure implements `PalletApi` to allow third-party pallets call methods:

```rust
// Third-party pallet

#[pallet::config]
pub trait Config: frame_system::Config {
    type ComposableXcm: pallet_composable_xcm::PalletApi;
}
```

Another option is to work directly with the Pallet structure or inherit the `Config` trait bound.

### 2. Abstract individual platform-specific operations using traits

The most flexible method in my opinion.

```rust
// High level example

// Generic operations with generic parameters
trait Exchange<P> {
    type Pallet: pallet_composable_xcm::PalletApi;

    fn swap(&self, pallet: &Self::Pallet, currency_in: &Currency, max_price: &Balance, ...);
}

// With specific Karura parameters
struct Karura { ... };

impl Exchange for Karura {
    type Pallet = pallet_composable_xcm::Pallet;

    ...
    fn swap(&self, pallet: &Self::Pallet, currency_in: &Currency,max_price: &Balance, ...) { ... }
    ...
}
```

As seen from above, this second method lets calls use `Pallet` primitives, which is different from the first method where `Pallet` implements calls.

## Implementation

This initial implementation is a **very minimal** attempt that **only demonstrates** the basic architecture idea of a **~3 days** research and development cycle. Nothing is final (nomenclature, arrangements, structures or traits) so any idea, critic or suggestion is welcome for further enhancements and well-defined modifications.

As previously stated before, each individual operation should be abstracted into common. Therefore, the second design method wasn't implemented at all.

## Ethereum compatibility

I am **assuming** that `frontier` won't be used to talk directly with the Ethereum network because, FWIU, this pallet is only about abstracting different parachains. Besides, some networks like Moonbeam already support such feature (They probably charge a fee though, idk).

## Curiosity

Not in the scope of this PR but it is worth mentioning that although interoperability is a thing, atomicity isn't. Thus the reason why sometimes you hear things like DeFi Hubs or composable/specialized parachains.

cc @hussein-aitlahcen @KaiserKarel 