### PR TITLE
CU-1uq4a7x - ValidateUnsigned instead of SignedExtension in Crowdloan

### DIFF
--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -47,15 +47,7 @@ Reference for proof mechanism: https://github.com/paritytech/polkadot/blob/maste
 	unused_extern_crates
 )]
 
-use codec::{Decode, Encode};
-use frame_support::{
-	pallet_prelude::{InvalidTransaction, ValidTransaction},
-	traits::IsSubType,
-	unsigned::{TransactionValidity, TransactionValidityError},
-};
 pub use pallet::*;
-use scale_info::TypeInfo;
-use sp_runtime::traits::{DispatchInfoOf, SignedExtension, Zero};
 
 pub mod models;
 
@@ -455,97 +447,42 @@ pub mod pallet {
 		);
 		Some(addr)
 	}
-}
 
-/// Validate `associate` calls prior to execution. Needed to avoid a DoS attack since they are
-/// otherwise free to place on chain.
-#[derive(Encode, Decode, Clone, Eq, PartialEq, TypeInfo)]
-#[scale_info(skip_type_params(T))]
-pub struct PrevalidateAssociation<T: Config + Send + Sync>(sp_std::marker::PhantomData<T>)
-where
-	<T as frame_system::Config>::Call: IsSubType<Call<T>>;
+	#[pallet::validate_unsigned]
+	impl<T: Config> ValidateUnsigned for Pallet<T> {
+		type Call = Call<T>;
 
-impl<T: Config + Send + Sync> sp_std::fmt::Debug for PrevalidateAssociation<T>
-where
-	<T as frame_system::Config>::Call: IsSubType<Call<T>>,
-{
-	#[cfg(feature = "std")]
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		write!(f, "PrevalidateAssociation")
-	}
-
-	#[cfg(not(feature = "std"))]
-	fn fmt(&self, _: &mut sp_std::fmt::Formatter) -> sp_std::fmt::Result {
-		Ok(())
-	}
-}
-
-#[allow(clippy::new_without_default)]
-impl<T: Config + Send + Sync> PrevalidateAssociation<T>
-where
-	<T as frame_system::Config>::Call: IsSubType<Call<T>>,
-{
-	/// Create new `SignedExtension` to validate crowdloan rewards association
-	pub fn new() -> Self {
-		Self(sp_std::marker::PhantomData)
-	}
-}
-
-impl<T: Config + Send + Sync> SignedExtension for PrevalidateAssociation<T>
-where
-	<T as frame_system::Config>::Call: IsSubType<Call<T>>,
-{
-	type AccountId = T::AccountId;
-	type Call = <T as frame_system::Config>::Call;
-	type AdditionalSigned = ();
-	type Pre = ();
-	const IDENTIFIER: &'static str = "PrevalidateAssociation";
-
-	fn additional_signed(&self) -> Result<Self::AdditionalSigned, TransactionValidityError> {
-		Ok(())
-	}
-
-	// <weight>
-	// The weight of this logic is included in the `associate` dispatchable.
-	// </weight>
-	fn validate(
-		&self,
-		_who: &Self::AccountId,
-		call: &Self::Call,
-		_info: &DispatchInfoOf<Self::Call>,
-		_len: usize,
-	) -> TransactionValidity {
-		use frame_support::traits::Get;
-
-		if let Some(Call::associate { reward_account, proof }) = IsSubType::is_sub_type(call) {
-			if Associations::<T>::get(reward_account).is_some() {
-				return InvalidTransaction::Custom(ValidityError::AlreadyAssociated as u8).into()
+		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
+			if let Call::associate { reward_account, proof } = call {
+				if Associations::<T>::get(reward_account).is_some() {
+					return InvalidTransaction::Custom(ValidityError::AlreadyAssociated as u8).into()
+				}
+				let remote_account =
+					get_remote_account::<T>(proof.clone(), reward_account, T::Prefix::get())
+						.map_err(|_| {
+							Into::<TransactionValidityError>::into(InvalidTransaction::Custom(
+								ValidityError::InvalidProof as u8,
+							))
+						})?;
+				match Rewards::<T>::get(remote_account.clone()) {
+					None => InvalidTransaction::Custom(ValidityError::NoReward as u8).into(),
+					Some(reward) if reward.total.is_zero() =>
+						InvalidTransaction::Custom(ValidityError::NoReward as u8).into(),
+					Some(_) =>
+						ValidTransaction::with_tag_prefix("CrowdloanRewardsAssociationCheck")
+							.and_provides(remote_account)
+							.build(),
+				}
+			} else {
+				Err(InvalidTransaction::Call.into())
 			}
-
-			let remote_account =
-				get_remote_account::<T>(proof.clone(), reward_account, T::Prefix::get()).map_err(
-					|_| {
-						Into::<TransactionValidityError>::into(InvalidTransaction::Custom(
-							ValidityError::InvalidProof as u8,
-						))
-					},
-				)?;
-
-			match Rewards::<T>::get(remote_account) {
-				None => InvalidTransaction::Custom(ValidityError::NoReward as u8).into(),
-				Some(reward) if reward.total.is_zero() =>
-					InvalidTransaction::Custom(ValidityError::NoReward as u8).into(),
-				Some(_) => Ok(ValidTransaction::default()),
-			}
-		} else {
-			Ok(ValidTransaction::default())
 		}
 	}
-}
 
-#[repr(u8)]
-pub enum ValidityError {
-	InvalidProof = 0,
-	NoReward = 1,
-	AlreadyAssociated = 2,
+	#[repr(u8)]
+	pub enum ValidityError {
+		InvalidProof = 0,
+		NoReward = 1,
+		AlreadyAssociated = 2,
+	}
 }

--- a/integration-tests/simnode/src/chain/dali.rs
+++ b/integration-tests/simnode/src/chain/dali.rs
@@ -53,7 +53,6 @@ impl substrate_simnode::ChainInfo for ChainInfo {
 			),
 			system::CheckWeight::<Self::Runtime>::new(),
 			transaction_payment::ChargeTransactionPayment::<Self::Runtime>::from(0),
-			crowdloan_rewards::PrevalidateAssociation::<Self::Runtime>::new(),
 		)
 	}
 }

