### PR TITLE
Add rust-toolchain.toml

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,7 +10,6 @@ on:
       - dali-chachacha
       - picasso
   workflow_dispatch:
-concurrency: ci-check
 jobs:
   check:
     runs-on:
@@ -20,15 +19,12 @@ jobs:
       - sre
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
+      - name: Setup toolchain
+        run: |
+         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+         echo "$HOME/.cargo/bin:$PATH" >> $GITHUB_PATH
       - name: Check
         run: |
-          rustup target add wasm32-unknown-unknown
           SKIP_WASM_BUILD=1 cargo check --all --benches
       - name: Benchmark
         run: |
@@ -51,20 +47,17 @@ jobs:
       - sre
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-          override: true
-      - name: Install Rust components and targets
+      - name: Setup toolchain
         run: |
-          rustup target add wasm32-unknown-unknown
-          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
-          rustup target add wasm32-unknown-unknown --toolchain nightly
+         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+         echo "$HOME/.cargo/bin:$PATH" >> $GITHUB_PATH
+      - run: |
+          rustup show
+          rustup override unset
+          rustup show
       - name: Cargo fmt
         run: |
-          cargo +nightly fmt -- --check
+          cargo fmt -- --check
       - name: Hadolint
         env:
           HADOLINT_VERSION: v2.8.0
@@ -81,7 +74,7 @@ jobs:
           exit $total_exit_code
       - name: Cargo clippy
         run: |
-          cargo +nightly clippy -- -D warnings
+          cargo clippy -- -D warnings
       - name: Cargo udeps
         env:
           UDEPS_VERSION: v0.1.24
@@ -94,7 +87,7 @@ jobs:
           total_exit_code=0
           while IFS= read -r crate; do
             echo "=== $crate ==="
-            (cd "$crate"; SKIP_WASM_BUILD=1 cargo +nightly udeps -q --all-targets) || total_exit_code=$?
+            (cd "$crate"; SKIP_WASM_BUILD=1 cargo udeps -q --all-targets) || total_exit_code=$?
             echo ""
           done < <(find . -name "Cargo.toml" -not -path "./polkadot-launch/*" -not -path "./target/*" -exec dirname '{}' \;)
           exit $total_exit_code
@@ -107,11 +100,10 @@ jobs:
       - sre
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - name: Setup toolchain
+        run: |
+         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+         echo "$HOME/.cargo/bin:$PATH" >> $GITHUB_PATH
       - name: Run Test
         run: |
           SKIP_WASM_BUILD=1 cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,7 @@ dependencies = [
  "pallet-crowdloan-bonus",
  "pallet-crowdloan-rewards",
  "pallet-currency-factory",
- "pallet-democracy",
+ "pallet-democracy 4.0.0-dev",
  "pallet-governance-registry",
  "pallet-identity",
  "pallet-indices",

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -19,9 +19,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{
-		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, ConvertInto, Zero,
-	},
+	traits::{AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, Zero},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 };
@@ -791,7 +789,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type AdminOrigin = EnsureRootOrHalfCouncil;
 	// TODO(hussein-aitlahcen): should be the proxy account
 	type AssociationOrigin = EnsureRootOrHalfCouncil;
-	type Convert = ConvertInto;
+	type Convert = sp_runtime::traits::ConvertInto;
 	type RelayChainAccountId = [u8; 32];
 	type InitialPayment = InitialPayment;
 	type VestingStep = VestingStep;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,5 @@
+[toolchain]
+channel = "nightly-2021-11-29"
+components = [ "rustfmt", "rustc", "rust-std", "cargo", "clippy", ]
+targets = [ "wasm32-unknown-unknown" ]
+profile = "minimal"


### PR DESCRIPTION
Stuff was breaking in CI due to automatically updating the Rust toolchain. That also leads to different WASM later on. Adding the rust-toolchain makes it easier to produce reproducible builds.