### PR TITLE
CU-1wef6he - refactor call-filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,6 +6450,7 @@ dependencies = [
 name = "pallet-call-filter"
 version = "0.1.0"
 dependencies = [
+ "composable-traits",
  "frame-support",
  "frame-system",
  "pallet-balances",

--- a/frame/call-filter/Cargo.toml
+++ b/frame/call-filter/Cargo.toml
@@ -15,6 +15,7 @@ system = { package = "frame-system", git = "https://github.com/paritytech/substr
 sp-std = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
 sp-io= { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
 scale-info = { version = "1.0.0", features = ["derive"], default-features = false }
+composable-traits = { path = "../../frame/composable-traits" , default-features = false}
 
 [dev-dependencies]
 sp-core = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }

--- a/frame/call-filter/src/lib.rs
+++ b/frame/call-filter/src/lib.rs
@@ -1,9 +1,10 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 
+use composable_traits::call_filter::{CallFilter, CallFilterEntry};
 pub use pallet::*;
 use sp_runtime::DispatchResult;
-use sp_std::{prelude::*, vec::Vec};
+use sp_std::prelude::*;
 use support::{
 	dispatch::{CallMetadata, GetCallMetadata},
 	pallet_prelude::*,
@@ -19,6 +20,8 @@ mod weights;
 
 #[support::pallet]
 pub mod pallet {
+	use composable_traits::call_filter::CallFilterHook;
+
 	use super::*;
 
 	#[pallet::config]
@@ -29,94 +32,125 @@ pub mod pallet {
 		/// The origin which may set filter.
 		type UpdateOrigin: EnsureOrigin<Self::Origin>;
 
-		// Weight information for the extrinsics in this module.
+		/// A hook that is able to block us from disabling/enabling an extrinsic.
+		type Hook: CallFilterHook;
+
+		/// Weight information for the extrinsics in this module.
 		type WeightInfo: WeightInfo;
 	}
 
 	#[pallet::error]
 	pub enum Error<T> {
-		/// can not pause
-		CannotPause,
-		/// invalid character encoding
-		InvalidCharacter,
+		/// We tried to disable an extrinsic that cannot be disabled.
+		CannotDisable,
+		/// The pallet name is not a valid UTF8 string.
+		InvalidString,
 	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Paused transaction . \[pallet_name_bytes, function_name_bytes\]
-		Disabled(Vec<u8>, Vec<u8>),
-		/// Unpaused transaction . \[pallet_name_bytes, function_name_bytes\]
-		TransactionUnpaused(Vec<u8>, Vec<u8>),
+		/// Paused transaction
+		Disabled { entry: CallFilterEntry },
+		/// Unpaused transaction
+		Enabled { entry: CallFilterEntry },
 	}
 
-	/// The paused transaction map
+	/// The list of disabled extrinsics.
 	///
-	/// map (PalletNameBytes, FunctionNameBytes) => Option<()>
+	/// CallFilterEntry -> ()
 	#[pallet::storage]
 	#[pallet::getter(fn disabled_calls)]
-	pub type PausedTransactions<T: Config> =
-		StorageMap<_, Twox64Concat, (Vec<u8>, Vec<u8>), (), OptionQuery>;
+	pub type DisabledCalls<T: Config> = StorageMap<_, Twox64Concat, CallFilterEntry, ()>;
 
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
-	#[pallet::hooks]
-	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
-
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		/// Disable a pallet function.
+		///
+		/// The dispatch origin for this call must be _Signed_ and the sender must be
+		/// `UpdateOrigin`.
+		///
+		/// Possibly emits a `Disabled` event.
 		#[pallet::weight(T::WeightInfo::disable())]
 		#[transactional]
-		pub fn disable(
-			origin: OriginFor<T>,
-			pallet_name: Vec<u8>,
-			function_name: Vec<u8>,
-		) -> DispatchResult {
+		pub fn disable(origin: OriginFor<T>, entry: CallFilterEntry) -> DispatchResult {
 			T::UpdateOrigin::ensure_origin(origin)?;
-
-			// not allowed to pause calls of this pallet to ensure safe
-			let pallet_name_string =
-				sp_std::str::from_utf8(&pallet_name).map_err(|_| Error::<T>::InvalidCharacter)?;
+			ensure!(entry.valid(), Error::<T>::InvalidString);
+			// We are not allowed to disable this pallet.
 			ensure!(
-				pallet_name_string != <Self as PalletInfoAccess>::name(),
-				Error::<T>::CannotPause
+				entry.pallet_name != <Self as PalletInfoAccess>::name().as_bytes(),
+				Error::<T>::CannotDisable
 			);
-
-			PausedTransactions::<T>::mutate_exists(
-				(pallet_name.clone(), function_name.clone()),
-				|maybe_paused| {
-					if maybe_paused.is_none() {
-						*maybe_paused = Some(());
-						Self::deposit_event(Event::Disabled(pallet_name, function_name));
-					}
-				},
-			);
+			Self::do_disable(&entry)?;
 			Ok(())
 		}
 
+		/// Enable a previously disabled pallet function.
+		///
+		/// The dispatch origin for this call must be _Signed_ and the sender must be
+		/// `UpdateOrigin`.
+		///
+		/// Possibly emits an `Enabled` event.
 		#[pallet::weight(T::WeightInfo::enable())]
 		#[transactional]
-		pub fn enable(
-			origin: OriginFor<T>,
-			pallet_name: Vec<u8>,
-			function_name: Vec<u8>,
-		) -> DispatchResult {
+		pub fn enable(origin: OriginFor<T>, entry: CallFilterEntry) -> DispatchResult {
 			T::UpdateOrigin::ensure_origin(origin)?;
-			if PausedTransactions::<T>::take((&pallet_name, &function_name)).is_some() {
-				Self::deposit_event(Event::TransactionUnpaused(pallet_name, function_name));
-			};
+			ensure!(entry.valid(), Error::<T>::InvalidString);
+			Self::do_enable(&entry)?;
 			Ok(())
 		}
 	}
-}
 
-impl<T: Config> Contains<T::Call> for Pallet<T>
-where
-	<T as system::Config>::Call: GetCallMetadata,
-{
-	fn contains(call: &T::Call) -> bool {
-		let CallMetadata { function_name, pallet_name } = call.get_call_metadata();
-		PausedTransactions::<T>::contains_key((pallet_name.as_bytes(), function_name.as_bytes()))
+	impl<T: Config> Pallet<T> {
+		pub(crate) fn disabled(entry: &CallFilterEntry) -> bool {
+			DisabledCalls::<T>::contains_key(entry)
+		}
+
+		pub(crate) fn do_enable(entry: &CallFilterEntry) -> DispatchResult {
+			if Self::disabled(entry) {
+				T::Hook::enable_hook(entry)?;
+				DisabledCalls::<T>::remove(entry);
+				Self::deposit_event(Event::Enabled { entry: entry.clone() });
+			}
+			Ok(())
+		}
+
+		pub(crate) fn do_disable(entry: &CallFilterEntry) -> DispatchResult {
+			if !Self::disabled(entry) {
+				T::Hook::disable_hook(entry)?;
+				DisabledCalls::<T>::insert(entry, ());
+				Self::deposit_event(Event::Disabled { entry: entry.clone() });
+			}
+			Ok(())
+		}
+	}
+
+	impl<T: Config> CallFilter for Pallet<T> {
+		fn disabled(entry: &CallFilterEntry) -> bool {
+			Self::disabled(entry)
+		}
+		fn enable(entry: &CallFilterEntry) -> DispatchResult {
+			Self::do_enable(entry)
+		}
+
+		fn disable(entry: &CallFilterEntry) -> DispatchResult {
+			Self::do_disable(entry)
+		}
+	}
+
+	impl<T: Config> Contains<T::Call> for Pallet<T>
+	where
+		<T as system::Config>::Call: GetCallMetadata,
+	{
+		fn contains(call: &T::Call) -> bool {
+			let CallMetadata { function_name, pallet_name } = call.get_call_metadata();
+			DisabledCalls::<T>::contains_key(CallFilterEntry {
+				pallet_name: pallet_name.as_bytes().to_vec(),
+				function_name: function_name.as_bytes().to_vec(),
+			})
+		}
 	}
 }

--- a/frame/call-filter/src/mock.rs
+++ b/frame/call-filter/src/mock.rs
@@ -68,6 +68,7 @@ ord_parameter_types! {
 impl Config for Runtime {
 	type Event = Event;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
+	type Hook = ();
 	type WeightInfo = ();
 }
 
@@ -81,7 +82,7 @@ construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
 		System: system::{Pallet, Call, Config, Storage, Event<T>},
-		CallFilter: call_filter::{Pallet, Storage, Call, Event<T>},
+		Filter: call_filter::{Pallet, Storage, Call, Event<T>},
 		Balances: pallet_balances::{Pallet, Storage, Call, Event<T>},
 	}
 );
@@ -97,7 +98,6 @@ impl Default for ExtBuilder {
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
 		let t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
-
 		t.into()
 	}
 }

--- a/frame/composable-traits/src/call_filter.rs
+++ b/frame/composable-traits/src/call_filter.rs
@@ -1,0 +1,40 @@
+use frame_support::{dispatch::DispatchResult, pallet_prelude::*};
+use sp_std::vec::Vec;
+
+/// An object that is able to tell us whether an entry can or cannot be disabled.
+pub trait CallFilterHook {
+	fn enable_hook(entry: &CallFilterEntry) -> DispatchResult;
+	fn disable_hook(entry: &CallFilterEntry) -> DispatchResult;
+}
+
+impl CallFilterHook for () {
+	#[inline(always)]
+	fn enable_hook(_: &CallFilterEntry) -> DispatchResult {
+		Ok(())
+	}
+	#[inline(always)]
+	fn disable_hook(_: &CallFilterEntry) -> DispatchResult {
+		Ok(())
+	}
+}
+
+/// An object that is able to pause/unpause extrinsics.
+pub trait CallFilter {
+	fn disabled(entry: &CallFilterEntry) -> bool;
+	fn enable(entry: &CallFilterEntry) -> DispatchResult;
+	fn disable(entry: &CallFilterEntry) -> DispatchResult;
+}
+
+/// A call filter entry, product of the pallet name and the extrinsic name.
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode, TypeInfo)]
+pub struct CallFilterEntry {
+	pub pallet_name: Vec<u8>,
+	pub function_name: Vec<u8>,
+}
+
+impl CallFilterEntry {
+	pub fn valid(&self) -> bool {
+		sp_std::str::from_utf8(&self.pallet_name).is_ok() &&
+			sp_std::str::from_utf8(&self.function_name).is_ok()
+	}
+}

--- a/frame/composable-traits/src/lib.rs
+++ b/frame/composable-traits/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod assets;
 pub mod auction;
 pub mod bonded_finance;
+pub mod call_filter;
 pub mod currency;
 pub mod dex;
 pub mod governance;

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -797,6 +797,7 @@ impl Contains<Call> for BaseCallFilter {
 impl call_filter::Config for Runtime {
 	type Event = Event;
 	type UpdateOrigin = EnsureRoot<AccountId>;
+	type Hook = ();
 	type WeightInfo = ();
 }
 


### PR DESCRIPTION
We were previously using a map `Entry -> Option<()>` but a StorageMap `Entry -> ()`
is enough as it uses `OptionQuery` by default.

I added a way to hook into enable/disable call of the filter pallet to make it
more flexible. If we want to block a pallet from being disabled, it can now be
done at the Runtime declaration.

I also extracted the whole behavior to its own traits.