### PR TITLE
CU-1pe15hj: Clippy additions and fixes

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    "core::result::Result::unwrap", # { path = "core::result::Result::unwrap", reason = "Errors should be handled properly. If panicking is valid in this context, make sure to write a comment explaining why." },
+    "core::option::Option::unwrap", # { path = "core::option::Option::unwrap", reason = "Errors should be handled properly. If panicking is valid in this context, make sure to write a comment explaining why." },
+]

--- a/frame/assets-registry/src/lib.rs
+++ b/frame/assets-registry/src/lib.rs
@@ -7,6 +7,8 @@
 //! 4. Map of native token to this chain(here) is added unconditionally.
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/assets-registry/src/lib.rs
+++ b/frame/assets-registry/src/lib.rs
@@ -248,7 +248,7 @@ pub mod pallet {
 			let local_admin = <LocalAdmin<T>>::get();
 			let foreign_admin = <ForeignAdmin<T>>::get();
 			match current_candidate_status {
-				None => {
+				None =>
 					if who == local_admin {
 						<AssetsMappingCandidates<T>>::insert(
 							(local_asset_id, foreign_asset_id),
@@ -259,20 +259,17 @@ pub mod pallet {
 							(local_asset_id, foreign_asset_id),
 							CandidateStatus::ForeignAdminApproved,
 						);
-					}
-				}
-				Some(CandidateStatus::LocalAdminApproved) => {
+					},
+				Some(CandidateStatus::LocalAdminApproved) =>
 					if who == foreign_admin {
 						Self::set_location(local_asset_id, foreign_asset_id.clone())?;
 						<AssetsMappingCandidates<T>>::remove((local_asset_id, foreign_asset_id));
-					}
-				}
-				Some(CandidateStatus::ForeignAdminApproved) => {
+					},
+				Some(CandidateStatus::ForeignAdminApproved) =>
 					if who == local_admin {
 						Self::set_location(local_asset_id, foreign_asset_id.clone())?;
 						<AssetsMappingCandidates<T>>::remove((local_asset_id, foreign_asset_id));
-					}
-				}
+					},
 			};
 			Ok(().into())
 		}
@@ -283,9 +280,8 @@ pub mod pallet {
 		type Success = T::AccountId;
 		fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
 			o.into().and_then(|o| match (o, LocalAdmin::<T>::try_get()) {
-				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f => {
-					Ok(who.clone())
-				}
+				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f =>
+					Ok(who.clone()),
 				(r, _) => Err(T::Origin::from(r)),
 			})
 		}
@@ -302,9 +298,8 @@ pub mod pallet {
 		type Success = T::AccountId;
 		fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
 			o.into().and_then(|o| match (o, ForeignAdmin::<T>::try_get()) {
-				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f => {
-					Ok(who.clone())
-				}
+				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f =>
+					Ok(who.clone()),
 				(r, _) => Err(T::Origin::from(r)),
 			})
 		}

--- a/frame/assets-registry/src/lib.rs
+++ b/frame/assets-registry/src/lib.rs
@@ -6,7 +6,7 @@
 //! 3. After approval map return mapped value.
 //! 4. Map of native token to this chain(here) is added unconditionally.
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/assets-registry/src/lib.rs
+++ b/frame/assets-registry/src/lib.rs
@@ -5,6 +5,8 @@
 //! 2. Assets map added as candidate and waits for approval.
 //! 3. After approval map return mapped value.
 //! 4. Map of native token to this chain(here) is added unconditionally.
+
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;
@@ -246,7 +248,7 @@ pub mod pallet {
 			let local_admin = <LocalAdmin<T>>::get();
 			let foreign_admin = <ForeignAdmin<T>>::get();
 			match current_candidate_status {
-				None =>
+				None => {
 					if who == local_admin {
 						<AssetsMappingCandidates<T>>::insert(
 							(local_asset_id, foreign_asset_id),
@@ -257,17 +259,20 @@ pub mod pallet {
 							(local_asset_id, foreign_asset_id),
 							CandidateStatus::ForeignAdminApproved,
 						);
-					},
-				Some(CandidateStatus::LocalAdminApproved) =>
+					}
+				}
+				Some(CandidateStatus::LocalAdminApproved) => {
 					if who == foreign_admin {
 						Self::set_location(local_asset_id, foreign_asset_id.clone())?;
 						<AssetsMappingCandidates<T>>::remove((local_asset_id, foreign_asset_id));
-					},
-				Some(CandidateStatus::ForeignAdminApproved) =>
+					}
+				}
+				Some(CandidateStatus::ForeignAdminApproved) => {
 					if who == local_admin {
 						Self::set_location(local_asset_id, foreign_asset_id.clone())?;
 						<AssetsMappingCandidates<T>>::remove((local_asset_id, foreign_asset_id));
-					},
+					}
+				}
 			};
 			Ok(().into())
 		}
@@ -278,8 +283,9 @@ pub mod pallet {
 		type Success = T::AccountId;
 		fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
 			o.into().and_then(|o| match (o, LocalAdmin::<T>::try_get()) {
-				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f =>
-					Ok(who.clone()),
+				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f => {
+					Ok(who.clone())
+				}
 				(r, _) => Err(T::Origin::from(r)),
 			})
 		}
