### PR TITLE
add temporary code-substitute

### DIFF
--- a/integration-tests/simnode/src/main.rs
+++ b/integration-tests/simnode/src/main.rs
@@ -18,6 +18,9 @@ fn main() -> Result<(), Box<dyn Error>> {
 	substrate_simnode::parachain_node::<PicassoChainInfo, _, _>(|node| async move {
 		let sudo = node.with_state(None, sudo::Pallet::<Runtime>::key);
 
+		// test code-substitute for picasso, by authoring blocks past the launch period
+		node.seal_blocks(10).await;
+
 		let old_runtime_version = node
 			.client()
 			.executor()


### PR DESCRIPTION
This adds a temporary code substitute to picasso chain spec, this isn't the final wasm file. This is just so simnode can use the code substitute to test the final wasm. Once we have the final wasm file, the code substitute would be changed to that.