### PR TITLE
Check including wasm build

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,14 +26,9 @@ jobs:
       - sre
     steps:
       - uses: actions/checkout@v2
-      - run: |
-          SKIP_WASM_BUILD=1 /home/runner/.cargo/bin/cargo check --all --benches
-      - name: Benchmark
+      - name: Compile Check
         run: |
-          SKIP_WASM_BUILD=1 /home/runner/.cargo/bin/cargo check --features=runtime-benchmarks --workspace --release --exclude integration-tests
-      - name: Picasso
-        run: |
-          /home/runner/.cargo/bin/cargo build --release -p picasso-runtime
+          /home/runner/.cargo/bin/cargo check --features=runtime-benchmarks --workspace --exclude integration-tests
   linters:
     name: Linters
     runs-on:


### PR DESCRIPTION
Changes the check step to exhaustively check every packages, including the WASM build and benchmarks. integration tests are still skipped as they are incompatible with `runtime-benchmarks` at the moment. Will add that in a second PR