--- a/integration-tests/simnode/src/chain/picasso.rs
+++ b/integration-tests/simnode/src/chain/picasso.rs
@@ -54,7 +54,6 @@ impl substrate_simnode::ChainInfo for ChainInfo {
 			),
 			system::CheckWeight::<Self::Runtime>::new(),
 			transaction_payment::ChargeTransactionPayment::<Self::Runtime>::from(0),
-			crowdloan_rewards::PrevalidateAssociation::<Self::Runtime>::new(),
 		)
 	}
 }

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -385,7 +385,6 @@ where
 			system::CheckNonce::<Runtime>::from(nonce),
 			system::CheckWeight::<Runtime>::new(),
 			transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
-			crowdloan_rewards::PrevalidateAssociation::<Runtime>::new(),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|_e| {
@@ -912,7 +911,7 @@ construct_runtime!(
 		AssetsRegistry: assets_registry::{Pallet, Call, Storage, Event<T>} = 55,
 		GovernanceRegistry: governance_registry::{Pallet, Call, Storage, Event<T>} = 56,
 		Assets: assets::{Pallet, Call, Storage} = 57,
-		CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>} = 58,
+		CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 58,
 		Vesting: vesting::{Call, Event<T>, Pallet, Storage} = 59,
 		BondedFinance: bonded_finance::{Call, Event<T>, Pallet, Storage} = 60,
 		DutchAuction: dutch_auction::{Pallet, Call, Storage, Event<T>} = 61,
@@ -934,7 +933,6 @@ pub type SignedExtra = (
 	system::CheckNonce<Runtime>,
 	system::CheckWeight<Runtime>,
 	transaction_payment::ChargeTransactionPayment<Runtime>,
-	crowdloan_rewards::PrevalidateAssociation<Runtime>,
 );
 /// Unchecked extrinsic type as expected by this runtime.
 pub type UncheckedExtrinsic = generic::UncheckedExtrinsic<Address, Call, Signature, SignedExtra>;

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -103,7 +103,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_version: 2000,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
-	transaction_version: 2,
+	transaction_version: 1,
 };
 
 /// The version information used to identify this runtime when compiled natively.

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -385,7 +385,6 @@ where
 			system::CheckNonce::<Runtime>::from(nonce),
 			system::CheckWeight::<Runtime>::new(),
 			transaction_payment::ChargeTransactionPayment::<Runtime>::from(tip),
-			crowdloan_rewards::PrevalidateAssociation::<Runtime>::new(),
 		);
 		let raw_payload = SignedPayload::new(call, extra)
 			.map_err(|_e| {
@@ -816,7 +815,7 @@ construct_runtime!(
 		Factory: currency_factory::{Pallet, Storage, Event<T>} = 53,
 		GovernanceRegistry: governance_registry::{Pallet, Call, Storage, Event<T>} = 54,
 		Assets: assets::{Pallet, Call, Storage} = 55,
-		CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>} = 56,
+		CrowdloanRewards: crowdloan_rewards::{Pallet, Call, Storage, Event<T>, ValidateUnsigned} = 56,
 		Vesting: vesting::{Call, Event<T>, Pallet, Storage} = 57,
 		BondedFinance: bonded_finance::{Call, Event<T>, Pallet, Storage} = 58,
 	}
@@ -836,7 +835,6 @@ pub type SignedExtra = (
 	system::CheckNonce<Runtime>,
 	system::CheckWeight<Runtime>,
 	transaction_payment::ChargeTransactionPayment<Runtime>,
-	crowdloan_rewards::PrevalidateAssociation<Runtime>,
 );
 
 /// Unchecked extrinsic type as expected by this runtime.


### PR DESCRIPTION
From what I have been reading online and based on the substrate source code, a SignedExtension cannot be used to allow an unsigned extrinsic to be dispatched. In fact, the online documentation is stating that it is usable but that is not true. Even on the claiming mechanism of Polkadot, the implementation is using a `ValidateUnsigned` impl for the pallet. What is strange is that there is a `validate_unsigned` [function exposed by SignedExtension](https://docs.substrate.io/rustdocs/latest/sp_runtime/traits/trait.SignedExtension.html#method.validate_unsigned).

I refactored the tests to reflect the change, deployed the devnet and ran some integrations tests successfully with this change. I was not able  to submit an unsigned extrinsic using the `SignedExtension` mechanism. And in fact, if no pallet is implementing `ValidateUnsigned` in the runtime, the default implementation expanded by `construct_runtime` is refusing any unsigned extrinsic with a `NoUnsignedValidator`.