### PR TITLE
[BondedFinance] Add benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6361,6 +6361,7 @@ name = "pallet-bonded-finance"
 version = "0.0.1"
 dependencies = [
  "composable-traits",
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "orml-tokens",
@@ -7869,6 +7870,7 @@ dependencies = [
  "pallet-aura",
  "pallet-authorship",
  "pallet-balances",
+ "pallet-bonded-finance",
  "pallet-call-filter",
  "pallet-collator-selection",
  "pallet-collective",
@@ -7892,6 +7894,7 @@ dependencies = [
  "pallet-treasury",
  "pallet-utility",
  "pallet-vault",
+ "pallet-vesting 0.0.1",
  "pallet-xcm",
  "parachain-info",
  "parity-scale-codec",

--- a/frame/bonded-finance/Cargo.toml
+++ b/frame/bonded-finance/Cargo.toml
@@ -16,9 +16,9 @@ package = "parity-scale-codec"
 version = "2.0.0"
 
 [dependencies]
+frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13"  }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
-
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-arithmetic = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-io = { default-features = false,  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
@@ -34,7 +34,6 @@ composable-traits = { path = "../../frame/composable-traits" }
 proptest = "1.0"
 proptest-derive = "0.3"
 serde = { version = "1.0.124" }
-sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "17a791edf431d7d7aee1ea3dfaeeb7bc21944301" }
 pallet-vesting = { path = "../../frame/vesting" }
 
@@ -54,6 +53,10 @@ std = [
 ]
 
 runtime-benchmarks = [
-	"frame-support/runtime-benchmarks",
-	"frame-system/runtime-benchmarks",
+    "frame-benchmarking",
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks"
 ]
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["orml-traits"]

--- a/frame/bonded-finance/src/benchmarks.rs
+++ b/frame/bonded-finance/src/benchmarks.rs
@@ -1,0 +1,110 @@
+#![cfg(feature = "runtime-benchmarks")]
+
+#[cfg(test)]
+use crate::Pallet as BondedFinance;
+use crate::{
+	utils::MIN_VESTED_TRANSFER, AssetIdOf, BalanceOf, BlockNumberOf, BondOfferOf, Call, Config,
+	Pallet,
+};
+use codec::Decode;
+use composable_traits::{
+	bonded_finance::{BondDuration, BondOffer, BondOfferReward},
+	math::WrappingNext,
+};
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller, Zero};
+use frame_support::{
+	dispatch::UnfilteredDispatchable,
+	traits::{fungible::Mutate as _, fungibles::Mutate as _},
+};
+use frame_system::RawOrigin;
+
+const BALANCE: u64 = 10 * 1_000_000_000_000;
+
+fn assets<T>() -> [AssetIdOf<T>; 2]
+where
+	T: Config,
+{
+	let a = 0u128.to_be_bytes();
+	let b = 1u128.to_be_bytes();
+	[AssetIdOf::<T>::decode(&mut &a[..]).unwrap(), AssetIdOf::<T>::decode(&mut &b[..]).unwrap()]
+}
+
+fn bond_offer<T>(bond_asset: AssetIdOf<T>, reward_asset: AssetIdOf<T>) -> BondOfferOf<T>
+where
+	T: Config,
+{
+	BondOffer {
+		asset: bond_asset,
+		bond_price: BalanceOf::<T>::from(MIN_VESTED_TRANSFER),
+		maturity: BondDuration::Finite { return_in: BlockNumberOf::<T>::from(1u32) },
+		nb_of_bonds: BalanceOf::<T>::from(1u32),
+		reward: BondOfferReward {
+			amount: BalanceOf::<T>::from(MIN_VESTED_TRANSFER),
+			asset: reward_asset,
+			maturity: BlockNumberOf::<T>::from(96u32),
+		},
+	}
+}
+
+fn call_bond<T>(caller: &T::AccountId, nb_of_bonds: BalanceOf<T>, offer_id: T::BondOfferId)
+where
+	T: Config,
+{
+	let offer_account_id = Pallet::<T>::account_id(offer_id);
+	T::NativeCurrency::mint_into(&offer_account_id, <_>::try_from(BALANCE).unwrap_or_default())
+		.unwrap();
+	Call::<T>::bond { nb_of_bonds, offer_id }
+		.dispatch_bypass_filter(RawOrigin::Signed(caller.clone()).into())
+		.unwrap();
+}
+
+fn call_offer<T>(bond_offer: BondOfferOf<T>, caller: &T::AccountId)
+where
+	T: Config,
+{
+	Call::<T>::offer { offer: bond_offer }
+		.dispatch_bypass_filter(RawOrigin::Signed(caller.clone()).into())
+		.unwrap();
+}
+
+fn initial_mint<T>(bond_asset: AssetIdOf<T>, caller: &T::AccountId, reward_assert: AssetIdOf<T>)
+where
+	T: Config,
+{
+	T::Currency::mint_into(bond_asset, caller, <_>::try_from(BALANCE).unwrap_or_default()).unwrap();
+	T::Currency::mint_into(reward_assert, caller, <_>::try_from(BALANCE).unwrap_or_default())
+		.unwrap();
+	T::NativeCurrency::mint_into(caller, <_>::try_from(BALANCE).unwrap_or_default()).unwrap();
+}
+
+benchmarks! {
+	bond {
+		let [bond_asset, reward_asset] = assets::<T>();
+		let caller: T::AccountId = whitelisted_caller();
+		initial_mint::<T>(bond_asset, &caller, reward_asset);
+		let bond_offer = bond_offer::<T>(bond_asset, reward_asset);
+		let nb_of_bonds = bond_offer.nb_of_bonds;
+		call_offer::<T>(bond_offer, &caller);
+		let offer_id = T::BondOfferId::zero().next();
+	}: _(RawOrigin::Signed(caller), offer_id, nb_of_bonds)
+
+	cancel {
+		let [bond_asset, reward_asset] = assets::<T>();
+		let caller: T::AccountId = whitelisted_caller();
+		initial_mint::<T>(bond_asset, &caller, reward_asset);
+		let bond_offer = bond_offer::<T>(bond_asset, reward_asset);
+		let nb_of_bonds = bond_offer.nb_of_bonds;
+		call_offer::<T>(bond_offer, &caller);
+		let offer_id = T::BondOfferId::zero().next();
+		call_bond::<T>(&caller, nb_of_bonds, offer_id);
+	}: _(RawOrigin::Signed(caller), offer_id)
+
+	offer {
+		let [bond_asset, reward_asset] = assets::<T>();
+		let caller: T::AccountId = whitelisted_caller();
+		initial_mint::<T>(bond_asset, &caller, reward_asset);
+		let bond_offer = bond_offer::<T>(bond_asset, reward_asset);
+	}: _(RawOrigin::Signed(caller), bond_offer)
+}
+
+impl_benchmark_test_suite!(BondedFinance, crate::mock::ExtBuilder::build(), crate::mock::Runtime);

--- a/frame/bonded-finance/src/mock.rs
+++ b/frame/bonded-finance/src/mock.rs
@@ -3,6 +3,7 @@
 #![cfg(test)]
 
 use super::*;
+use crate::utils::MIN_VESTED_TRANSFER;
 use frame_support::{
 	construct_runtime,
 	pallet_prelude::*,
@@ -26,7 +27,6 @@ pub type Amount = i128;
 pub type AccountId = u128;
 
 pub const NATIVE_CURRENCY_ID: MockCurrencyId = MockCurrencyId::PICA;
-pub const MIN_VESTED_TRANSFER: u64 = 1_000_000;
 pub const MIN_REWARD: u128 = 1_000_000;
 
 pub const ALICE: AccountId = 1;
@@ -126,7 +126,7 @@ impl orml_tokens::Config for Runtime {
 
 parameter_types! {
 	pub const MaxVestingSchedule: u32 = 2;
-	pub const MinVestedTransfer: u64 = MIN_VESTED_TRANSFER;
+	pub const MinVestedTransfer: u64 = MIN_VESTED_TRANSFER as _;
 }
 
 impl pallet_vesting::Config for Runtime {
@@ -169,12 +169,11 @@ construct_runtime!(
 	{
 		System: frame_system::{Pallet, Call, Storage, Config, Event<T>},
 		Vesting: pallet_vesting::{Pallet, Storage, Call, Event<T>, Config<T>},
-	  Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>},
-	  BondedFinance: pallet::{Pallet, Call, Storage, Event<T>},
+		Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>},
+		BondedFinance: pallet::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
-#[derive(Default)]
 pub struct ExtBuilder;
 
 impl ExtBuilder {

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -3,6 +3,7 @@
 #![cfg(test)]
 
 use super::*;
+use crate::utils::MIN_VESTED_TRANSFER;
 use composable_traits::bonded_finance::{BondDuration, BondOffer, BondOfferReward};
 use frame_support::{
 	error::BadOrigin,

--- a/frame/bonded-finance/src/utils.rs
+++ b/frame/bonded-finance/src/utils.rs
@@ -1,0 +1,3 @@
+#[cfg(any(feature = "runtime-benchmarks", test))]
+
+pub const MIN_VESTED_TRANSFER: u32 = 1_000_000;

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -8,7 +8,14 @@ rust-version = "1.56"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["pallet-vault", "session-benchmarking", "currency-factory", "oracle", "vault"]
+normal = [
+	"currency-factory",
+	"oracle",
+	"pallet-bonded-finance",
+	"pallet-vault",
+	"session-benchmarking",
+	"vault"
+]
 
 [dependencies]
 frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -95,3 +95,6 @@ hex = "0.4.3"
 default = []
 runtime-benchmarks = ["picasso-runtime/runtime-benchmarks", "composable-runtime/runtime-benchmarks"]
 ocw = []
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["pallet-bonded-finance"]

--- a/runtime/picasso/Cargo.toml
+++ b/runtime/picasso/Cargo.toml
@@ -10,7 +10,20 @@ authors = ["Seun Lanlege <seunlanlege@gmail.com>"]
 targets = ["x86_64-unknown-linux-gnu"]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["pallet-vault", "session-benchmarking", "assets-registry", "currency-factory", "oracle", "vault", "assets", "governance-registry", "call-filter", "orml-unknown-tokens", "orml-xtokens"]
+normal = [
+	"assets",
+	"assets-registry",
+	"call-filter",
+	"currency-factory",
+	"governance-registry",
+	"oracle",
+	"orml-unknown-tokens",
+	"orml-xtokens",
+	"pallet-bonded-finance",
+	"pallet-vault",
+	"session-benchmarking",
+	"vault",
+]
 
 [dependencies]
 frame-system = { package = "frame-system", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
@@ -67,6 +80,8 @@ governance-registry = { package = "pallet-governance-registry", path = "../../fr
 currency-factory = { package = "pallet-currency-factory", path = "../../frame/currency-factory", default-features = false, optional = true}
 composable-traits = { path = "../../frame/composable-traits" , default-features = false}
 call-filter = { package = "pallet-call-filter", path = "../../frame/call-filter", default-features = false }
+pallet-bonded-finance = { optional = true, path = "../../frame/bonded-finance", default-features = false }
+vesting = { optional = true, package = "pallet-vesting", path = "../../frame/vesting", default-features = false }
 
 # Used for the node template's RPCs
 system-rpc-runtime-api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
@@ -136,6 +151,8 @@ std = [
 	"multisig/std",
 	"vault/std",
   	"assets/std",
+	"pallet-bonded-finance/std",
+	"vesting/std",
 	"governance-registry/std",
 	"call-filter/std",
 	"currency-factory/std",
@@ -198,18 +215,21 @@ runtime-benchmarks = [
 	"treasury/runtime-benchmarks",
 	"scheduler/runtime-benchmarks",
 	"collective/runtime-benchmarks",
+	"pallet-bonded-finance/runtime-benchmarks",
+	"vesting/runtime-benchmarks",
 	"democracy/runtime-benchmarks",
 	"utility/runtime-benchmarks",
-  "vault/runtime-benchmarks"
+  	"vault/runtime-benchmarks"
 ]
 
 develop = [
-  "crowdloan-rewards",
-  "assets",
-  "governance-registry",
-	"assets-registry",
 	"assets",
-	"oracle",
-	"vault",
+	"assets-registry",
+	"crowdloan-rewards",
 	"currency-factory",
+	"governance-registry",
+	"oracle",
+	"pallet-bonded-finance",
+	"vault",
+	"vesting",
 ]

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -799,6 +799,43 @@ impl crowdloan_rewards::Config for Runtime {
 	type WeightInfo = weights::crowdloan_rewards::WeightInfo<Runtime>;
 }
 
+#[cfg(feature = "develop")]
+parameter_types! {
+	pub const MaxVestingSchedule: u32 = 2;
+	pub const MinVestedTransfer: u64 = 1_000_000;
+}
+
+#[cfg(feature = "develop")]
+impl vesting::Config for Runtime {
+	type Currency = Tokens;
+	type Event = Event;
+	type MaxVestingSchedules = MaxVestingSchedule;
+	type MinVestedTransfer = MinVestedTransfer;
+	type VestedTransferOrigin = system::EnsureSigned<AccountId>;
+	type WeightInfo = ();
+}
+
+#[cfg(feature = "develop")]
+parameter_types! {
+	pub const BondedFinanceId: PalletId = PalletId(*b"bondedfi");
+	pub const MinReward: Balance = 1_000_000;
+	pub const Stake: Balance = 10_000;
+}
+
+#[cfg(feature = "develop")]
+impl pallet_bonded_finance::Config for Runtime {
+	type AdminOrigin = EnsureRoot<AccountId>;
+	type BondOfferId = u64;
+	type Convert = sp_runtime::traits::ConvertInto;
+	type Currency = Tokens;
+	type Event = Event;
+	type MinReward = MinReward;
+	type NativeCurrency = Balances;
+	type PalletId = BondedFinanceId;
+	type Stake = Stake;
+	type Vesting = Vesting;
+}
+
 /// The calls we permit to be executed by extrinsics
 pub struct BaseCallFilter;
 
@@ -924,7 +961,9 @@ construct_runtime!(
 		AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 55,
 		GovernanceRegistry: governance_registry::{Pallet, Call, Storage, Event<T>} = 56,
 		Assets: assets::{Pallet, Call, Storage} = 57,
-	  CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>} = 58,
+		CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>} = 58,
+		Vesting: vesting::{Call, Event<T>, Pallet, Storage} = 59,
+		BondedFinance: pallet_bonded_finance::{Call, Event<T>, Pallet, Storage} = 60,
 
 		CallFilter: call_filter::{Pallet, Call, Storage, Event<T>} = 100,
 	}
@@ -1087,6 +1126,7 @@ impl_runtime_apis! {
 			#[cfg(feature = "develop")]
 			{
 				list_benchmark!(list, extra, vault, Vault);
+				list_benchmark!(list, extra, pallet_bonded_finance, BondedFinance);
 				list_benchmark!(list, extra, oracle, Oracle);
 				list_benchmark!(list, extra, crowdloan_rewards, CrowdloanRewards);
 			}
@@ -1142,6 +1182,7 @@ impl_runtime_apis! {
 			#[cfg(feature ="develop")]
 			{
 				add_benchmark!(params, batches, vault, Vault);
+				add_benchmark!(params, batches, pallet_bonded_finance, BondedFinance);
 				add_benchmark!(params, batches, oracle, Oracle);
 				add_benchmark!(params, batches, crowdloan_rewards, CrowdloanRewards);
 			}

--- a/runtime/primitives/src/currency.rs
+++ b/runtime/primitives/src/currency.rs
@@ -1,6 +1,6 @@
 //! CurrencyId implementation
 
-use codec::{Decode, Encode};
+use codec::{CompactAs, Decode, Encode};
 use composable_traits::currency::{DynamicCurrencyId, Exponent, PriceableAsset};
 use scale_info::TypeInfo;
 use sp_runtime::{ArithmeticError, DispatchError, RuntimeDebug};
@@ -9,7 +9,9 @@ use sp_runtime::{ArithmeticError, DispatchError, RuntimeDebug};
 use serde::{Deserialize, Serialize};
 use sp_runtime::sp_std::ops::Deref;
 
-#[derive(Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo)]
+#[derive(
+	Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, TypeInfo, CompactAs,
+)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[repr(transparent)]
 pub struct CurrencyId(u128);

--- a/utils/collator-sidecar/Cargo.toml
+++ b/utils/collator-sidecar/Cargo.toml
@@ -18,3 +18,6 @@ jsonrpc-core-client = { version = "18", features = ["ws"] }
 sc-rpc = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 picasso = { package = "picasso-runtime", path = "../../runtime/picasso" }
 common = { path = "../../runtime/common" }
+
+[package.metadata.cargo-udeps.ignore]
+normal = ["pallet-bonded-finance"]


### PR DESCRIPTION
Pallet benchmarks are intended to be used as an upper-bound for extrinsic calls, which means creating benchmark functions with worst case scenarios.

Weight is a unit of time and every signed extrinsic should have a weight to calculate fees or the average number of transactions for a block. The same necessity is true for unsigned transactions because theoretically anyone could submit infinite number of extrinsics inside a single block for anything that has `#[weight = 0]`, therefore, please consider adding weights for non-root calls of the `ping` pallet to avoid third-party flood.