@@ -296,8 +302,9 @@ pub mod pallet {
 		type Success = T::AccountId;
 		fn try_origin(o: T::Origin) -> Result<Self::Success, T::Origin> {
 			o.into().and_then(|o| match (o, ForeignAdmin::<T>::try_get()) {
-				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f =>
-					Ok(who.clone()),
+				(frame_system::RawOrigin::Signed(ref who), Ok(ref f)) if who == f => {
+					Ok(who.clone())
+				}
 				(r, _) => Err(T::Origin::from(r)),
 			})
 		}

--- a/frame/assets-registry/src/mock.rs
+++ b/frame/assets-registry/src/mock.rs
@@ -12,10 +12,10 @@ pub type AccountId = u32;
 type Block = frame_system::mocking::MockBlock<Test>;
 type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Test>;
 
-pub const ROOT: AccountId = 0u32;
-pub const ALICE: AccountId = 1u32;
-pub const BOB: AccountId = 2u32;
-pub const CHARLIE: AccountId = 3u32;
+pub const ROOT: AccountId = 0_u32;
+pub const ALICE: AccountId = 1_u32;
+pub const BOB: AccountId = 2_u32;
+pub const CHARLIE: AccountId = 3_u32;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -49,6 +49,7 @@
 //! - `mint_into`
 //! - `burn_from`
 
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -49,7 +49,7 @@
 //! - `mint_into`
 //! - `burn_from`
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -50,6 +50,7 @@
 //! - `burn_from`
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/bonded-finance/src/mock.rs
+++ b/frame/bonded-finance/src/mock.rs
@@ -25,7 +25,7 @@ pub type Balance = u128;
 pub type Amount = i128;
 pub type AccountId = u128;
 
-pub const NATIVE_CURRENCY_ID: MockCurrencyId = MockCurrencyId::PICA;
+pub const NATIVE_CURRENCY_ID: MockCurrencyId = MockCurrencyId::Pica;
 pub const MIN_VESTED_TRANSFER: u64 = 1_000_000;
 pub const MIN_REWARD: u128 = 1_000_000;
 
@@ -49,9 +49,9 @@ pub const CHARLIE: AccountId = 3;
 	proptest_derive::Arbitrary,
 )]
 pub enum MockCurrencyId {
-	PICA,
-	BTC,
-	ETH,
+	Pica,
+	Btc,
+	Eth,
 }
 
 parameter_types! {

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -53,36 +53,36 @@ macro_rules! prop_assert_ok {
 #[test]
 fn valid_offer() {
 	assert!(BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as _,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Infinite,
 		reward: BondOfferReward {
-			asset: MockCurrencyId::PICA,
+			asset: MockCurrencyId::Pica,
 			amount: 1_000_000u128 * 100_000u128,
 			maturity: 96u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 	assert!(BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as _,
 		nb_of_bonds: 1u128,
 		maturity: BondDuration::Finite { return_in: 1 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128,
 			maturity: 96u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 	assert!(BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128 * 100_000u128,
 			maturity: 96u128,
 		}
@@ -94,12 +94,12 @@ fn valid_offer() {
 fn invalid_offer() {
 	// invalid bond_price
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as u128 - 1,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Infinite,
 		reward: BondOfferReward {
-			asset: MockCurrencyId::PICA,
+			asset: MockCurrencyId::Pica,
 			amount: 1_000_000u128,
 			maturity: 96u128
 		}
@@ -108,12 +108,12 @@ fn invalid_offer() {
 
 	// invalid nb_of_bonds
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as _,
 		nb_of_bonds: 0,
 		maturity: BondDuration::Finite { return_in: 1 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128,
 			maturity: 96u128,
 		}
@@ -122,12 +122,12 @@ fn invalid_offer() {
 
 	// invalid maturity
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Finite { return_in: 0 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128,
 			maturity: 96u128,
 		}
@@ -136,22 +136,22 @@ fn invalid_offer() {
 
 	// invalid reward
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
-		reward: BondOfferReward { asset: MockCurrencyId::BTC, amount: 0, maturity: 96u128 }
+		reward: BondOfferReward { asset: MockCurrencyId::Btc, amount: 0, maturity: 96u128 }
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 
 	// invalid reward: < MinVested
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128 * 100_000u128 - 1,
 			maturity: 96u128
 		}
@@ -160,12 +160,12 @@ fn invalid_offer() {
 
 	// invalid reward maturity
 	assert!(!BondOffer {
-		asset: MockCurrencyId::BTC,
+		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
 		nb_of_bonds: 100_000u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			amount: 1_000_000u128,
 			maturity: 0u128
 		}
@@ -190,12 +190,12 @@ prop_compose! {
 			  )
 			  -> BondOffer<MockCurrencyId, Balance, BlockNumber> {
 					  BondOffer {
-							  asset: MockCurrencyId::BTC,
+							  asset: MockCurrencyId::Btc,
 								bond_price,
 								nb_of_bonds,
 								maturity,
 							  reward: BondOfferReward {
-									  asset: MockCurrencyId::ETH,
+									  asset: MockCurrencyId::Eth,
 									  amount: Balance::max(MIN_REWARD.saturating_mul(nb_of_bonds), reward_amount),
 									  maturity: reward_maturity,
 							  }

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -55,36 +55,36 @@ fn valid_offer() {
 	assert!(BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as _,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Infinite,
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Pica,
-			amount: 1_000_000u128 * 100_000u128,
-			maturity: 96u128,
+			amount: 1_000_000_u128 * 100_000_u128,
+			maturity: 96_u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 	assert!(BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as _,
-		nb_of_bonds: 1u128,
+		nb_of_bonds: 1_u128,
 		maturity: BondDuration::Finite { return_in: 1 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128,
-			maturity: 96u128,
+			amount: 1_000_000_u128,
+			maturity: 96_u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 	assert!(BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128 * 100_000u128,
-			maturity: 96u128,
+			amount: 1_000_00_0_u128 * 100_000_u128,
+			maturity: 96_u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
@@ -96,12 +96,12 @@ fn invalid_offer() {
 	assert!(!BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: MIN_VESTED_TRANSFER as u128 - 1,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Infinite,
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Pica,
-			amount: 1_000_000u128,
-			maturity: 96u128
+			amount: 1_000_000_u128,
+			maturity: 96_u128
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
@@ -114,8 +114,8 @@ fn invalid_offer() {
 		maturity: BondDuration::Finite { return_in: 1 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128,
-			maturity: 96u128,
+			amount: 1_000_000_u128,
+			maturity: 96_u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
@@ -124,12 +124,12 @@ fn invalid_offer() {
 	assert!(!BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Finite { return_in: 0 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128,
-			maturity: 96u128,
+			amount: 1_000_000_u128,
+			maturity: 96_u128,
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
@@ -138,9 +138,9 @@ fn invalid_offer() {
 	assert!(!BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
-		reward: BondOfferReward { asset: MockCurrencyId::Btc, amount: 0, maturity: 96u128 }
+		reward: BondOfferReward { asset: MockCurrencyId::Btc, amount: 0, maturity: 96_u128 }
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
 
@@ -148,12 +148,12 @@ fn invalid_offer() {
 	assert!(!BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128 * 100_000u128 - 1,
-			maturity: 96u128
+			amount: 1_000_000_u128 * 100_000_u128 - 1,
+			maturity: 96_u128
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));
@@ -162,12 +162,12 @@ fn invalid_offer() {
 	assert!(!BondOffer {
 		asset: MockCurrencyId::Btc,
 		bond_price: 1_000_000 + MIN_VESTED_TRANSFER as u128,
-		nb_of_bonds: 100_000u128,
+		nb_of_bonds: 100_000_u128,
 		maturity: BondDuration::Finite { return_in: 1_000_000 },
 		reward: BondOfferReward {
 			asset: MockCurrencyId::Btc,
-			amount: 1_000_000u128,
-			maturity: 0u128
+			amount: 1_000_000_u128,
+			maturity: 0_u128
 		}
 	}
 	.valid(MinVestedTransfer::get() as _, MinReward::get()));

--- a/frame/call-filter/src/lib.rs
+++ b/frame/call-filter/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/call-filter/src/lib.rs
+++ b/frame/call-filter/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/call-filter/src/lib.rs
+++ b/frame/call-filter/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/composable-traits/src/currency.rs
+++ b/frame/composable-traits/src/currency.rs
@@ -11,7 +11,7 @@ where
 	Self: Copy,
 {
 	fn unit<T: From<u64>>(&self) -> T {
-		T::from(10u64.pow(self.smallest_unit_exponent()))
+		T::from(10_u64.pow(self.smallest_unit_exponent()))
 	}
 	fn smallest_unit_exponent(self) -> Exponent;
 }

--- a/frame/composable-traits/src/lib.rs
+++ b/frame/composable-traits/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod assets;

--- a/frame/composable-traits/src/lib.rs
+++ b/frame/composable-traits/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod assets;

--- a/frame/composable-traits/src/lib.rs
+++ b/frame/composable-traits/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod assets;

--- a/frame/composable-traits/src/rate_model.rs
+++ b/frame/composable-traits/src/rate_model.rs
@@ -559,9 +559,9 @@ mod tests {
 	#[test]
 	fn test_empty_drained_market() {
 		let mut jump_model = JumpModel::new_model(
-			FixedU128::from_float(0.010000000000000000),
-			FixedU128::from_float(0.110000000000000000),
-			FixedU128::from_float(0.310000000000000000),
+			FixedU128::from_float(0.01),
+			FixedU128::from_float(0.11),
+			FixedU128::from_float(0.31),
 			Percent::zero(),
 		)
 		.unwrap();
@@ -575,9 +575,9 @@ mod tests {
 	#[test]
 	fn test_slope() {
 		let mut jump_model = JumpModel::new_model(
-			FixedU128::from_float(0.010000000000000000),
-			FixedU128::from_float(0.110000000000000000),
-			FixedU128::from_float(0.310000000000000000),
+			FixedU128::from_float(0.01),
+			FixedU128::from_float(0.11),
+			FixedU128::from_float(0.31),
 			Percent::from_percent(80),
 		)
 		.unwrap();

--- a/frame/composable-traits/src/rate_model.rs
+++ b/frame/composable-traits/src/rate_model.rs
@@ -62,7 +62,7 @@ pub fn calc_utilization_ratio(
 	let utilization_ratio = borrows
 		.checked_div(&total)
 		.expect("above checks prove it cannot error")
-		.checked_mul_int(100u16)
+		.checked_mul_int(100_u16)
 		.unwrap()
 		.try_into()
 		.unwrap();
@@ -299,8 +299,8 @@ impl DynamicPIDControllerModel {
 		utilization_ratio: FixedU128,
 	) -> Result<Rate, ArithmeticError> {
 		// compute error term `et = uo - ut`
-		let et: i128 = self.uo.into_inner().try_into().unwrap_or(0i128) -
-			utilization_ratio.into_inner().try_into().unwrap_or(0i128);
+		let et: i128 = self.uo.into_inner().try_into().unwrap_or(0_i128) -
+			utilization_ratio.into_inner().try_into().unwrap_or(0_i128);
 		let et: FixedI128 = FixedI128::from_inner(et);
 		// compute proportional term `pt = kp * et`
 		let pt = self.kp.checked_mul(&et).ok_or(ArithmeticError::Overflow)?;
@@ -319,13 +319,13 @@ impl DynamicPIDControllerModel {
 		// update interest_rate `ir = ir_t_1 + ut`
 		if ut.is_negative() {
 			let ut = ut.neg();
-			self.ir_t_1 = self
-				.ir_t_1
-				.saturating_sub(FixedU128::from_inner(ut.into_inner().try_into().unwrap_or(0u128)));
+			self.ir_t_1 = self.ir_t_1.saturating_sub(FixedU128::from_inner(
+				ut.into_inner().try_into().unwrap_or(0_u128),
+			));
 		} else {
-			self.ir_t_1 = self
-				.ir_t_1
-				.saturating_add(FixedU128::from_inner(ut.into_inner().try_into().unwrap_or(0u128)));
+			self.ir_t_1 = self.ir_t_1.saturating_add(FixedU128::from_inner(
+				ut.into_inner().try_into().unwrap_or(0_u128),
+			));
 		}
 		Ok(self.ir_t_1)
 	}
@@ -380,7 +380,7 @@ pub struct DoubleExponentModel {
 impl DoubleExponentModel {
 	/// Create a double exponent model
 	pub fn new_model(coefficients: [u8; 16]) -> Option<Self> {
-		let sum_of_coefficients = coefficients.iter().fold(0u16, |acc, &c| acc + c as u16);
+		let sum_of_coefficients = coefficients.iter().fold(0_u16, |acc, &c| acc + c as u16);
 		if sum_of_coefficients == EXPECTED_COEFFICIENTS_SUM {
 			return Some(DoubleExponentModel { coefficients })
 		}
@@ -531,10 +531,10 @@ mod tests {
 
 	fn valid_jump_model() -> impl Strategy<Value = JumpModelStrategy> {
 		(
-			(1..=10u32).prop_map(|x| Ratio::saturating_from_rational(x, 100)),
-			(11..=30u32).prop_map(|x| Ratio::saturating_from_rational(x, 100)),
+			(1..=10_u32).prop_map(|x| Ratio::saturating_from_rational(x, 100)),
+			(11..=30_u32).prop_map(|x| Ratio::saturating_from_rational(x, 100)),
 			(31..=50).prop_map(|x| Ratio::saturating_from_rational(x, 100)),
-			(0..=100u8).prop_map(Percent::from_percent),
+			(0..=100_u8).prop_map(Percent::from_percent),
 		)
 			.prop_filter("Jump rate model", |(base, jump, full, _)| {
 				// tried high order strategy - failed as it tries to combine collections with not
@@ -603,7 +603,7 @@ mod tests {
 	fn proptest_jump_model() {
 		let mut runner = TestRunner::default();
 		runner
-			.run(&(valid_jump_model(), 0..=100u8), |(strategy, utilization)| {
+			.run(&(valid_jump_model(), 0..=100_u8), |(strategy, utilization)| {
 				let base_rate = strategy.base_rate;
 				let jump_rate = strategy.jump_percentage;
 				let full_rate = strategy.full_percentage;
@@ -626,7 +626,7 @@ mod tests {
 		let base_rate = Rate::saturating_from_rational(2, 100);
 		let jump_rate = Rate::saturating_from_rational(10, 100);
 		let full_rate = Rate::saturating_from_rational(32, 100);
-		let strategy = (0..=100u8, 1..=99u8)
+		let strategy = (0..=100_u8, 1..=99_u8)
 			.prop_map(|(optimal, utilization)| (optimal, utilization, utilization + 1));
 
 		let mut runner = TestRunner::default();

--- a/frame/crowdloan-bonus/src/lib.rs
+++ b/frame/crowdloan-bonus/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/crowdloan-bonus/src/lib.rs
+++ b/frame/crowdloan-bonus/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/crowdloan-bonus/src/lib.rs
+++ b/frame/crowdloan-bonus/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -15,6 +15,7 @@ proof = sign (concat prefix (hex reward_account))
 Reference for proof mechanism: https://github.com/paritytech/polkadot/blob/master/runtime/common/src/claims.rs
 */
 
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,
@@ -252,7 +253,7 @@ pub mod pallet {
 						ethereum_recover(T::Prefix::get(), &reward_account_encoded, &eth_proof)
 							.ok_or(Error::<T>::InvalidProof)?;
 					Result::<_, DispatchError>::Ok(RemoteAccount::Ethereum(ethereum_address))
-				},
+				}
 				Proof::RelayChain(relay_account, relay_proof) => {
 					ensure!(
 						verify_relay(
@@ -264,7 +265,7 @@ pub mod pallet {
 						Error::<T>::InvalidProof
 					);
 					Ok(RemoteAccount::RelayChain(relay_account))
-				},
+				}
 			}?;
 			let claimed = Self::do_claim(remote_account.clone(), &reward_account)?;
 			Associations::<T>::insert(reward_account.clone(), remote_account.clone());
@@ -320,10 +321,10 @@ pub mod pallet {
 								// The user should have claimed the upfront payment + the vested
 								// amount until this window point.
 								let vested_reward = reward.total - upfront_payment;
-								upfront_payment +
-									(vested_reward
-										.saturating_mul(T::Convert::convert(vesting_window)) /
-										T::Convert::convert(reward.vesting_period))
+								upfront_payment
+									+ (vested_reward
+										.saturating_mul(T::Convert::convert(vesting_window))
+										/ T::Convert::convert(reward.vesting_period))
 							}
 						};
 						let available_to_claim = should_have_claimed - reward.claimed;

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -15,7 +15,7 @@ proof = sign (concat prefix (hex reward_account))
 Reference for proof mechanism: https://github.com/paritytech/polkadot/blob/master/runtime/common/src/claims.rs
 */
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -16,6 +16,7 @@ Reference for proof mechanism: https://github.com/paritytech/polkadot/blob/maste
 */
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -253,7 +253,7 @@ pub mod pallet {
 						ethereum_recover(T::Prefix::get(), &reward_account_encoded, &eth_proof)
 							.ok_or(Error::<T>::InvalidProof)?;
 					Result::<_, DispatchError>::Ok(RemoteAccount::Ethereum(ethereum_address))
-				}
+				},
 				Proof::RelayChain(relay_account, relay_proof) => {
 					ensure!(
 						verify_relay(
@@ -265,7 +265,7 @@ pub mod pallet {
 						Error::<T>::InvalidProof
 					);
 					Ok(RemoteAccount::RelayChain(relay_account))
-				}
+				},
 			}?;
 			let claimed = Self::do_claim(remote_account.clone(), &reward_account)?;
 			Associations::<T>::insert(reward_account.clone(), remote_account.clone());
@@ -321,10 +321,10 @@ pub mod pallet {
 								// The user should have claimed the upfront payment + the vested
 								// amount until this window point.
 								let vested_reward = reward.total - upfront_payment;
-								upfront_payment
-									+ (vested_reward
-										.saturating_mul(T::Convert::convert(vesting_window))
-										/ T::Convert::convert(reward.vesting_period))
+								upfront_payment +
+									(vested_reward
+										.saturating_mul(T::Convert::convert(vesting_window)) /
+										T::Convert::convert(reward.vesting_period))
 							}
 						};
 						let available_to_claim = should_have_claimed - reward.claimed;

--- a/frame/crowdloan-rewards/src/mocks.rs
+++ b/frame/crowdloan-rewards/src/mocks.rs
@@ -1,20 +1,17 @@
-use crate::{self as pallet_crowdloan_rewards, models::RemoteAccount};
-use frame_support::{
-	construct_runtime, parameter_types,
-	traits::{EnsureOrigin, Everything, GenesisBuild},
-	PalletId,
-};
+use crate::{self as pallet_crowdloan_rewards};
+use frame_support::{construct_runtime, parameter_types, traits::Everything};
 use frame_system as system;
-use orml_traits::parameter_type_with_key;
+
 use sp_core::H256;
-use sp_keystore::{testing::KeyStore, SyncCryptoStore};
+
 use sp_runtime::{
 	testing::Header,
-	traits::{ConvertInto, IdentityLookup, One},
+	traits::{ConvertInto, IdentityLookup},
 	Perbill,
 };
-use system::{EnsureOneOf, EnsureRoot, EnsureSigned, EnsureSignedBy};
+use system::EnsureRoot;
 
+// REVIEW: Are these unused type aliases and constants needed? Or can they be removed?
 pub type CurrencyId = u64;
 pub type BlockNumber = u64;
 pub type AccountId = u64;

--- a/frame/crowdloan-rewards/src/models.rs
+++ b/frame/crowdloan-rewards/src/models.rs
@@ -47,7 +47,7 @@ impl<'de> Deserialize<'de> for EthereumAddress {
 		if s.len() != 40 {
 			return Err(frame_support::serde::de::Error::custom(
 				"Bad length of Ethereum address (should be 42 including '0x')",
-			));
+			))
 		}
 		let raw: Vec<u8> = rustc_hex::FromHex::from_hex(s)
 			.map_err(|e| frame_support::serde::de::Error::custom(format!("{:?}", e)))?;

--- a/frame/crowdloan-rewards/src/models.rs
+++ b/frame/crowdloan-rewards/src/models.rs
@@ -40,12 +40,14 @@ impl<'de> Deserialize<'de> for EthereumAddress {
 		D: Deserializer<'de>,
 	{
 		let base_string = String::deserialize(deserializer)?;
-		let offset = if base_string.starts_with("0x") { 2 } else { 0 };
-		let s = &base_string[offset..];
+		// strip_prefix instead of trim_start_matches because strip_prefix only removes
+		// whereas trim_start_matches removes the prefix as many times at it appears
+		// (i.e. "11foo".trim_start_matches("1") == "foo", not "1foo")
+		let s = base_string.strip_prefix("0x").unwrap_or(&base_string);
 		if s.len() != 40 {
 			return Err(frame_support::serde::de::Error::custom(
 				"Bad length of Ethereum address (should be 42 including '0x')",
-			))
+			));
 		}
 		let raw: Vec<u8> = rustc_hex::FromHex::from_hex(s)
 			.map_err(|e| frame_support::serde::de::Error::custom(format!("{:?}", e)))?;

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -2,21 +2,18 @@ use crate::{
 	ethereum_recover, ethereum_signable_message,
 	mocks::{
 		AccountId, Balance, Balances, BlockNumber, CrowdloanRewards, ExtBuilder, Origin,
-		RelayChainAccountId, System, Test, ACCOUNT_FREE_START, ALICE, BOB, CHARLIE, DAYS,
-		INITIAL_PAYMENT, MINIMUM_BALANCE, PROOF_PREFIX, VESTING_STEP, WEEKS,
+		RelayChainAccountId, System, Test, ACCOUNT_FREE_START, ALICE, INITIAL_PAYMENT,
+		PROOF_PREFIX, VESTING_STEP, WEEKS,
 	},
 	models::{EcdsaSignature, EthereumAddress, Proof, RemoteAccount},
-	verify_relay, Error, RemoteAccountOf, RewardAmountOf, VestingPeriodOf,
+	Error, RemoteAccountOf, RewardAmountOf, VestingPeriodOf,
 };
 use codec::Encode;
 use frame_support::{
-	assert_noop, assert_ok,
-	dispatch::{DispatchResult, DispatchResultWithPostInfo},
-	traits::Currency,
+	assert_noop, assert_ok, dispatch::DispatchResultWithPostInfo, traits::Currency,
 };
 use hex_literal::hex;
 use sp_core::{ed25519, keccak_256, Pair};
-use sp_runtime::MultiSignature;
 
 type RelayKey = ed25519::Pair;
 type EthKey = libsecp256k1::SecretKey;
@@ -30,10 +27,12 @@ enum ClaimKey {
 impl ClaimKey {
 	fn as_remote_public(&self) -> RemoteAccount<RelayChainAccountId> {
 		match self {
-			ClaimKey::Relay(relay_account) =>
-				RemoteAccount::RelayChain(relay_account.public().into()),
-			ClaimKey::Eth(ethereum_account) =>
-				RemoteAccount::Ethereum(ethereum_address(ethereum_account)),
+			ClaimKey::Relay(relay_account) => {
+				RemoteAccount::RelayChain(relay_account.public().into())
+			}
+			ClaimKey::Eth(ethereum_account) => {
+				RemoteAccount::Ethereum(ethereum_address(ethereum_account))
+			}
 		}
 	}
 	fn claim(&self, reward_account: AccountId) -> DispatchResultWithPostInfo {
@@ -272,7 +271,7 @@ fn test_not_a_contributor() {
 fn test_association_ok() {
 	with_rewards_default(|_, accounts| {
 		assert_ok!(CrowdloanRewards::initialize(Origin::root()));
-		for (picasso_account, remote_account) in accounts.clone().into_iter() {
+		for (picasso_account, remote_account) in accounts.into_iter() {
 			assert_ok!(remote_account.associate(picasso_account));
 		}
 	});
@@ -282,7 +281,7 @@ fn test_association_ok() {
 fn test_association_ko() {
 	with_rewards_default(|_, accounts| {
 		assert_ok!(CrowdloanRewards::initialize(Origin::root()));
-		for (picasso_account, remote_account) in accounts.clone().into_iter() {
+		for (picasso_account, remote_account) in accounts.into_iter() {
 			assert_noop!(remote_account.claim(picasso_account), Error::<Test>::NotAssociated);
 		}
 	});

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -27,12 +27,10 @@ enum ClaimKey {
 impl ClaimKey {
 	fn as_remote_public(&self) -> RemoteAccount<RelayChainAccountId> {
 		match self {
-			ClaimKey::Relay(relay_account) => {
-				RemoteAccount::RelayChain(relay_account.public().into())
-			}
-			ClaimKey::Eth(ethereum_account) => {
-				RemoteAccount::Ethereum(ethereum_address(ethereum_account))
-			}
+			ClaimKey::Relay(relay_account) =>
+				RemoteAccount::RelayChain(relay_account.public().into()),
+			ClaimKey::Eth(ethereum_account) =>
+				RemoteAccount::Ethereum(ethereum_address(ethereum_account)),
 		}
 	}
 	fn claim(&self, reward_account: AccountId) -> DispatchResultWithPostInfo {

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -65,7 +65,7 @@ fn ethereum_proof(
 	);
 	let (sig, recovery_id) =
 		libsecp256k1::sign(&libsecp256k1::Message::parse(&msg), ethereum_account);
-	let mut r = [0u8; 65];
+	let mut r = [0_u8; 65];
 	r[0..64].copy_from_slice(&sig.serialize()[..]);
 	r[64] = recovery_id.serialize();
 	Proof::Ethereum(EcdsaSignature(r))

--- a/frame/currency-factory/src/lib.rs
+++ b/frame/currency-factory/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/currency-factory/src/lib.rs
+++ b/frame/currency-factory/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/currency-factory/src/lib.rs
+++ b/frame/currency-factory/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/curve-amm/proptest-regressions/tests.txt
+++ b/frame/curve-amm/proptest-regressions/tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 1ea305057bd951d12bd15cc5e9e1516e48e44c471411f28d2a3715702aa1ea37 # shrinks to alice_balance = 0, bob_balance = 0

--- a/frame/curve-amm/src/lib.rs
+++ b/frame/curve-amm/src/lib.rs
@@ -1,5 +1,4 @@
-//
-
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/curve-amm/src/lib.rs
+++ b/frame/curve-amm/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,
@@ -444,8 +445,8 @@ pub mod pallet {
 				// fees as a swap. Otherwise, one could exchange w/o paying fees.
 				// And this formula leads to exactly that equality
 				// fee = pool.fee * n_coins / (4 * (n_coins - 1))
-				let one = FixedU128::saturating_from_integer(1u8);
-				let four = FixedU128::saturating_from_integer(4u8);
+				let one = FixedU128::saturating_from_integer(1_u8);
+				let four = FixedU128::saturating_from_integer(4_u8);
 				let n_coins_f = FixedU128::saturating_from_integer(n_coins as u128);
 				let fee_f: FixedU128 = pool.fee.into();
 				let fee_f = fee_f
@@ -962,7 +963,7 @@ pub mod pallet {
 		) -> Option<FixedU128> {
 			let zero = FixedU128::zero();
 			let prec = T::Precision::get();
-			let two = FixedU128::saturating_from_integer(2u8);
+			let two = FixedU128::saturating_from_integer(2_u8);
 			let n = FixedU128::try_from(xp_f.len() as u128).ok()?;
 
 			// Same coin
@@ -1051,7 +1052,7 @@ pub mod pallet {
 		) -> Option<FixedU128> {
 			let zero = FixedU128::zero();
 			let prec = T::Precision::get();
-			let two = FixedU128::saturating_from_integer(2u8);
+			let two = FixedU128::saturating_from_integer(2_u8);
 			let n = FixedU128::try_from(xp_f.len() as u128).ok()?;
 
 			if i >= xp_f.len() {

--- a/frame/curve-amm/src/tests.rs
+++ b/frame/curve-amm/src/tests.rs
@@ -45,10 +45,10 @@ macro_rules! prop_assert_epsilon {
 #[test]
 fn compute_d_works() {
 	let xp = vec![
-		FixedU128::saturating_from_rational(11u128, 10u128),
-		FixedU128::saturating_from_rational(88u128, 100u128),
+		FixedU128::saturating_from_rational(11_u128, 10_u128),
+		FixedU128::saturating_from_rational(88_u128, 100_u128),
 	];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 	let d = CurveAmm::get_d(&xp, ann);
 	// expected d is 1.978195735374521596
@@ -56,19 +56,19 @@ fn compute_d_works() {
 	let delta = d
 		.map(|x| {
 			x.saturating_sub(FixedU128::saturating_from_rational(
-				1978195735374521596u128,
-				10_000_000_000_000_000u128,
+				1978195735374521596_u128,
+				10_000_000_000_000_000_u128,
 			))
 			.saturating_abs()
 		})
-		.map(|x| x.cmp(&FixedU128::saturating_from_rational(1u128, 10_000_000_000_000u128)));
+		.map(|x| x.cmp(&FixedU128::saturating_from_rational(1_u128, 10_000_000_000_000_u128)));
 	assert_eq!(delta, Some(Ordering::Less));
 }
 
 #[test]
 fn compute_d_empty() {
 	let xp = vec![];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 	let result = CurveAmm::get_d(&xp, ann);
 	assert_eq!(result, Some(FixedU128::zero()));
@@ -78,12 +78,12 @@ fn compute_d_empty() {
 fn get_y_successful() {
 	let i = 0;
 	let j = 1;
-	let x = FixedU128::saturating_from_rational(111u128, 100u128);
+	let x = FixedU128::saturating_from_rational(111_u128, 100_u128);
 	let xp = vec![
-		FixedU128::saturating_from_rational(11u128, 10u128),
-		FixedU128::saturating_from_rational(88u128, 100u128),
+		FixedU128::saturating_from_rational(11_u128, 10_u128),
+		FixedU128::saturating_from_rational(88_u128, 100_u128),
 	];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 
 	let result = CurveAmm::get_y(i, j, x, &xp, ann);
@@ -92,12 +92,12 @@ fn get_y_successful() {
 	let delta = result
 		.map(|x| {
 			x.saturating_sub(FixedU128::saturating_from_rational(
-				1247108067356516682u128,
-				10_000_000_000_000_000u128,
+				1247108067356516682_u128,
+				10_000_000_000_000_000_u128,
 			))
 			.saturating_abs()
 		})
-		.map(|x| x.cmp(&FixedU128::saturating_from_rational(1u128, 10_000_000_000_000u128)));
+		.map(|x| x.cmp(&FixedU128::saturating_from_rational(1_u128, 10_000_000_000_000_u128)));
 	assert_eq!(delta, Some(Ordering::Less));
 }
 
@@ -105,12 +105,12 @@ fn get_y_successful() {
 fn get_y_same_coin() {
 	let i = 1;
 	let j = 1;
-	let x = FixedU128::saturating_from_rational(111u128, 100u128);
+	let x = FixedU128::saturating_from_rational(111_u128, 100_u128);
 	let xp = vec![
-		FixedU128::saturating_from_rational(11u128, 10u128),
-		FixedU128::saturating_from_rational(88u128, 100u128),
+		FixedU128::saturating_from_rational(11_u128, 10_u128),
+		FixedU128::saturating_from_rational(88_u128, 100_u128),
 	];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 
 	let result = CurveAmm::get_y(i, j, x, &xp, ann);
@@ -122,12 +122,12 @@ fn get_y_same_coin() {
 fn get_y_i_greater_than_n() {
 	let i = 33;
 	let j = 1;
-	let x = FixedU128::saturating_from_rational(111u128, 100u128);
+	let x = FixedU128::saturating_from_rational(111_u128, 100_u128);
 	let xp = vec![
-		FixedU128::saturating_from_rational(11u128, 10u128),
-		FixedU128::saturating_from_rational(88u128, 100u128),
+		FixedU128::saturating_from_rational(11_u128, 10_u128),
+		FixedU128::saturating_from_rational(88_u128, 100_u128),
 	];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 
 	let result = CurveAmm::get_y(i, j, x, &xp, ann);
@@ -139,12 +139,12 @@ fn get_y_i_greater_than_n() {
 fn get_y_j_greater_than_n() {
 	let i = 1;
 	let j = 33;
-	let x = FixedU128::saturating_from_rational(111u128, 100u128);
+	let x = FixedU128::saturating_from_rational(111_u128, 100_u128);
 	let xp = vec![
-		FixedU128::saturating_from_rational(11u128, 10u128),
-		FixedU128::saturating_from_rational(88u128, 100u128),
+		FixedU128::saturating_from_rational(11_u128, 10_u128),
+		FixedU128::saturating_from_rational(88_u128, 100_u128),
 	];
-	let amp = FixedU128::saturating_from_rational(292u128, 100u128);
+	let amp = FixedU128::saturating_from_rational(292_u128, 100_u128);
 	let ann = CurveAmm::get_ann(amp, xp.len()).unwrap();
 
 	let result = CurveAmm::get_y(i, j, x, &xp, ann);
@@ -241,7 +241,7 @@ fn add_remove_liquidity() {
 fn exchange_test() {
 	new_test_ext().execute_with(|| {
 		let assets = vec![MockCurrencyId::USDC, MockCurrencyId::USDT];
-		let amp_coeff = FixedU128::saturating_from_rational(1000i128, 1i128);
+		let amp_coeff = FixedU128::saturating_from_rational(1000_i128, 1_i128);
 		let fee = Permill::zero();
 		let admin_fee = Permill::zero();
 
@@ -269,15 +269,15 @@ fn exchange_test() {
 		assert!(pool_lp_asset.is_some());
 		let pool_lp_asset = pool_lp_asset.unwrap();
 		// 1 USDC = 1 USDT
-		let amounts = vec![130000u128, 130000u128];
-		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, amounts.clone(), 0u128));
+		let amounts = vec![130000_u128, 130000_u128];
+		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, amounts.clone(), 0_u128));
 		let alice_balance = Tokens::balance(pool_lp_asset, &ALICE);
 		assert_ne!(alice_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 200000 - 130000);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDC, &ALICE), 200000 - 130000);
 		let pool = CurveAmm::pool(pool_id);
 		assert!(pool.is_some());
-		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, amounts.clone(), 0u128));
+		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, amounts.clone(), 0_u128));
 		let bob_balance = Tokens::balance(pool_lp_asset, &BOB);
 		assert_ne!(bob_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), 200000 - 130000);
@@ -298,7 +298,7 @@ proptest! {
 	new_test_ext().execute_with(|| {
 		// configuration for DEX Pool
 		let assets = vec![MockCurrencyId::USDC, MockCurrencyId::USDT];
-		let amp_coeff = FixedU128::saturating_from_rational(10000i128, 1i128);
+		let amp_coeff = FixedU128::saturating_from_rational(10000_i128, 1_i128);
 		let fee = Permill::zero();
 		let admin_fee = Permill::zero();
 
@@ -336,7 +336,7 @@ proptest! {
 
 		// ALICE adds liquidity to DEX pool.
 		let alice_amounts = vec![alice_balance as u128, alice_balance as u128];
-		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, alice_amounts.clone(), 0u128));
+		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, alice_amounts.clone(), 0_u128));
 		let alice_lp_balance = Tokens::balance(pool_lp_asset, &ALICE);
 		assert_ne!(alice_lp_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
@@ -344,7 +344,7 @@ proptest! {
 
 		// BOB adds liquidity to DEX pool.
 		let bob_amounts = vec![bob_balance as u128, bob_balance as u128];
-		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, bob_amounts.clone(), 0u128));
+		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, bob_amounts.clone(), 0_u128));
 		let bob_lp_balance = Tokens::balance(pool_lp_asset, &BOB);
 		assert_ne!(bob_lp_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), 0);
@@ -364,7 +364,7 @@ proptest! {
 	new_test_ext().execute_with(|| {
 		// configuration for DEX Pool
 		let assets = vec![MockCurrencyId::USDC, MockCurrencyId::USDT];
-		let amp_coeff = FixedU128::saturating_from_rational(1000i128, 1i128);
+		let amp_coeff = FixedU128::saturating_from_rational(1000_i128, 1_i128);
 		let fee = Permill::zero();
 		let admin_fee = Permill::zero();
 
@@ -396,7 +396,7 @@ proptest! {
 
 		// ALICE adds liquidity to DEX pool.
 		let alice_amounts = vec![alice_balance as u128, alice_balance as u128];
-		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, alice_amounts.clone(), 0u128));
+		assert_ok!(CurveAmm::add_liquidity(&ALICE, pool_id, alice_amounts.clone(), 0_u128));
 		let alice_lp_balance = Tokens::balance(pool_lp_asset, &ALICE);
 		assert_ne!(alice_lp_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
@@ -404,13 +404,13 @@ proptest! {
 
 		// BOB adds liquidity to DEX pool.
 		let bob_amounts = vec![bob_balance as u128, bob_balance as u128];
-		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, bob_amounts.clone(), 0u128));
+		assert_ok!(CurveAmm::add_liquidity(&BOB, pool_id, bob_amounts.clone(), 0_u128));
 		let bob_lp_balance = Tokens::balance(pool_lp_asset, &BOB);
 		assert_ne!(bob_balance, 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), 0);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDC, &BOB), 0);
 
-		let min_amt = vec![0u128, 0u128];
+		let min_amt = vec![0_u128, 0_u128];
 		assert_eq!(Tokens::balance(MockCurrencyId::USDC, &CurveAmm::account_id(&pool_id)), alice_balance as u128 + bob_balance as u128);
 		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &CurveAmm::account_id(&pool_id)), alice_balance as u128 + bob_balance as u128);
 

--- a/frame/dutch-auction/src/lib.rs
+++ b/frame/dutch-auction/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/dutch-auction/src/lib.rs
+++ b/frame/dutch-auction/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/dutch-auction/src/lib.rs
+++ b/frame/dutch-auction/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,
@@ -236,7 +237,7 @@ pub mod pallet {
 								AuctionStepFunction::StairstepExponentialDecrease(parameters) =>
 									parameters.price(total_price, delta_time),
 							}?
-							.checked_mul_int(1u64)
+							.checked_mul_int(1_u64)
 							.ok_or(ArithmeticError::Overflow)?;
 
 							let price =

--- a/frame/dutch-auction/src/price_function.rs
+++ b/frame/dutch-auction/src/price_function.rs
@@ -112,7 +112,7 @@ mod tests {
 		let half = 10;
 
 		let calc = StairstepExponentialDecrease {
-			cut: Permill::from_float(2.71f64.powf(f64::ln(1.0 / 2.0) / half as f64)),
+			cut: Permill::from_float(2.71_f64.powf(f64::ln(1.0 / 2.0) / half as f64)),
 			step: 1,
 		};
 
@@ -141,7 +141,7 @@ mod tests {
 		let initial_price = LiftedFixedBalance::saturating_from_integer(1_000_000);
 		let calc_linear = LinearDecrease { total: time_max };
 		let calc_divide_by_2 =
-			StairstepExponentialDecrease { cut: Permill::from_rational(1u32, 2u32), step: 1 };
+			StairstepExponentialDecrease { cut: Permill::from_rational(1_u32, 2_u32), step: 1 };
 
 		// bases
 		assert_eq!(

--- a/frame/governance-registry/src/lib.rs
+++ b/frame/governance-registry/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Is used to add new assets into chain.
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/governance-registry/src/lib.rs
+++ b/frame/governance-registry/src/lib.rs
@@ -3,6 +3,7 @@
 //! Is used to add new assets into chain.
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/governance-registry/src/lib.rs
+++ b/frame/governance-registry/src/lib.rs
@@ -1,6 +1,8 @@
 //! # Governance Registry Pallet
 //!
 //! Is used to add new assets into chain.
+
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub use pallet::*;

--- a/frame/lending/src/lib.rs
+++ b/frame/lending/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/lending/src/lib.rs
+++ b/frame/lending/src/lib.rs
@@ -1,5 +1,4 @@
-//!
-
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/lending/src/lib.rs
+++ b/frame/lending/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,
@@ -1368,7 +1369,7 @@ pub mod pallet {
 			let borrow_asset = T::Vault::asset_id(&market.borrow)?;
 			let borrow_amount_value = Self::get_price(borrow_asset, borrow_amount)?;
 			Ok(swap_back(borrow_amount_value.into(), &market.collateral_factor)?
-				.checked_mul_int(1u64)
+				.checked_mul_int(1_u64)
 				.ok_or(ArithmeticError::Overflow)?
 				.into())
 		}
@@ -1385,7 +1386,7 @@ pub mod pallet {
 				Ok(borrower
 					.borrow_for_collateral()
 					.map_err(|_| Error::<T>::NotEnoughCollateralToBorrowAmount)?
-					.checked_mul_int(1u64)
+					.checked_mul_int(1_u64)
 					.ok_or(ArithmeticError::Overflow)?
 					.into())
 			} else {
@@ -1509,7 +1510,7 @@ pub mod pallet {
 		let balance = principal
 			.checked_mul(&market_interest_index)
 			.and_then(|from_start_total| from_start_total.checked_div(&account_interest_index))
-			.and_then(|x| x.checked_mul_int(1u64))
+			.and_then(|x| x.checked_mul_int(1_u64))
 			.ok_or(ArithmeticError::Overflow)?;
 		Ok(Some(balance))
 	}

--- a/frame/lending/src/mocks/mod.rs
+++ b/frame/lending/src/mocks/mod.rs
@@ -65,22 +65,22 @@ pub static UNRESERVED: Lazy<AccountId> = Lazy::new(|| {
 	TypeInfo,
 )]
 pub enum MockCurrencyId {
-	PICA,
-	BTC,
-	ETH,
-	LTC,
-	USDT,
+	Pica,
+	Btc,
+	Eth,
+	Ltc,
+	Usdt,
 	LpToken(u128),
 }
 
 impl From<u128> for MockCurrencyId {
 	fn from(id: u128) -> Self {
 		match id {
-			0 => MockCurrencyId::PICA,
-			1 => MockCurrencyId::BTC,
-			2 => MockCurrencyId::ETH,
-			3 => MockCurrencyId::LTC,
-			4 => MockCurrencyId::USDT,
+			0 => MockCurrencyId::Pica,
+			1 => MockCurrencyId::Btc,
+			2 => MockCurrencyId::Eth,
+			3 => MockCurrencyId::Ltc,
+			4 => MockCurrencyId::Usdt,
 			5 => MockCurrencyId::LpToken(0),
 			_ => unreachable!(),
 		}
@@ -89,18 +89,18 @@ impl From<u128> for MockCurrencyId {
 
 impl Default for MockCurrencyId {
 	fn default() -> Self {
-		MockCurrencyId::PICA
+		MockCurrencyId::Pica
 	}
 }
 
 impl PriceableAsset for MockCurrencyId {
 	fn smallest_unit_exponent(self) -> composable_traits::currency::Exponent {
 		match self {
-			MockCurrencyId::PICA => 0,
-			MockCurrencyId::BTC => 8,
-			MockCurrencyId::ETH => 18,
-			MockCurrencyId::LTC => 8,
-			MockCurrencyId::USDT => 2,
+			MockCurrencyId::Pica => 0,
+			MockCurrencyId::Btc => 8,
+			MockCurrencyId::Eth => 18,
+			MockCurrencyId::Ltc => 8,
+			MockCurrencyId::Usdt => 2,
 			MockCurrencyId::LpToken(_) => 0,
 		}
 	}
@@ -209,7 +209,7 @@ impl pallet_currency_factory::Config for Test {
 
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
-	pub const NativeAssetId: MockCurrencyId = MockCurrencyId::PICA;
+	pub const NativeAssetId: MockCurrencyId = MockCurrencyId::Pica;
 	pub const CreationDeposit: Balance = 10;
 	pub const RentPerBlock: Balance = 1;
 	pub const MinimumDeposit: Balance = 0;
@@ -287,7 +287,7 @@ impl Orderbook for MockOrderbook {
 		_source_price: Price<Self::GroupId, Self::Balance>,
 		_amm_slippage: Permill,
 	) -> Result<SellOrder<Self::OrderId, Self::AccountId>, DispatchError> {
-		Ok(SellOrder { id: 0, account: ALICE.clone() })
+		Ok(SellOrder { id: 0, account: *ALICE })
 	}
 
 	fn market_sell(

--- a/frame/lending/src/mocks/mod.rs
+++ b/frame/lending/src/mocks/mod.rs
@@ -402,7 +402,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 		System::set_block_number(0);
 		Timestamp::set_timestamp(MILLISECS_PER_BLOCK);
 		// Initialize BTC price to 50000
-		pallet_lending::mocks::oracle::BTCValue::<Test>::set(50000u128);
+		pallet_lending::mocks::oracle::BTCValue::<Test>::set(50000_u128);
 	});
 	ext
 }

--- a/frame/lending/src/mocks/oracle.rs
+++ b/frame/lending/src/mocks/oracle.rs
@@ -50,7 +50,7 @@ pub mod pallet {
 			amount: Balance,
 		) -> Result<Price<Self::Balance, Self::Timestamp>, DispatchError> {
 			let derive_price = |p: u128, a: u128| {
-				let e = 10u128
+				let e = 10_u128
 					.checked_pow(asset.smallest_unit_exponent())
 					.ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
 				let price = multiply_by_rational(p, a, e)
@@ -98,7 +98,7 @@ pub mod pallet {
 			_of: Self::AssetId,
 			_weights: Vec<u128>,
 		) -> Result<Self::Balance, DispatchError> {
-			Ok(0u32.into())
+			Ok(0_u32.into())
 		}
 	}
 }

--- a/frame/lending/src/mocks/oracle.rs
+++ b/frame/lending/src/mocks/oracle.rs
@@ -90,7 +90,7 @@ pub mod pallet {
 						.checked_mul_int(price)
 						.ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
 					Ok(Price { price: derived, block })
-				}
+				},
 			}
 		}
 

--- a/frame/lending/src/mocks/oracle.rs
+++ b/frame/lending/src/mocks/oracle.rs
@@ -57,16 +57,18 @@ pub mod pallet {
 					.map_err(|_| DispatchError::Arithmetic(ArithmeticError::Overflow))?;
 				Ok(Price { price, block: () })
 			};
+
+			#[allow(clippy::inconsistent_digit_grouping)] // values are in cents
 			match asset {
 				/* NOTE(hussein-aitlahcen)
 					Ideally we would have all the static currency quoted against USD cents on chain.
 					So that we would be able to derive LP tokens price.
 				*/
-				MockCurrencyId::USDT => Ok(Price { price: amount, block: () }),
-				MockCurrencyId::PICA => derive_price(10_00, amount),
-				MockCurrencyId::BTC => derive_price(Self::btc_value(), amount),
-				MockCurrencyId::ETH => derive_price(3400_00, amount),
-				MockCurrencyId::LTC => derive_price(180_00, amount),
+				MockCurrencyId::Usdt => Ok(Price { price: amount, block: () }),
+				MockCurrencyId::Pica => derive_price(10_00, amount),
+				MockCurrencyId::Btc => derive_price(Self::btc_value(), amount),
+				MockCurrencyId::Eth => derive_price(3400_00, amount),
+				MockCurrencyId::Ltc => derive_price(180_00, amount),
 
 				/* NOTE(hussein-aitlahcen)
 					If we want users to be able to consider LP tokens as currency,
@@ -88,7 +90,7 @@ pub mod pallet {
 						.checked_mul_int(price)
 						.ok_or(DispatchError::Arithmetic(ArithmeticError::Overflow))?;
 					Ok(Price { price: derived, block })
-				},
+				}
 			}
 		}
 

--- a/frame/lending/src/tests.rs
+++ b/frame/lending/src/tests.rs
@@ -177,7 +177,7 @@ fn accrue_interest_induction() {
 		.run(
 			&(
 				0..=2 * SECONDS_PER_YEAR / MILLISECS_PER_BLOCK,
-				(minimal..=35u32).prop_map(|i| 10u128.pow(i)),
+				(minimal..=35_u32).prop_map(|i| 10_u128.pow(i)),
 			),
 			|(slot, total_issued)| {
 				let (optimal, ref mut interest_rate_model) = new_jump_model();

--- a/frame/lending/src/tests.rs
+++ b/frame/lending/src/tests.rs
@@ -75,10 +75,10 @@ fn create_market(
 /// Create a market with a USDT vault LP token as collateral
 fn create_simple_vaulted_market() -> ((MarketIndex, BorrowAssetVault), CollateralAsset) {
 	let (_collateral_vault, VaultInfo { lp_token_id: collateral_asset, .. }) =
-		create_simple_vault(MockCurrencyId::USDT);
+		create_simple_vault(MockCurrencyId::Usdt);
 	(
 		create_market(
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			collateral_asset,
 			*ALICE,
 			DEFAULT_MARKET_VAULT_RESERVE,
@@ -91,8 +91,8 @@ fn create_simple_vaulted_market() -> ((MarketIndex, BorrowAssetVault), Collatera
 /// Create a market with straight USDT as collateral
 fn create_simple_market() -> (MarketIndex, BorrowAssetVault) {
 	create_market(
-		MockCurrencyId::BTC,
-		MockCurrencyId::USDT,
+		MockCurrencyId::Btc,
+		MockCurrencyId::Usdt,
 		*ALICE,
 		DEFAULT_MARKET_VAULT_RESERVE,
 		NormalizedCollateralFactor::saturating_from_rational(200, 100),
@@ -272,19 +272,19 @@ fn test_borrow_repay_in_same_block() {
 		let collateral_amount = 900000;
 		let (market, vault) = create_simple_market();
 		// Balance for ALICE
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, collateral_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), collateral_amount);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, collateral_amount));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), collateral_amount);
 
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, collateral_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
 
 		// Balance of BTC for CHARLIE
 		// CHARLIE is only lender of BTC
 		let borrow_asset_deposit = collateral_amount;
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &CHARLIE, borrow_asset_deposit));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), borrow_asset_deposit);
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &CHARLIE, borrow_asset_deposit));
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), borrow_asset_deposit);
 		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault, borrow_asset_deposit));
 		let mut total_cash = DEFAULT_MARKET_VAULT_STRATEGY_SHARE.mul(borrow_asset_deposit);
 
@@ -306,7 +306,7 @@ fn test_borrow_repay_in_same_block() {
 		let alice_repay_amount = Lending::borrow_balance_current(&market, &ALICE).unwrap();
 		// MINT required BTC so that ALICE and BOB can repay the borrow.
 		assert_ok!(Tokens::mint_into(
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			&ALICE,
 			alice_repay_amount.unwrap() - (alice_limit / 4)
 		));
@@ -357,27 +357,27 @@ fn test_borrow() {
 	new_test_ext().execute_with(|| {
 		let (market, vault) = create_simple_market();
 
-		Oracle::set_btc_price(50_000 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(50_000 * MockCurrencyId::Usdt.unit::<Balance>());
 
 		let btc_price = |x| {
-			Oracle::get_price(MockCurrencyId::BTC, x * MockCurrencyId::BTC.unit::<Balance>())
+			Oracle::get_price(MockCurrencyId::Btc, x * MockCurrencyId::Btc.unit::<Balance>())
 				.expect("impossible")
 				.price
 		};
 
-		let collateral_amount = 1_000_000 * MockCurrencyId::USDT.unit::<Balance>();
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, collateral_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), collateral_amount);
+		let collateral_amount = 1_000_000 * MockCurrencyId::Usdt.unit::<Balance>();
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, collateral_amount));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), collateral_amount);
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, collateral_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
 
-		let borrow_asset_deposit = 100 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &CHARLIE, borrow_asset_deposit));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), borrow_asset_deposit);
+		let borrow_asset_deposit = 100 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &CHARLIE, borrow_asset_deposit));
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), borrow_asset_deposit);
 		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault, borrow_asset_deposit));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), 0);
 
 		let alice_limit = Lending::get_borrow_limit(&market, &ALICE).unwrap();
 
@@ -394,7 +394,7 @@ fn test_borrow() {
 		assert_eq!(Lending::total_cash(&market), Ok(expected_cash));
 
 		// Borrow a single BTC
-		let alice_borrow = MockCurrencyId::BTC.unit::<Balance>();
+		let alice_borrow = MockCurrencyId::Btc.unit::<Balance>();
 		assert_ok!(Lending::borrow_internal(&market, &ALICE, alice_borrow));
 		assert_eq!(Lending::total_cash(&market), Ok(expected_cash - alice_borrow));
 		assert_eq!(Lending::total_borrows(&market), Ok(alice_borrow));
@@ -407,7 +407,7 @@ fn test_borrow() {
 
 		// Interests mean that we cannot borrow the remaining 9 BTCs.
 		assert_noop!(
-			Lending::borrow_internal(&market, &ALICE, 9 * MockCurrencyId::BTC.unit::<Balance>()),
+			Lending::borrow_internal(&market, &ALICE, 9 * MockCurrencyId::Btc.unit::<Balance>()),
 			Error::<Test>::NotEnoughCollateralToBorrowAmount
 		);
 
@@ -415,7 +415,7 @@ fn test_borrow() {
 		assert_ok!(Lending::borrow_internal(
 			&market,
 			&ALICE,
-			8 * MockCurrencyId::BTC.unit::<Balance>()
+			8 * MockCurrencyId::Btc.unit::<Balance>()
 		));
 
 		// More than one borrow request in same block is invalid.
@@ -426,7 +426,7 @@ fn test_borrow() {
 
 		process_block(10001);
 
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, collateral_amount));
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, collateral_amount));
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, collateral_amount));
 
 		let alice_limit = Lending::get_borrow_limit(&market, &ALICE).unwrap();
@@ -437,14 +437,14 @@ fn test_borrow() {
 
 		// Try to borrow more than limit
 		assert_noop!(
-			Lending::borrow_internal(&market, &ALICE, 11 * MockCurrencyId::BTC.unit::<Balance>()),
+			Lending::borrow_internal(&market, &ALICE, 11 * MockCurrencyId::Btc.unit::<Balance>()),
 			Error::<Test>::NotEnoughCollateralToBorrowAmount
 		);
 
 		assert_ok!(Lending::borrow_internal(
 			&market,
 			&ALICE,
-			10 * MockCurrencyId::BTC.unit::<Balance>()
+			10 * MockCurrencyId::Btc.unit::<Balance>()
 		));
 	});
 }
@@ -454,17 +454,17 @@ fn test_vault_market_cannot_withdraw() {
 	new_test_ext().execute_with(|| {
 		let (market, vault_id) = create_simple_market();
 
-		let deposit_usdt = 1_000_000 * MockCurrencyId::USDT.unit::<Balance>();
-		let deposit_btc = 10 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, deposit_usdt));
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &ALICE, deposit_btc));
+		let deposit_usdt = 1_000_000 * MockCurrencyId::Usdt.unit::<Balance>();
+		let deposit_btc = 10 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, deposit_usdt));
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &ALICE, deposit_btc));
 
 		assert_ok!(Vault::deposit(Origin::signed(*ALICE), vault_id, deposit_btc));
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, deposit_usdt));
 
 		// We don't even wait 1 block, which mean the market couldn't withdraw funds.
 		assert_noop!(
-			Lending::borrow_internal(&market, &ALICE, 1 * MockCurrencyId::BTC.unit::<Balance>()),
+			Lending::borrow_internal(&market, &ALICE, MockCurrencyId::Btc.unit::<Balance>()),
 			Error::<Test>::NotEnoughBorrowAsset
 		);
 	});
@@ -475,10 +475,10 @@ fn test_vault_market_can_withdraw() {
 	new_test_ext().execute_with(|| {
 		let (market, vault_id) = create_simple_market();
 
-		let deposit_usdt = 1_000_000 * MockCurrencyId::USDT.unit::<Balance>();
-		let deposit_btc = 10 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, deposit_usdt));
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &ALICE, deposit_btc));
+		let deposit_usdt = 1_000_000 * MockCurrencyId::Usdt.unit::<Balance>();
+		let deposit_btc = 10 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, deposit_usdt));
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &ALICE, deposit_btc));
 
 		assert_ok!(Vault::deposit(Origin::signed(*ALICE), vault_id, deposit_btc));
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, deposit_usdt));
@@ -491,7 +491,7 @@ fn test_vault_market_can_withdraw() {
 		assert_ok!(Lending::borrow_internal(
 			&market,
 			&ALICE,
-			1 * MockCurrencyId::BTC.unit::<Balance>()
+			MockCurrencyId::Btc.unit::<Balance>()
 		),);
 	});
 }
@@ -499,29 +499,29 @@ fn test_vault_market_can_withdraw() {
 #[test]
 fn borrow_repay() {
 	new_test_ext().execute_with(|| {
-		let alice_balance = 1_000_000 * MockCurrencyId::USDT.unit::<Balance>();
-		let bob_balance = 1_000_000 * MockCurrencyId::USDT.unit::<Balance>();
+		let alice_balance = 1_000_000 * MockCurrencyId::Usdt.unit::<Balance>();
+		let bob_balance = 1_000_000 * MockCurrencyId::Usdt.unit::<Balance>();
 
 		let (market, vault) = create_simple_market();
 
 		// Balance for ALICE
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, alice_balance));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), alice_balance);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, alice_balance));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), alice_balance);
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, alice_balance));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
 
 		// Balance for BOB
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &BOB, bob_balance));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), bob_balance);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &BOB), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &BOB, bob_balance));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &BOB), bob_balance);
 		assert_ok!(Lending::deposit_collateral_internal(&market, &BOB, bob_balance));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &BOB), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &BOB), 0);
 
-		let borrow_asset_deposit = 10 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &CHARLIE, borrow_asset_deposit));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &CHARLIE), borrow_asset_deposit);
+		let borrow_asset_deposit = 10 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &CHARLIE, borrow_asset_deposit));
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &CHARLIE), borrow_asset_deposit);
 		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault, borrow_asset_deposit));
 
 		// Allow the market to initialize it's account by withdrawing
@@ -558,12 +558,12 @@ fn borrow_repay() {
 
 		// MINT required BTC so that ALICE and BOB can repay the borrow.
 		assert_ok!(Tokens::mint_into(
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			&ALICE,
 			alice_repay_amount.unwrap() - alice_limit
 		));
 		assert_ok!(Tokens::mint_into(
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			&BOB,
 			bob_repay_amount.unwrap() - bob_limit
 		));
@@ -571,8 +571,8 @@ fn borrow_repay() {
 		// interest paid on borrows
 		assert_ok!(Lending::repay_borrow_internal(&market, &BOB, &BOB, bob_repay_amount));
 		assert_ok!(Lending::repay_borrow_internal(&market, &ALICE, &ALICE, alice_repay_amount));
-		assert!(alice_balance > Tokens::balance(MockCurrencyId::USDT, &ALICE));
-		assert!(bob_balance > Tokens::balance(MockCurrencyId::USDT, &BOB));
+		assert!(alice_balance > Tokens::balance(MockCurrencyId::Usdt, &ALICE));
+		assert!(bob_balance > Tokens::balance(MockCurrencyId::Usdt, &BOB));
 	});
 }
 
@@ -580,26 +580,26 @@ fn borrow_repay() {
 fn test_liquidation() {
 	new_test_ext().execute_with(|| {
 		let (market, vault) = create_market(
-			MockCurrencyId::USDT,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Usdt,
+			MockCurrencyId::Btc,
 			*ALICE,
 			Perquintill::from_percent(10),
 			NormalizedCollateralFactor::saturating_from_rational(2, 1),
 		);
 
-		Oracle::set_btc_price(100 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(100 * MockCurrencyId::Usdt.unit::<Balance>());
 
-		let two_btc_amount = 2 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &ALICE, two_btc_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), two_btc_amount);
+		let two_btc_amount = 2 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &ALICE, two_btc_amount));
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), two_btc_amount);
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, two_btc_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), 0);
 
 		let usdt_amt = u32::MAX as Balance;
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &CHARLIE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &CHARLIE, usdt_amt));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &CHARLIE), usdt_amt);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &CHARLIE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &CHARLIE, usdt_amt));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &CHARLIE), usdt_amt);
 		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault, usdt_amt));
 
 		assert_eq!(Lending::borrow_balance_current(&market, &ALICE), Ok(Some(0)));
@@ -620,7 +620,7 @@ fn test_liquidation() {
 		}
 
 		// Collateral going down imply liquidation
-		Oracle::set_btc_price(99 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(99 * MockCurrencyId::Usdt.unit::<Balance>());
 
 		assert_ok!(Lending::liquidate_internal(&market, &ALICE));
 	});
@@ -630,30 +630,30 @@ fn test_liquidation() {
 fn test_warn_soon_under_collaterized() {
 	new_test_ext().execute_with(|| {
 		let (market, vault) = create_market(
-			MockCurrencyId::USDT,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Usdt,
+			MockCurrencyId::Btc,
 			*ALICE,
 			Perquintill::from_percent(10),
 			NormalizedCollateralFactor::saturating_from_rational(2, 1),
 		);
 
 		// 1 BTC = 100 USDT
-		Oracle::set_btc_price(100 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(100 * MockCurrencyId::Usdt.unit::<Balance>());
 
 		// Deposit 2 BTC
-		let two_btc_amount = 2 * MockCurrencyId::BTC.unit::<Balance>();
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &ALICE, two_btc_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), two_btc_amount);
+		let two_btc_amount = 2 * MockCurrencyId::Btc.unit::<Balance>();
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &ALICE, two_btc_amount));
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), two_btc_amount);
 		assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, two_btc_amount));
-		assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), 0);
+		assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), 0);
 
 		// Balance of USDT for CHARLIE
 		// CHARLIE is only lender of USDT
 		let usdt_amt = u32::MAX as Balance;
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &CHARLIE), 0);
-		assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &CHARLIE, usdt_amt));
-		assert_eq!(Tokens::balance(MockCurrencyId::USDT, &CHARLIE), usdt_amt);
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &CHARLIE), 0);
+		assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &CHARLIE, usdt_amt));
+		assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &CHARLIE), usdt_amt);
 		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault, usdt_amt));
 
 		// Allow the market to initialize it's account by withdrawing
@@ -673,18 +673,18 @@ fn test_warn_soon_under_collaterized() {
 		*/
 		assert_eq!(
 			Lending::get_borrow_limit(&market, &ALICE),
-			Ok(100 * MockCurrencyId::USDT.unit::<Balance>())
+			Ok(100 * MockCurrencyId::Usdt.unit::<Balance>())
 		);
 
 		// Borrow 80 USDT
-		let borrow_amount = 80 * MockCurrencyId::USDT.unit::<Balance>();
+		let borrow_amount = 80 * MockCurrencyId::Usdt.unit::<Balance>();
 		assert_ok!(Lending::borrow_internal(&market, &ALICE, borrow_amount));
 
 		for i in 2..10000 {
 			process_block(i);
 		}
 
-		Oracle::set_btc_price(90 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(90 * MockCurrencyId::Usdt.unit::<Balance>());
 
 		/*
 			Collateral = 2*90 = 180
@@ -693,7 +693,7 @@ fn test_warn_soon_under_collaterized() {
 		*/
 		assert_eq!(Lending::soon_under_collaterized(&market, &ALICE), Ok(false));
 
-		Oracle::set_btc_price(87 * MockCurrencyId::USDT.unit::<Balance>());
+		Oracle::set_btc_price(87 * MockCurrencyId::Usdt.unit::<Balance>());
 
 		/*
 		   Collateral = 2*87 = 174
@@ -787,14 +787,14 @@ proptest! {
 	fn market_collateral_deposit_withdraw_identity(amount in valid_amount_without_overflow()) {
 		new_test_ext().execute_with(|| {
 			let (market, _) = create_simple_market();
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
-			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, amount));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), amount);
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
+			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, amount));
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), amount);
 
 			prop_assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, amount));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
 			prop_assert_ok!(Lending::withdraw_collateral_internal(&market, &ALICE, amount));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), amount);
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), amount);
 
 			Ok(())
 		})?;
@@ -804,14 +804,14 @@ proptest! {
 	fn market_collateral_deposit_withdraw_higher_amount_fails(amount in valid_amount_without_overflow()) {
 		new_test_ext().execute_with(|| {
 			let (market, _vault) = create_simple_market();
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
-			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::USDT, &ALICE, amount * MockCurrencyId::USDT.unit::<Balance>()));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), amount * MockCurrencyId::USDT.unit::<Balance>());
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
+			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::Usdt, &ALICE, amount * MockCurrencyId::Usdt.unit::<Balance>()));
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), amount * MockCurrencyId::Usdt.unit::<Balance>());
 
-			prop_assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, amount * MockCurrencyId::USDT.unit::<Balance>()));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::USDT, &ALICE), 0);
+			prop_assert_ok!(Lending::deposit_collateral_internal(&market, &ALICE, amount * MockCurrencyId::Usdt.unit::<Balance>()));
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Usdt, &ALICE), 0);
 			prop_assert_eq!(
-				Lending::withdraw_collateral_internal(&market, &ALICE, amount * MockCurrencyId::USDT.unit::<Balance>() + 1),
+				Lending::withdraw_collateral_internal(&market, &ALICE, amount * MockCurrencyId::Usdt.unit::<Balance>() + 1),
 				Err(Error::<Test>::NotEnoughCollateral.into())
 			);
 
@@ -841,7 +841,7 @@ proptest! {
 	fn market_creation_with_multi_level_priceable_lp(depth in 0..20) {
 		new_test_ext().execute_with(|| {
 			// Assume we have a pricable base asset
-			let base_asset = MockCurrencyId::ETH;
+			let base_asset = MockCurrencyId::Eth;
 			let base_vault = create_simple_vault(base_asset);
 
 			let (_, VaultInfo { lp_token_id, ..}) =
@@ -852,7 +852,7 @@ proptest! {
 
 			// A market with two priceable assets can be created
 			create_market(
-				MockCurrencyId::BTC,
+				MockCurrencyId::Btc,
 				lp_token_id,
 				*ALICE,
 				Perquintill::from_percent(10),
@@ -882,15 +882,15 @@ proptest! {
 			prop_assert_ne!(Lending::account_id(&market_id1), Lending::account_id(&market_id2));
 
 			// Alice lend an amount in market1 vault
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), 0);
-			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &ALICE, amount1));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::BTC, &ALICE), amount1);
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), 0);
+			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &ALICE, amount1));
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Btc, &ALICE), amount1);
 			prop_assert_ok!(Vault::deposit(Origin::signed(*ALICE), vault_id1, amount1));
 
 			// Bob lend an amount in market2 vault
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::BTC, &BOB), 0);
-			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::BTC, &BOB, amount2));
-			prop_assert_eq!(Tokens::balance(MockCurrencyId::BTC, &BOB), amount2);
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Btc, &BOB), 0);
+			prop_assert_ok!(Tokens::mint_into(MockCurrencyId::Btc, &BOB, amount2));
+			prop_assert_eq!(Tokens::balance(MockCurrencyId::Btc, &BOB), amount2);
 			prop_assert_ok!(Vault::deposit(Origin::signed(*BOB), vault_id2, amount2));
 
 			// Allow the market to initialize it's account by withdrawing
@@ -904,11 +904,11 @@ proptest! {
 
 			// // The funds should not be shared.
 			prop_assert_acceptable_computation_error!(
-				Tokens::balance(MockCurrencyId::BTC, &Lending::account_id(&market_id1)),
+				Tokens::balance(MockCurrencyId::Btc, &Lending::account_id(&market_id1)),
 				expected_market1_balance
 			);
 			prop_assert_acceptable_computation_error!(
-				Tokens::balance(MockCurrencyId::BTC, &Lending::account_id(&market_id2)),
+				Tokens::balance(MockCurrencyId::Btc, &Lending::account_id(&market_id2)),
 				expected_market2_balance
 			);
 

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -520,10 +520,9 @@ pub mod pallet {
 			let author_stake = OracleStake::<T>::get(&who).unwrap_or_else(Zero::zero);
 			ensure!(Self::is_requested(&asset_id), Error::<T>::PriceNotRequested);
 			ensure!(
-				author_stake >=
-					T::MinStake::get().saturating_add(
-						Self::answer_in_transit(&who).unwrap_or_else(Zero::zero)
-					),
+				author_stake
+					>= T::MinStake::get()
+						.saturating_add(Self::answer_in_transit(&who).unwrap_or_else(Zero::zero)),
 				Error::<T>::NotEnoughStake
 			);
 
@@ -538,10 +537,10 @@ pub mod pallet {
 				// because current_prices.len() limited by u32
 				// (type of AssetsInfo::<T>::get(asset_id).max_answers).
 				if current_prices.len() as u32 >= asset_info.max_answers {
-					return Err(Error::<T>::MaxPrices.into())
+					return Err(Error::<T>::MaxPrices.into());
 				}
 				if current_prices.iter().any(|candidate| candidate.who == who) {
-					return Err(Error::<T>::AlreadySubmitted.into())
+					return Err(Error::<T>::AlreadySubmitted.into());
 				}
 				current_prices.push(set_price);
 				Ok(())
@@ -721,12 +720,12 @@ pub mod pallet {
 		) {
 			let stale_block = block.saturating_sub(T::StalePrice::get());
 			let (staled_prices, mut fresh_prices) =
-				match pre_prices.iter().position(|p| p.block >= stale_block) {
-					Some(index) => {
-						Self::remove_price_in_transit(asset_id, &pre_prices[index].who);
+				match pre_prices.iter().enumerate().find(|(_, p)| p.block >= stale_block) {
+					Some((index, pre_price)) => {
+						Self::remove_price_in_transit(asset_id, &pre_price.who);
 						let fresh_prices = pre_prices.split_off(index);
 						(pre_prices, fresh_prices)
-					},
+					}
 					None => (pre_prices, vec![]),
 				};
 
@@ -737,7 +736,12 @@ pub mod pallet {
 				for price in fresh_prices.iter().skip(pruned) {
 					Self::remove_price_in_transit(asset_id, &price.who);
 				}
-				fresh_prices = fresh_prices[0..max_answers as usize].to_vec();
+				#[allow(clippy::indexing_slicing)]
+				// max_answers is confirmed to be less than the len in the condition of the if block
+				// (in a block due to https://github.com/rust-lang/rust/issues/15701)
+				{
+					fresh_prices = fresh_prices[0..max_answers as usize].to_vec()
+				};
 			}
 
 			(staled_prices, fresh_prices)
@@ -747,7 +751,7 @@ pub mod pallet {
 			prices: &[PrePrice<T::PriceValue, T::BlockNumber, T::AccountId>],
 		) -> Option<T::PriceValue> {
 			if prices.is_empty() {
-				return None
+				return None;
 			}
 
 			let mut numbers: Vec<T::PriceValue> =
@@ -757,8 +761,10 @@ pub mod pallet {
 
 			let mid = numbers.len() / 2;
 			if numbers.len() % 2 == 0 {
+				#[allow(clippy::indexing_slicing)] // mid is less than the len (len/2)
 				Some(numbers[mid - 1].saturating_add(numbers[mid]) / 2u32.into())
 			} else {
+				#[allow(clippy::indexing_slicing)] // mid is less than the len (len/2)
 				Some(numbers[mid])
 			}
 		}
@@ -829,7 +835,7 @@ pub mod pallet {
 				log::info!("no signer");
 				return Err(
 					"No local accounts available. Consider adding one via `author_insertKey` RPC.",
-				)
+				);
 			}
 			// checks to make sure key from keystore has not already submitted price
 			let prices = PrePrices::<T>::get(*price_id);
@@ -840,12 +846,12 @@ pub mod pallet {
 
 			if prices.len() as u32 >= Self::asset_info(price_id).max_answers {
 				log::info!("Max answers reached");
-				return Err("Max answers reached")
+				return Err("Max answers reached");
 			}
 
 			if prices.into_iter().any(|price| price.who == address) {
 				log::info!("Tx already submitted");
-				return Err("Tx already submitted")
+				return Err("Tx already submitted");
 			}
 			// Make an external HTTP request to fetch the current price.
 			// Note this call will block until response is received.
@@ -903,7 +909,7 @@ pub mod pallet {
 			// Let's check the status code before we proceed to reading the response.
 			if response.code != 200 {
 				log::warn!("Unexpected status code: {}", response.code);
-				return Err(http::Error::Unknown)
+				return Err(http::Error::Unknown);
 			}
 
 			let body = response.body().collect::<Vec<u8>>();
@@ -919,7 +925,7 @@ pub mod pallet {
 				None => {
 					log::warn!("Unable to extract price from the response: {:?}", body_str);
 					Err(http::Error::Unknown)
-				},
+				}
 			}?;
 
 			log::warn!("Got price: {} cents", price);
@@ -937,7 +943,7 @@ pub mod pallet {
 						JsonValue::Number(number) => number,
 						_ => return None,
 					}
-				},
+				}
 				_ => return None,
 			};
 			Some(price.integer as u64)

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -520,9 +520,10 @@ pub mod pallet {
 			let author_stake = OracleStake::<T>::get(&who).unwrap_or_else(Zero::zero);
 			ensure!(Self::is_requested(&asset_id), Error::<T>::PriceNotRequested);
 			ensure!(
-				author_stake
-					>= T::MinStake::get()
-						.saturating_add(Self::answer_in_transit(&who).unwrap_or_else(Zero::zero)),
+				author_stake >=
+					T::MinStake::get().saturating_add(
+						Self::answer_in_transit(&who).unwrap_or_else(Zero::zero)
+					),
 				Error::<T>::NotEnoughStake
 			);
 
@@ -537,10 +538,10 @@ pub mod pallet {
 				// because current_prices.len() limited by u32
 				// (type of AssetsInfo::<T>::get(asset_id).max_answers).
 				if current_prices.len() as u32 >= asset_info.max_answers {
-					return Err(Error::<T>::MaxPrices.into());
+					return Err(Error::<T>::MaxPrices.into())
 				}
 				if current_prices.iter().any(|candidate| candidate.who == who) {
-					return Err(Error::<T>::AlreadySubmitted.into());
+					return Err(Error::<T>::AlreadySubmitted.into())
 				}
 				current_prices.push(set_price);
 				Ok(())
@@ -725,7 +726,7 @@ pub mod pallet {
 						Self::remove_price_in_transit(asset_id, &pre_price.who);
 						let fresh_prices = pre_prices.split_off(index);
 						(pre_prices, fresh_prices)
-					}
+					},
 					None => (pre_prices, vec![]),
 				};
 
@@ -737,8 +738,8 @@ pub mod pallet {
 					Self::remove_price_in_transit(asset_id, &price.who);
 				}
 				#[allow(clippy::indexing_slicing)]
-				// max_answers is confirmed to be less than the len in the condition of the if block
-				// (in a block due to https://github.com/rust-lang/rust/issues/15701)
+				// max_answers is confirmed to be less than the len in the condition of the if
+				// block (in a block due to https://github.com/rust-lang/rust/issues/15701)
 				{
 					fresh_prices = fresh_prices[0..max_answers as usize].to_vec();
 				};
@@ -751,7 +752,7 @@ pub mod pallet {
 			prices: &[PrePrice<T::PriceValue, T::BlockNumber, T::AccountId>],
 		) -> Option<T::PriceValue> {
 			if prices.is_empty() {
-				return None;
+				return None
 			}
 
 			let mut numbers: Vec<T::PriceValue> =
@@ -844,7 +845,7 @@ pub mod pallet {
 				log::info!("no signer");
 				return Err(
 					"No local accounts available. Consider adding one via `author_insertKey` RPC.",
-				);
+				)
 			}
 			// checks to make sure key from keystore has not already submitted price
 			let prices = PrePrices::<T>::get(*price_id);
@@ -855,12 +856,12 @@ pub mod pallet {
 
 			if prices.len() as u32 >= Self::asset_info(price_id).max_answers {
 				log::info!("Max answers reached");
-				return Err("Max answers reached");
+				return Err("Max answers reached")
 			}
 
 			if prices.into_iter().any(|price| price.who == address) {
 				log::info!("Tx already submitted");
-				return Err("Tx already submitted");
+				return Err("Tx already submitted")
 			}
 			// Make an external HTTP request to fetch the current price.
 			// Note this call will block until response is received.
@@ -918,7 +919,7 @@ pub mod pallet {
 			// Let's check the status code before we proceed to reading the response.
 			if response.code != 200 {
 				log::warn!("Unexpected status code: {}", response.code);
-				return Err(http::Error::Unknown);
+				return Err(http::Error::Unknown)
 			}
 
 			let body = response.body().collect::<Vec<u8>>();
@@ -934,7 +935,7 @@ pub mod pallet {
 				None => {
 					log::warn!("Unable to extract price from the response: {:?}", body_str);
 					Err(http::Error::Unknown)
-				}
+				},
 			}?;
 
 			log::warn!("Got price: {} cents", price);
@@ -952,7 +953,7 @@ pub mod pallet {
 						JsonValue::Number(number) => number,
 						_ => return None,
 					}
-				}
+				},
 				_ => return None,
 			};
 			Some(price.integer as u64)

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 
@@ -579,7 +580,7 @@ pub mod pallet {
 			stake: BalanceOf<T>,
 		) -> DispatchResult {
 			let amount_staked = Self::oracle_stake(signer.clone())
-				.unwrap_or_else(|| 0u32.into())
+				.unwrap_or_else(|| 0_u32.into())
 				.checked_add(&stake)
 				.ok_or(Error::<T>::ExceedStake)?;
 			T::Currency::transfer(&who, &signer, stake, KeepAlive)?;
@@ -692,7 +693,7 @@ pub mod pallet {
 					let historical = Self::price_history(asset_id);
 					if (historical.len() as u32) < T::MaxHistory::get() {
 						PriceHistory::<T>::mutate(asset_id, |prices| {
-							if Self::prices(asset_id).block != 0u32.into() {
+							if Self::prices(asset_id).block != 0_u32.into() {
 								prices.push(Price { price, block });
 							}
 						})
@@ -763,7 +764,7 @@ pub mod pallet {
 			let mid = numbers.len() / 2;
 			if numbers.len() % 2 == 0 {
 				#[allow(clippy::indexing_slicing)] // mid is less than the len (len/2)
-				Some(numbers[mid - 1].saturating_add(numbers[mid]) / 2u32.into())
+				Some(numbers[mid - 1].saturating_add(numbers[mid]) / 2_u32.into())
 			} else {
 				#[allow(clippy::indexing_slicing)] // mid is less than the len (len/2)
 				Some(numbers[mid])
@@ -797,7 +798,7 @@ pub mod pallet {
 			asset_id: T::AssetId,
 			mut price_weights: Vec<T::PriceValue>,
 		) -> Result<T::PriceValue, DispatchError> {
-			let precision: T::PriceValue = 100u128.into();
+			let precision: T::PriceValue = 100_u128.into();
 			let historical_prices: Vec<Price<T::PriceValue, T::BlockNumber>> =
 				Self::price_history(asset_id);
 
@@ -807,8 +808,8 @@ pub mod pallet {
 			let sum = Self::price_values_sum(&price_weights);
 			ensure!(sum == precision, Error::<T>::MustSumTo100);
 
-			let last_weight = price_weights.pop().unwrap_or_else(|| 0u128.into());
-			ensure!(last_weight != 0u128.into(), Error::<T>::ArithmeticError);
+			let last_weight = price_weights.pop().unwrap_or_else(|| 0_u128.into());
+			ensure!(last_weight != 0_u128.into(), Error::<T>::ArithmeticError);
 
 			let mut weighted_prices = price_weights
 				.iter()
@@ -828,7 +829,7 @@ pub mod pallet {
 			weighted_prices.push(current_weighted_price);
 
 			let weighted_average = Self::price_values_sum(&weighted_prices);
-			ensure!(weighted_average != 0u128.into(), Error::<T>::ArithmeticError);
+			ensure!(weighted_average != 0_u128.into(), Error::<T>::ArithmeticError);
 
 			Ok(weighted_average)
 		}
@@ -836,7 +837,7 @@ pub mod pallet {
 		fn price_values_sum(price_values: &[T::PriceValue]) -> T::PriceValue {
 			price_values
 				.iter()
-				.fold(T::PriceValue::from(0u128), |acc, b| acc.saturating_add(*b))
+				.fold(T::PriceValue::from(0_u128), |acc, b| acc.saturating_add(*b))
 		}
 
 		// REVIEW: indexing

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::too_many_arguments)]
 

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -798,7 +798,8 @@ pub mod pallet {
 			mut price_weights: Vec<T::PriceValue>,
 		) -> Result<T::PriceValue, DispatchError> {
 			let precision: T::PriceValue = 100u128.into();
-			let historical_prices = Self::price_history(asset_id);
+			let historical_prices: Vec<Price<T::PriceValue, T::BlockNumber>> =
+				Self::price_history(asset_id);
 
 			// add an extra to account for current price not stored in history
 			ensure!(historical_prices.len() + 1 >= price_weights.len(), Error::<T>::DepthTooLarge);
@@ -849,8 +850,11 @@ pub mod pallet {
 			}
 			// checks to make sure key from keystore has not already submitted price
 			let prices = PrePrices::<T>::get(*price_id);
-			let public_key = sp_io::crypto::sr25519_public_keys(CRYPTO_KEY_TYPE);
-			let account = AccountId32::new(public_key[0].0);
+			let public_keys: Vec<sp_core::sr25519::Public> =
+				sp_io::crypto::sr25519_public_keys(CRYPTO_KEY_TYPE);
+			let account = AccountId32::new(
+				public_keys.first().ok_or("No public keys for crypto key type `orac`")?.0,
+			);
 			let mut to32 = AccountId32::as_ref(&account);
 			let address: T::AccountId = T::AccountId::decode(&mut to32).unwrap_or_default();
 

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -580,7 +580,7 @@ fn historic_pricing() {
 
 		do_price_update(0, 15);
 		let price_15 = Price { price: 101, block: 15 };
-		price_history = vec![price_5.clone(), price_10.clone(), price_15.clone()];
+		price_history = vec![price_5, price_10.clone(), price_15.clone()];
 
 		assert_eq!(Oracle::price_history(0), price_history);
 		assert_eq!(Oracle::price_history(0).len(), 3);
@@ -868,7 +868,7 @@ fn parse_price_works() {
 
 fn add_price_storage(price: u128, asset_id: u128, who: AccountId, block: u64) {
 	let price = PrePrice { price, block, who };
-	PrePrices::<Test>::mutate(asset_id.clone(), |current_prices| current_prices.push(price));
+	PrePrices::<Test>::mutate(asset_id, |current_prices| current_prices.push(price));
 	AnswerInTransit::<Test>::mutate(who, |transit| {
 		*transit = Some(transit.unwrap_or_else(Zero::zero) + 5)
 	});

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -295,7 +295,7 @@ fn add_price() {
 		System::set_block_number(6);
 		// fails no stake
 		assert_noop!(
-			Oracle::submit_price(Origin::signed(account_1), 100u128, 0u128),
+			Oracle::submit_price(Origin::signed(account_1), 100_u128, 0_u128),
 			Error::<Test>::NotEnoughStake
 		);
 
@@ -309,28 +309,28 @@ fn add_price() {
 		assert_ok!(Oracle::add_stake(Origin::signed(account_4), 50));
 		assert_ok!(Oracle::add_stake(Origin::signed(account_5), 50));
 
-		assert_ok!(Oracle::submit_price(Origin::signed(account_1), 100u128, 0u128));
-		assert_ok!(Oracle::submit_price(Origin::signed(account_2), 100u128, 0u128));
+		assert_ok!(Oracle::submit_price(Origin::signed(account_1), 100_u128, 0_u128));
+		assert_ok!(Oracle::submit_price(Origin::signed(account_2), 100_u128, 0_u128));
 		assert_noop!(
-			Oracle::submit_price(Origin::signed(account_2), 100u128, 0u128),
+			Oracle::submit_price(Origin::signed(account_2), 100_u128, 0_u128),
 			Error::<Test>::AlreadySubmitted
 		);
-		assert_ok!(Oracle::submit_price(Origin::signed(account_4), 100u128, 0u128));
+		assert_ok!(Oracle::submit_price(Origin::signed(account_4), 100_u128, 0_u128));
 
 		assert_eq!(Oracle::answer_in_transit(account_1), Some(5));
 		assert_eq!(Oracle::answer_in_transit(account_2), Some(5));
 		assert_eq!(Oracle::answer_in_transit(account_4), Some(5));
 
 		assert_noop!(
-			Oracle::submit_price(Origin::signed(account_5), 100u128, 0u128),
+			Oracle::submit_price(Origin::signed(account_5), 100_u128, 0_u128),
 			Error::<Test>::MaxPrices
 		);
 
-		let price = PrePrice { price: 100u128, block: 6, who: account_1 };
+		let price = PrePrice { price: 100_u128, block: 6, who: account_1 };
 
-		let price2 = PrePrice { price: 100u128, block: 6, who: account_2 };
+		let price2 = PrePrice { price: 100_u128, block: 6, who: account_2 };
 
-		let price4 = PrePrice { price: 100u128, block: 6, who: account_4 };
+		let price4 = PrePrice { price: 100_u128, block: 6, who: account_4 };
 
 		assert_eq!(Oracle::pre_prices(0), vec![price, price2, price4]);
 		System::set_block_number(2);
@@ -338,13 +338,13 @@ fn add_price() {
 
 		// fails price not requested
 		assert_noop!(
-			Oracle::submit_price(Origin::signed(account_1), 100u128, 0u128),
+			Oracle::submit_price(Origin::signed(account_1), 100_u128, 0_u128),
 			Error::<Test>::PriceNotRequested
 		);
 
 		// non existent asset_id
 		assert_noop!(
-			Oracle::submit_price(Origin::signed(account_1), 100u128, 10u128),
+			Oracle::submit_price(Origin::signed(account_1), 100_u128, 10_u128),
 			Error::<Test>::MaxPrices
 		);
 	});
@@ -357,7 +357,7 @@ fn medianize_price() {
 		// should not panic
 		Oracle::get_median_price(&Oracle::pre_prices(0));
 		for i in 0..3 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 0);
 		}
 		let price = Oracle::get_median_price(&Oracle::pre_prices(0));
@@ -516,7 +516,7 @@ fn on_init() {
 		// set prices into storage
 		let account_1: AccountId = Default::default();
 		for i in 0..3 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 2);
 		}
 
@@ -529,7 +529,7 @@ fn on_init() {
 
 		// doesn't prune state if under min prices
 		for i in 0..2 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 3);
 		}
 
@@ -646,7 +646,7 @@ fn on_init_prune_scenerios() {
 		// set prices into storage
 		let account_1: AccountId = Default::default();
 		for i in 0..3 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 0);
 		}
 		// all pruned
@@ -656,12 +656,12 @@ fn on_init_prune_scenerios() {
 		assert_eq!(Oracle::pre_prices(0).len(), 0);
 
 		for i in 0..5 {
-			let price = i as u128 + 1u128;
+			let price = i as u128 + 1_u128;
 			add_price_storage(price, 0, account_1, 0);
 		}
 
 		for i in 0..3 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 3);
 		}
 
@@ -671,12 +671,12 @@ fn on_init_prune_scenerios() {
 		assert_eq!(Oracle::prices(0), price);
 
 		for i in 0..5 {
-			let price = i as u128 + 1u128;
+			let price = i as u128 + 1_u128;
 			add_price_storage(price, 0, account_1, 0);
 		}
 
 		for i in 0..2 {
-			let price = i as u128 + 300u128;
+			let price = i as u128 + 300_u128;
 			add_price_storage(price, 0, account_1, 3);
 		}
 
@@ -706,7 +706,7 @@ fn on_init_over_max_answers() {
 		// set prices into storage
 		let account_1: AccountId = Default::default();
 		for i in 0..5 {
-			let price = i as u128 + 100u128;
+			let price = i as u128 + 100_u128;
 			add_price_storage(price, 0, account_1, 0);
 		}
 
@@ -836,7 +836,7 @@ fn should_check_oracles_submitted_price() {
 			5
 		));
 
-		add_price_storage(100u128, 0, account_2, 0);
+		add_price_storage(100_u128, 0, account_2, 0);
 		// when
 		Oracle::fetch_price_and_send_signed(&0).unwrap();
 	});
@@ -877,7 +877,7 @@ fn add_price_storage(price: u128, asset_id: u128, who: AccountId, block: u64) {
 fn do_price_update(asset_id: u128, block: u64) {
 	let account_1: AccountId = Default::default();
 	for i in 0..3 {
-		let price = i as u128 + 100u128;
+		let price = i as u128 + 100_u128;
 		add_price_storage(price, asset_id, account_1, block);
 	}
 

--- a/frame/order-book-dex/src/lib.rs
+++ b/frame/order-book-dex/src/lib.rs
@@ -1,6 +1,7 @@
 //! on chain state to handle state of cross chain exchanges
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/order-book-dex/src/lib.rs
+++ b/frame/order-book-dex/src/lib.rs
@@ -1,4 +1,6 @@
 //! on chain state to handle state of cross chain exchanges
+
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/order-book-dex/src/lib.rs
+++ b/frame/order-book-dex/src/lib.rs
@@ -1,6 +1,6 @@
 //! on chain state to handle state of cross chain exchanges
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/ping/src/lib.rs
+++ b/frame/ping/src/lib.rs
@@ -16,6 +16,7 @@
 
 //! Pallet to spam the XCM/UMP.
 
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_pallet_xcm::{ensure_sibling_para, Origin as CumulusOrigin};

--- a/frame/ping/src/lib.rs
+++ b/frame/ping/src/lib.rs
@@ -16,7 +16,7 @@
 
 //! Pallet to spam the XCM/UMP.
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_pallet_xcm::{ensure_sibling_para, Origin as CumulusOrigin};

--- a/frame/ping/src/lib.rs
+++ b/frame/ping/src/lib.rs
@@ -17,6 +17,7 @@
 //! Pallet to spam the XCM/UMP.
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use cumulus_pallet_xcm::{ensure_sibling_para, Origin as CumulusOrigin};

--- a/frame/privilege/src/lib.rs
+++ b/frame/privilege/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/privilege/src/lib.rs
+++ b/frame/privilege/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/privilege/src/lib.rs
+++ b/frame/privilege/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![warn(
 	bad_style,

--- a/frame/transaction-fee/src/lib.rs
+++ b/frame/transaction-fee/src/lib.rs
@@ -4,6 +4,7 @@
 //! but with added support for `MultiCurrency` using a `Dex` interface.
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};
@@ -201,7 +202,7 @@ where
 		// a very very little potential gain in the future.
 		let dispatch_info = <E as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
 
-		let partial_fee = Self::compute_fee(len, &dispatch_info, 0u32.into());
+		let partial_fee = Self::compute_fee(len, &dispatch_info, 0_u32.into());
 		let DispatchInfo { weight, class, .. } = dispatch_info;
 
 		RuntimeDispatchInfo { weight, class, partial_fee }
@@ -214,7 +215,7 @@ where
 		E: GetDispatchInfo,
 	{
 		let dispatch_info = <E as GetDispatchInfo>::get_dispatch_info(&unchecked_extrinsic);
-		Self::compute_fee_details(len, &dispatch_info, 0u32.into())
+		Self::compute_fee_details(len, &dispatch_info, 0_u32.into())
 	}
 
 	/// Compute the final fee value for a particular transaction.

--- a/frame/transaction-fee/src/lib.rs
+++ b/frame/transaction-fee/src/lib.rs
@@ -3,6 +3,7 @@
 //! Loosely based on https://github.com/paritytech/substrate/blob/master/frame/transaction-payment/src/lib.rs
 //! but with added support for `MultiCurrency` using a `Dex` interface.
 
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};

--- a/frame/transaction-fee/src/lib.rs
+++ b/frame/transaction-fee/src/lib.rs
@@ -3,7 +3,7 @@
 //! Loosely based on https://github.com/paritytech/substrate/blob/master/frame/transaction-payment/src/lib.rs
 //! but with added support for `MultiCurrency` using a `Dex` interface.
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode};

--- a/frame/transaction-fee/src/mock.rs
+++ b/frame/transaction-fee/src/mock.rs
@@ -80,7 +80,7 @@ impl Get<system::limits::BlockWeights> for BlockWeights {
 		system::limits::BlockWeights::builder()
 			.base_block(0)
 			.for_class(DispatchClass::all(), |weights| {
-				weights.base_extrinsic = EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow()).into();
+				weights.base_extrinsic = EXTRINSIC_BASE_WEIGHT.with(|v| *v.borrow());
 			})
 			.for_class(DispatchClass::non_mandatory(), |weights| {
 				weights.max_total = 1024.into();

--- a/frame/transaction-fee/src/tests.rs
+++ b/frame/transaction-fee/src/tests.rs
@@ -37,8 +37,8 @@ fn can_pay_fees_easily() {
 			let fees = 10 + 10 + 5; // length fee (1:1) + weight fee (1:1) + base weight (1:1)
 			assert_eq!(Tokens::free_balance(CurrencyId::LAYR, &1), 100 - fees);
 
-			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
-			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
+			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
+			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
 		});
 }
 
@@ -60,16 +60,16 @@ fn refund_on_post_dispatch() {
 			let fees = 10 + 10 + 5; // length fee (1:1) + weight fee (1:1) + base weight (1:1)
 			assert_eq!(Tokens::free_balance(CurrencyId::LAYR, &1), 100 - fees);
 
-			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
-			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
+			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
+			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
 
 			assert_eq!(
 				ChargeTransactionFee::<Runtime>::post_dispatch(pre, &info, &post_info, 10, &Ok(())),
 				Ok(())
 			);
 
-			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
-			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 20);
+			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
+			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 20);
 			// actual weight is 5, so 5 should be refunded
 			assert_eq!(Tokens::free_balance(CurrencyId::LAYR, &1), 100 - (fees - 5));
 		});
@@ -93,8 +93,8 @@ fn can_swap_to_pay_fees() {
 					.pre_dispatch(&1, &CALL, &info, 10)
 					.unwrap();
 
-			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
-			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
+			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
+			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
 
 			assert_eq!(
 				ChargeTransactionFee::<Runtime>::post_dispatch(pre, &info, &post_info, 10, &Ok(())),
@@ -102,8 +102,8 @@ fn can_swap_to_pay_fees() {
 			);
 
 			// assert that swap succeeded and was used to pay fees
-			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 0);
-			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| val.borrow().clone()), 25);
+			assert_eq!(TIP_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 0);
+			assert_eq!(FEE_UNBALANCED_AMOUNT.with(|val| *val.borrow()), 25);
 			// assert that user now has minimum layr deposit
 			assert_eq!(Tokens::free_balance(CurrencyId::LAYR, &1), 1);
 		});
@@ -392,7 +392,7 @@ fn zero_transfer_on_free_transaction() {
 			let pre = ChargeTransactionFee::<Runtime>::from(0, Default::default(), None)
 				.pre_dispatch(&user, &CALL, &dispatch_info, len)
 				.unwrap();
-			assert_eq!(Tokens::total_balance(CurrencyId::LAYR, &(&user)), 0);
+			assert_eq!(Tokens::total_balance(CurrencyId::LAYR, &user), 0);
 			assert_ok!(ChargeTransactionFee::<Runtime>::post_dispatch(
 				pre,
 				&dispatch_info,
@@ -400,7 +400,7 @@ fn zero_transfer_on_free_transaction() {
 				len,
 				&Ok(())
 			));
-			assert_eq!(Tokens::total_balance(CurrencyId::LAYR, &(&user)), 0);
+			assert_eq!(Tokens::total_balance(CurrencyId::LAYR, &user), 0);
 			// No events for such a scenario
 			assert_eq!(System::events().len(), 0);
 		});

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
 	dead_code,

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
 	dead_code,

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(
 	dead_code,

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -27,6 +27,7 @@
 //!   required.
 
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -26,7 +26,7 @@
 //! - `update_vesting_schedules` - Update all vesting schedules under an account, `root` origin
 //!   required.
 
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -26,6 +26,7 @@
 //! - `update_vesting_schedules` - Update all vesting schedules under an account, `root` origin
 //!   required.
 
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 #![allow(clippy::unused_unit)]
 

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -38,8 +38,8 @@ pub const CHARLIE: AccountId = 3;
 	TypeInfo,
 )]
 pub enum MockCurrencyId {
-	BTC,
-	ETH,
+	Btc,
+	Eth,
 }
 
 parameter_types! {
@@ -149,7 +149,7 @@ impl ExtBuilder {
 		let mut t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 
 		orml_tokens::GenesisConfig::<Runtime> {
-			balances: vec![(ALICE, MockCurrencyId::BTC, 100), (CHARLIE, MockCurrencyId::BTC, 50)],
+			balances: vec![(ALICE, MockCurrencyId::Btc, 100), (CHARLIE, MockCurrencyId::Btc, 50)],
 		}
 		.assimilate_storage(&mut t)
 		.unwrap();
@@ -157,8 +157,8 @@ impl ExtBuilder {
 		vesting::GenesisConfig::<Runtime> {
 			vesting: vec![
 				// asset, who, start, period, period_count, per_period
-				(MockCurrencyId::BTC, CHARLIE, 2, 3, 1, 5),
-				(MockCurrencyId::BTC, CHARLIE, 2 + 3, 3, 3, 5),
+				(MockCurrencyId::Btc, CHARLIE, 2, 3, 1, 5),
+				(MockCurrencyId::Btc, CHARLIE, 2 + 3, 3, 3, 5),
 			],
 		}
 		.assimilate_storage(&mut t)

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -12,11 +12,11 @@ use orml_tokens::BalanceLock;
 fn vesting_from_chain_spec_works() {
 	ExtBuilder::build().execute_with(|| {
 		// From the vesting below, only 20 out of 50 are locked at block 0.
-		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &CHARLIE, 30));
-		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &CHARLIE, 31).is_err());
+		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &CHARLIE, 30));
+		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &CHARLIE, 31).is_err());
 
 		assert_eq!(
-			Vesting::vesting_schedules(&CHARLIE, MockCurrencyId::BTC),
+			Vesting::vesting_schedules(&CHARLIE, MockCurrencyId::Btc),
 			vec![
 				/*
 					+------+------+-----+
@@ -50,16 +50,16 @@ fn vesting_from_chain_spec_works() {
 
 		System::set_block_number(13);
 
-		assert_ok!(Vesting::claim(Origin::signed(CHARLIE), MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim(Origin::signed(CHARLIE), MockCurrencyId::Btc));
 		// At block 13, we only have 5 out of the 50 that are locked.
-		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &CHARLIE, 45));
-		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &CHARLIE, 46).is_err());
+		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &CHARLIE, 45));
+		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &CHARLIE, 46).is_err());
 
 		System::set_block_number(14);
 
-		assert_ok!(Vesting::claim(Origin::signed(CHARLIE), MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim(Origin::signed(CHARLIE), MockCurrencyId::Btc));
 		// Everything is unlocked from blcok 14 onwards.
-		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &CHARLIE, 50));
+		assert_ok!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &CHARLIE, 50));
 	});
 }
 
@@ -73,14 +73,14 @@ fn vested_transfer_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule.clone(),
 		));
-		assert_eq!(Vesting::vesting_schedules(&BOB, MockCurrencyId::BTC), vec![schedule.clone()]);
+		assert_eq!(Vesting::vesting_schedules(&BOB, MockCurrencyId::Btc), vec![schedule.clone()]);
 		System::assert_last_event(Event::Vesting(crate::Event::VestingScheduleAdded {
 			from: ALICE,
 			to: BOB,
-			asset: MockCurrencyId::BTC,
+			asset: MockCurrencyId::Btc,
 			schedule,
 		}));
 	});
@@ -94,7 +94,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule,
 		));
 
@@ -105,12 +105,12 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			another_schedule,
 		));
 
 		assert_eq!(
-			Tokens::locks(&BOB, MockCurrencyId::BTC).get(0),
+			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
 			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 17u64 })
 		);
 	});
@@ -124,10 +124,10 @@ fn cannot_use_fund_if_not_claimed() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule,
 		));
-		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::BTC, &BOB, 49).is_err());
+		assert!(Tokens::ensure_can_withdraw(MockCurrencyId::Btc, &BOB, 49).is_err());
 	});
 }
 
@@ -137,14 +137,14 @@ fn vested_transfer_fails_if_zero_period_or_count() {
 		let schedule =
 			VestingSchedule { start: 1u64, period: 0u64, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
 		let schedule =
 			VestingSchedule { start: 1u64, period: 1u64, period_count: 0u32, per_period: 100u64 };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::ZeroVestingPeriodCount
 		);
 	});
@@ -156,7 +156,7 @@ fn vested_transfer_fails_if_transfer_err() {
 		let schedule =
 			VestingSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, schedule,),
 			orml_tokens::Error::<Runtime>::BalanceTooLow,
 		);
 	});
@@ -168,7 +168,7 @@ fn vested_transfer_fails_if_overflow() {
 		let schedule =
 			VestingSchedule { start: 1u64, period: 1u64, period_count: 2u32, per_period: u64::MAX };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			ArithmeticError::Overflow,
 		);
 
@@ -178,7 +178,7 @@ fn vested_transfer_fails_if_overflow() {
 			Vesting::vested_transfer(
 				Origin::signed(ALICE),
 				BOB,
-				MockCurrencyId::BTC,
+				MockCurrencyId::Btc,
 				another_schedule,
 			),
 			ArithmeticError::Overflow,
@@ -192,7 +192,7 @@ fn vested_transfer_fails_if_bad_origin() {
 		let schedule =
 			VestingSchedule { start: 0u64, period: 10u64, period_count: 1u32, per_period: 100u64 };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(CHARLIE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(CHARLIE), BOB, MockCurrencyId::Btc, schedule,),
 			BadOrigin
 		);
 	});
@@ -206,30 +206,30 @@ fn claim_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule,
 		));
 
 		System::set_block_number(11);
 		// remain locked if not claimed
-		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 10).is_err());
+		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 10).is_err());
 		// unlocked after claiming
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::BTC));
-		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 10));
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
+		assert!(VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::Btc));
+		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 10));
 		// more are still locked
-		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 1).is_err());
+		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 1).is_err());
 
 		System::set_block_number(21);
 		// claim more
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::BTC));
-		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 10));
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
+		assert!(!VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::Btc));
+		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 10));
 		// all used up
-		assert_eq!(Tokens::free_balance(MockCurrencyId::BTC, &BOB), 0);
+		assert_eq!(Tokens::free_balance(MockCurrencyId::Btc, &BOB), 0);
 
 		// no locks anymore
-		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::BTC), vec![]);
+		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::Btc), vec![]);
 	});
 }
 
@@ -241,25 +241,25 @@ fn claim_for_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule,
 		));
 
-		assert_ok!(Vesting::claim_for(Origin::signed(ALICE), BOB, MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim_for(Origin::signed(ALICE), BOB, MockCurrencyId::Btc));
 
 		assert_eq!(
-			Tokens::locks(&BOB, MockCurrencyId::BTC).get(0),
+			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
 			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 20u64 })
 		);
-		assert!(VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::BTC));
+		assert!(VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::Btc));
 
 		System::set_block_number(21);
 
-		assert_ok!(Vesting::claim_for(Origin::signed(ALICE), BOB, MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim_for(Origin::signed(ALICE), BOB, MockCurrencyId::Btc));
 
 		// no locks anymore
-		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::BTC), vec![]);
-		assert!(!VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::BTC));
+		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::Btc), vec![]);
+		assert!(!VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::Btc));
 	});
 }
 
@@ -271,7 +271,7 @@ fn update_vesting_schedules_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule,
 		));
 
@@ -280,40 +280,40 @@ fn update_vesting_schedules_works() {
 		assert_ok!(Vesting::update_vesting_schedules(
 			Origin::root(),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			vec![updated_schedule],
 		));
 
 		System::set_block_number(11);
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
-		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 1).is_err());
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
+		assert!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 1).is_err());
 
 		System::set_block_number(21);
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
-		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, 10));
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
+		assert_ok!(Tokens::transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, 10));
 
 		// empty vesting schedules cleanup the storage and unlock the fund
-		assert!(VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::BTC));
+		assert!(VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::Btc));
 		assert_eq!(
-			Tokens::locks(&BOB, MockCurrencyId::BTC).get(0),
+			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
 			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 10u64 })
 		);
 		assert_ok!(Vesting::update_vesting_schedules(
 			Origin::root(),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			vec![],
 		));
-		assert!(!VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::BTC));
-		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::BTC), vec![]);
+		assert!(!VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::Btc));
+		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::Btc), vec![]);
 	});
 }
 
 #[test]
 fn update_vesting_schedules_fails_if_unexpected_existing_locks() {
 	ExtBuilder::build().execute_with(|| {
-		assert_ok!(Tokens::transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, 1));
-		assert_ok!(Tokens::set_lock(*b"prelocks", MockCurrencyId::BTC, &BOB, 0u64));
+		assert_ok!(Tokens::transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, 1));
+		assert_ok!(Tokens::set_lock(*b"prelocks", MockCurrencyId::Btc, &BOB, 0u64));
 	});
 }
 
@@ -323,7 +323,7 @@ fn vested_transfer_check_for_min() {
 		let schedule =
 			VestingSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 3u64 };
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::AmountLow
 		);
 	});
@@ -337,7 +337,7 @@ fn multiple_vesting_schedule_claim_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule.clone(),
 		));
 
@@ -346,28 +346,28 @@ fn multiple_vesting_schedule_claim_works() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule2.clone(),
 		));
 
 		assert_eq!(
-			Vesting::vesting_schedules(&BOB, MockCurrencyId::BTC),
+			Vesting::vesting_schedules(&BOB, MockCurrencyId::Btc),
 			vec![schedule, schedule2.clone()]
 		);
 
 		System::set_block_number(21);
 
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
 
-		assert_eq!(Vesting::vesting_schedules(&BOB, MockCurrencyId::BTC), vec![schedule2]);
+		assert_eq!(Vesting::vesting_schedules(&BOB, MockCurrencyId::Btc), vec![schedule2]);
 
 		System::set_block_number(31);
 
-		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::BTC));
+		assert_ok!(Vesting::claim(Origin::signed(BOB), MockCurrencyId::Btc));
 
-		assert!(!VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::BTC));
+		assert!(!VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::Btc));
 
-		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::BTC), vec![]);
+		assert_eq!(Tokens::locks(&BOB, MockCurrencyId::Btc), vec![]);
 	});
 }
 
@@ -379,20 +379,20 @@ fn exceeding_maximum_schedules_should_fail() {
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule.clone(),
 		));
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
-			MockCurrencyId::BTC,
+			MockCurrencyId::Btc,
 			schedule.clone(),
 		));
 		assert_noop!(
 			Vesting::vested_transfer(
 				Origin::signed(ALICE),
 				BOB,
-				MockCurrencyId::BTC,
+				MockCurrencyId::Btc,
 				schedule.clone(),
 			),
 			Error::<Runtime>::MaxVestingSchedulesExceeded
@@ -401,7 +401,7 @@ fn exceeding_maximum_schedules_should_fail() {
 		let schedules = vec![schedule.clone(), schedule.clone(), schedule];
 
 		assert_noop!(
-			Vesting::update_vesting_schedules(Origin::root(), BOB, MockCurrencyId::BTC, schedules,),
+			Vesting::update_vesting_schedules(Origin::root(), BOB, MockCurrencyId::Btc, schedules,),
 			Error::<Runtime>::MaxVestingSchedulesExceeded
 		);
 	});

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -26,7 +26,12 @@ fn vesting_from_chain_spec_works() {
 					|5     |5     |5    |
 					+------+------+-----+
 				*/
-				VestingSchedule { start: 2u64, period: 3u64, period_count: 1u32, per_period: 5u64 },
+				VestingSchedule {
+					start: 2_u64,
+					period: 3_u64,
+					period_count: 1_u32,
+					per_period: 5_u64
+				},
 				/*
 				  +------+------+-----+
 				  |block |vested|total|
@@ -40,10 +45,10 @@ fn vesting_from_chain_spec_works() {
 				  +------+------+-----+
 				*/
 				VestingSchedule {
-					start: 2u64 + 3u64,
-					period: 3u64,
-					period_count: 3u32,
-					per_period: 5u64,
+					start: 2_u64 + 3_u64,
+					period: 3_u64,
+					period_count: 3_u32,
+					per_period: 5_u64,
 				}
 			]
 		);
@@ -68,8 +73,12 @@ fn vested_transfer_works() {
 	ExtBuilder::build().execute_with(|| {
 		System::set_block_number(1);
 
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 1u32, per_period: 100u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 1_u32,
+			per_period: 100_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -89,8 +98,12 @@ fn vested_transfer_works() {
 #[test]
 fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -100,8 +113,12 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 
 		System::set_block_number(12);
 
-		let another_schedule =
-			VestingSchedule { start: 10u64, period: 13u64, period_count: 1u32, per_period: 7u64 };
+		let another_schedule = VestingSchedule {
+			start: 10_u64,
+			period: 13_u64,
+			period_count: 1_u32,
+			per_period: 7_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -111,7 +128,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 
 		assert_eq!(
 			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
-			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 17u64 })
+			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 17_u64 })
 		);
 	});
 }
@@ -119,8 +136,12 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 #[test]
 fn cannot_use_fund_if_not_claimed() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 10u64, period: 10u64, period_count: 1u32, per_period: 50u64 };
+		let schedule = VestingSchedule {
+			start: 10_u64,
+			period: 10_u64,
+			period_count: 1_u32,
+			per_period: 50_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -134,15 +155,23 @@ fn cannot_use_fund_if_not_claimed() {
 #[test]
 fn vested_transfer_fails_if_zero_period_or_count() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 1u64, period: 0u64, period_count: 1u32, per_period: 100u64 };
+		let schedule = VestingSchedule {
+			start: 1_u64,
+			period: 0_u64,
+			period_count: 1_u32,
+			per_period: 100_u64,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
-		let schedule =
-			VestingSchedule { start: 1u64, period: 1u64, period_count: 0u32, per_period: 100u64 };
+		let schedule = VestingSchedule {
+			start: 1_u64,
+			period: 1_u64,
+			period_count: 0_u32,
+			per_period: 100_u64,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::ZeroVestingPeriodCount
@@ -153,8 +182,12 @@ fn vested_transfer_fails_if_zero_period_or_count() {
 #[test]
 fn vested_transfer_fails_if_transfer_err() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 100u64 };
+		let schedule = VestingSchedule {
+			start: 1_u64,
+			period: 1_u64,
+			period_count: 1_u32,
+			per_period: 100_u64,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, schedule,),
 			orml_tokens::Error::<Runtime>::BalanceTooLow,
@@ -165,15 +198,23 @@ fn vested_transfer_fails_if_transfer_err() {
 #[test]
 fn vested_transfer_fails_if_overflow() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 1u64, period: 1u64, period_count: 2u32, per_period: u64::MAX };
+		let schedule = VestingSchedule {
+			start: 1_u64,
+			period: 1_u64,
+			period_count: 2_u32,
+			per_period: u64::MAX,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, schedule,),
 			ArithmeticError::Overflow,
 		);
 
-		let another_schedule =
-			VestingSchedule { start: u64::MAX, period: 1u64, period_count: 2u32, per_period: 1u64 };
+		let another_schedule = VestingSchedule {
+			start: u64::MAX,
+			period: 1_u64,
+			period_count: 2_u32,
+			per_period: 1_u64,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(
 				Origin::signed(ALICE),
@@ -189,8 +230,12 @@ fn vested_transfer_fails_if_overflow() {
 #[test]
 fn vested_transfer_fails_if_bad_origin() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 1u32, per_period: 100u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 1_u32,
+			per_period: 100_u64,
+		};
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(CHARLIE), BOB, MockCurrencyId::Btc, schedule,),
 			BadOrigin
@@ -201,8 +246,12 @@ fn vested_transfer_fails_if_bad_origin() {
 #[test]
 fn claim_works() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -236,8 +285,12 @@ fn claim_works() {
 #[test]
 fn claim_for_works() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -249,7 +302,7 @@ fn claim_for_works() {
 
 		assert_eq!(
 			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
-			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 20u64 })
+			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 20_u64 })
 		);
 		assert!(VestingSchedules::<Runtime>::contains_key(&BOB, MockCurrencyId::Btc));
 
@@ -266,8 +319,12 @@ fn claim_for_works() {
 #[test]
 fn update_vesting_schedules_works() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -275,8 +332,12 @@ fn update_vesting_schedules_works() {
 			schedule,
 		));
 
-		let updated_schedule =
-			VestingSchedule { start: 0u64, period: 20u64, period_count: 2u32, per_period: 10u64 };
+		let updated_schedule = VestingSchedule {
+			start: 0_u64,
+			period: 20_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::update_vesting_schedules(
 			Origin::root(),
 			BOB,
@@ -296,7 +357,7 @@ fn update_vesting_schedules_works() {
 		assert!(VestingSchedules::<Runtime>::contains_key(BOB, MockCurrencyId::Btc));
 		assert_eq!(
 			Tokens::locks(&BOB, MockCurrencyId::Btc).get(0),
-			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 10u64 })
+			Some(&BalanceLock { id: VESTING_LOCK_ID, amount: 10_u64 })
 		);
 		assert_ok!(Vesting::update_vesting_schedules(
 			Origin::root(),
@@ -313,7 +374,7 @@ fn update_vesting_schedules_works() {
 fn update_vesting_schedules_fails_if_unexpected_existing_locks() {
 	ExtBuilder::build().execute_with(|| {
 		assert_ok!(Tokens::transfer(Origin::signed(ALICE), BOB, MockCurrencyId::Btc, 1));
-		assert_ok!(Tokens::set_lock(*b"prelocks", MockCurrencyId::Btc, &BOB, 0u64));
+		assert_ok!(Tokens::set_lock(*b"prelocks", MockCurrencyId::Btc, &BOB, 0_u64));
 	});
 }
 
@@ -321,7 +382,7 @@ fn update_vesting_schedules_fails_if_unexpected_existing_locks() {
 fn vested_transfer_check_for_min() {
 	ExtBuilder::build().execute_with(|| {
 		let schedule =
-			VestingSchedule { start: 1u64, period: 1u64, period_count: 1u32, per_period: 3u64 };
+			VestingSchedule { start: 1_u64, period: 1_u64, period_count: 1_u32, per_period: 3_u64 };
 		assert_noop!(
 			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::Btc, schedule,),
 			Error::<Runtime>::AmountLow
@@ -332,8 +393,12 @@ fn vested_transfer_check_for_min() {
 #[test]
 fn multiple_vesting_schedule_claim_works() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -341,8 +406,12 @@ fn multiple_vesting_schedule_claim_works() {
 			schedule.clone(),
 		));
 
-		let schedule2 =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 3u32, per_period: 10u64 };
+		let schedule2 = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 3_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,
@@ -374,8 +443,12 @@ fn multiple_vesting_schedule_claim_works() {
 #[test]
 fn exceeding_maximum_schedules_should_fail() {
 	ExtBuilder::build().execute_with(|| {
-		let schedule =
-			VestingSchedule { start: 0u64, period: 10u64, period_count: 2u32, per_period: 10u64 };
+		let schedule = VestingSchedule {
+			start: 0_u64,
+			period: 10_u64,
+			period_count: 2_u32,
+			per_period: 10_u64,
+		};
 		assert_ok!(Vesting::vested_transfer(
 			Origin::signed(ALICE),
 			BOB,

--- a/integration-tests/src/kusama_test_net.rs
+++ b/integration-tests/src/kusama_test_net.rs
@@ -9,8 +9,8 @@ use support::traits::GenesisBuild;
 use xcm_emulator::{decl_test_network, decl_test_parachain, decl_test_relay_chain};
 
 type Balances = u128;
-pub const ALICE: [u8; 32] = [4u8; 32];
-pub const BOB: [u8; 32] = [5u8; 32];
+pub const ALICE: [u8; 32] = [4_u8; 32];
+pub const BOB: [u8; 32] = [5_u8; 32];
 pub const PICA: Balances = 1_000_000_000_000;
 
 decl_test_parachain! {
@@ -55,7 +55,7 @@ decl_test_network! {
 
 fn default_parachains_host_configuration() -> HostConfiguration<BlockNumber> {
 	HostConfiguration {
-		validation_upgrade_frequency: 1u32,
+		validation_upgrade_frequency: 1_u32,
 		validation_upgrade_delay: 1,
 		code_retention_period: 1200,
 		max_code_size: MAX_CODE_SIZE,

--- a/integration-tests/src/xcm_tests.rs
+++ b/integration-tests/src/xcm_tests.rs
@@ -98,7 +98,7 @@ fn send_remark() {
 			(Parent, Parachain(DALI_PARA_ID)),
 			Xcm(vec![Transact {
 				origin_type: OriginKind::SovereignAccount,
-				require_weight_at_most: 40000 as u64,
+				require_weight_at_most: 40000,
 				call: remark.encode().into(),
 			}]),
 		));
@@ -128,7 +128,7 @@ fn withdraw_and_deposit_back() {
 				beneficiary: Parachain(PICASSO_PARA_ID).into(),
 			},
 		]);
-		assert_ok!(picasso_runtime::RelayerXcm::send_xcm(Here, Parent, message.clone(),));
+		assert_ok!(picasso_runtime::RelayerXcm::send_xcm(Here, Parent, message,));
 	});
 
 	KusamaRelay::execute_with(|| {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 
 pub mod chain_spec;
 mod client;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+
 pub mod chain_spec;
 mod client;
 pub mod rpc;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 
 pub mod chain_spec;
 mod client;

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -276,9 +276,9 @@ where
 				force_authoring,
 				slot_duration,
 				// We got around 500ms for proposing
-				block_proposal_slot_portion: SlotProportion::new(1f32 / 24f32),
+				block_proposal_slot_portion: SlotProportion::new(1_f32 / 24_f32),
 				// And a maximum of 750ms if slots are skipped
-				max_block_proposal_slot_portion: Some(SlotProportion::new(1f32 / 16f32)),
+				max_block_proposal_slot_portion: Some(SlotProportion::new(1_f32 / 16_f32)),
 				telemetry,
 			}))
 		},

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod impls;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod impls;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod impls;

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -257,7 +258,7 @@ parameter_types! {
 	/// See `multiplier_can_grow_from_zero` in integration_tests.rs.
 	/// This value is currently only used by pallet-transaction-payment as an assertion that the
 	/// next multiplier is always > min value.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_u128);
 	pub const OperationalFeeMultiplier: u8 = 5;
 }
 

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -785,7 +785,7 @@ impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
 		#[cfg(feature = "develop")]
 		if call_filter::Pallet::<Runtime>::contains(call) {
-			return false
+			return false;
 		}
 		!matches!(
 			call,

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
@@ -296,7 +297,7 @@ parameter_types! {
 	/// See `multiplier_can_grow_from_zero` in integration_tests.rs.
 	/// This value is currently only used by pallet-transaction-payment as an assertion that the
 	/// next multiplier is always > min value.
-	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000u128);
+	pub MinimumMultiplier: Multiplier = Multiplier::saturating_from_rational(1, 1_000_000_u128);
 	pub const OperationalFeeMultiplier: u8 = 5;
 }
 

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -785,7 +785,7 @@ impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
 		#[cfg(feature = "develop")]
 		if call_filter::Pallet::<Runtime>::contains(call) {
-			return false;
+			return false
 		}
 		!matches!(
 			call,

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
+#![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod currency;

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -1,3 +1,4 @@
+#![cfg_attr(not(test), warn(clippy::disallowed_method))] // allow in tests
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod currency;

--- a/runtime/primitives/src/lib.rs
+++ b/runtime/primitives/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(test), warn(clippy::disallowed_method, clippy::indexing_slicing))] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 pub mod currency;

--- a/utils/price-feed/src/frontend.rs
+++ b/utils/price-feed/src/frontend.rs
@@ -122,8 +122,8 @@ fn normalize_price(
 	let dt = expected_exponent - q;
 	let normalized_price = match dt.signum() {
 		0 => p,
-		1 => p * u64::pow(10u64, dt as u32),
-		-1 => p / u64::pow(10u64, dt.abs() as u32),
+		1 => p * u64::pow(10_u64, dt as u32),
+		-1 => p / u64::pow(10_u64, dt.abs() as u32),
 		_ => unreachable!(),
 	};
 	NormalizedPrice(normalized_price)


### PR DESCRIPTION
This PR has several fixes/ additions:

`clippy::disallowed_method` has been added to every crate, with a top-level clippy.toml file containing the disallowed methods. Currently it only contains Result/Option::unwrap, but it can be easily added to in the future. (`expect` is one that should be added as well; I figured it would be best to start with `unwrap`). I have removed/ audited/ fixed uses of unwrap where I was able to, however for most of them I was unable to figure out what was going on. There are several instances of `some_method_checked().unwrap()`, which doesn't make sense to me; perhaps the not-checked/`unckecked` versions of said functions either don't exist or have different behaviour than the checked functions followed by an `unwrap`? If anyone has any insight into this and could explain it would be greatly appreciated!

`clippy::indexing_slicing` has been added to all crates as well. _Most_ of the time, if explicit slicing/ indexing is being used, there is a better way to go about the problem. I refactored part of the `curve-amm` pallet to not use slicing and use iterators instead. This allowed me to get rid of some loops and mutability, along with some "temporary" variables, improving the flow and reducing the complexity of the code.

Some other miscellaneous clippy warning were fixed, mostly in tests. One of the main ones was changing CONSTANT_CASE enum variants to PascalCase (or UpperCamelCase, however you like to call it). If it is preferred that they be CONSTANT_CASE, they should be annotated with `#[allow(clippy::upper_case_acronyms)]`, ideally with a comment explaining why.
(see https://rust-lang.github.io/api-guidelines/naming.html#casing-conforms-to-rfc-430-c-case)

Other lints fixed were `clippy::excessive_precision` (float literals such as `0.100000000000000_f32` have been trucated to not have the trailing zeros), `clippy::identity_op` (1 * whatever), `clippy::clone_on_copy` (`copy_type.clone()` changed to either `*copy_type` if it's a reference or just `copy_type` if it's by value)

The last few commits were fixing `clippy::unseparated_literal_suffix`, if deemed unnecessary or out of the scope of this PR they can be reverted.