### PR TITLE
[CU-1y23865] testnet-release

### DIFF
--- a/.github/workflows/testnet-release.yml
+++ b/.github/workflows/testnet-release.yml
@@ -3,30 +3,31 @@ name: "Testnet Community Release"
 on:
   push: 
     branches: 
-      - main
+    - main
+
 env:
-  CHAIN: "picasso"
+  CHAIN: "dali"
   RELEASE_VERSION: "latest"
 
 jobs:
   build-and-publish:
     runs-on: 
-        - self-hosted
-        - linux
-        - x64
-        - sre
+    - self-hosted
+    - linux
+    - x64
+    - sre
     steps:
     - uses: actions/checkout@v2
       with: 
         fetch-depth: 0
-        ref: picasso
+        ref: main
 
     - name: Build and Push Artifacts to gcloud
       run: |
-        /home/runner/.cargo/bin/cargo build --release --bins
+        /home/runner/.cargo/bin/cargo build --release --bins --features develop
         git rev-parse HEAD > revision
-        tar -czvf composable-${{ env.RELEASE_VERSION }}.tar.gz target/release/composable
-        tar -czvf picasso_runtime.compact.wasm-${RELEASE_VERSION}.tar.gz target/release/wbuild/picasso-runtime/picasso_runtime.compact.wasm
+        tar -czvf composable-${CHAIN}-${RELEASE_VERSION}.tar.gz target/release/composable
+        tar -czvf ${CHAIN}_runtime.compact.wasm-${RELEASE_VERSION}.tar.gz target/release/wbuild/rococo-runtime/rococo_runtime.compact.wasm
         tar -czvf parachain-utils-${RELEASE_VERSION}.tar.gz target/release/parachain-utils
         tar -czvf revision-${RELEASE_VERSION}.tar.gz revision
-        gsutil mv *.tar.gz gs://composable-binaries/testnet-releases/picasso/
+        gsutil mv *.tar.gz gs://composable-binaries/testnet-releases/${CHAIN}/

--- a/.github/workflows/testnet-release.yml
+++ b/.github/workflows/testnet-release.yml
@@ -1,9 +1,6 @@
 name: "Testnet Community Release"
 
 on:
-  pull_request: # debug
-    branches:   # debug
-      - main    # debug
   push: 
     branches: 
       - main

--- a/.github/workflows/testnet-release.yml
+++ b/.github/workflows/testnet-release.yml
@@ -1,0 +1,35 @@
+name: "Testnet Community Release"
+
+on:
+  pull_request: # debug
+    branches:   # debug
+      - main    # debug
+  push: 
+    branches: 
+      - main
+env:
+  CHAIN: "picasso"
+  RELEASE_VERSION: "latest"
+
+jobs:
+  build-and-publish:
+    runs-on: 
+        - self-hosted
+        - linux
+        - x64
+        - sre
+    steps:
+    - uses: actions/checkout@v2
+      with: 
+        fetch-depth: 0
+        ref: picasso
+
+    - name: Build and Push Artifacts to gcloud
+      run: |
+        /home/runner/.cargo/bin/cargo build --release --bins
+        git rev-parse HEAD > revision
+        tar -czvf composable-${{ env.RELEASE_VERSION }}.tar.gz target/release/composable
+        tar -czvf picasso_runtime.compact.wasm-${RELEASE_VERSION}.tar.gz target/release/wbuild/picasso-runtime/picasso_runtime.compact.wasm
+        tar -czvf parachain-utils-${RELEASE_VERSION}.tar.gz target/release/parachain-utils
+        tar -czvf revision-${RELEASE_VERSION}.tar.gz revision
+        gsutil mv *.tar.gz gs://composable-binaries/testnet-releases/picasso/

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -17,11 +17,11 @@ use orml_traits::parameter_type_with_key;
 use primitives::currency::CurrencyId;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+#[cfg(feature = "develop")]
+use sp_runtime::traits::ConvertInto;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{
-		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, Zero,
-	},
+	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Zero},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -17,8 +17,6 @@ use orml_traits::parameter_type_with_key;
 use primitives::currency::CurrencyId;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-#[cfg(feature = "develop")]
-use sp_runtime::traits::ConvertInto;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Zero},


### PR DESCRIPTION
Those build artifacts will be used in the playbook to deploy a local Polkadot cluster (https://github.com/ComposableFi/composable/pull/417) in the future.