### PR TITLE
Run CI on push to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -8,6 +8,9 @@ on:
       - main
       - develop
       - release/*
+  push:
+    branches:
+      - main    
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Makes sure that main remains buildable, as well as that we should get coverage reports for main, fixing the incorrect comparisons in PRs.