### PR TITLE
CU-1ubvcrq - introduce `Validated` and `Validate` for custom codec validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1538,6 +1538,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "composable-support"
+version = "0.0.1"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "proptest 1.0.0",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "composable-tests-helpers"
 version = "0.0.1"
 dependencies = [

--- a/frame/composable-support/Cargo.toml
+++ b/frame/composable-support/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "composable-support"
+version = "0.0.1"
+authors = ["Composable Developers"]
+homepage = "https://composable.finance"
+edition = "2021"
+rust-version = "1.56"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dev-dependencies]
+proptest = { version = "1.0" }
+
+[dependencies]
+frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13"  }
+frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13"  }
+sp-arithmetic = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+sp-std = { default-features = false,  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
+scale-info = { version = "1.0", default-features = false, features = ["derive"] }
+
+[dependencies.codec]
+default-features = false
+features = ["derive"]
+package = "parity-scale-codec"
+version = "2.0.0"
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "scale-info/std",
+]

--- a/frame/composable-support/src/lib.rs
+++ b/frame/composable-support/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg_attr(
+	not(test),
+	warn(
+		clippy::disallowed_method,
+		clippy::disallowed_type,
+		clippy::indexing_slicing,
+		clippy::todo,
+		clippy::unwrap_used,
+		clippy::panic
+	)
+)] // allow in tests
+#![warn(clippy::unseparated_literal_suffix)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+pub mod validation;

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -1,21 +1,62 @@
-use core::marker::PhantomData;
+use core::{marker::PhantomData, ops::Deref};
 use scale_info::TypeInfo;
 
 /// Black box that embbed the validated value.
-#[derive(Eq, PartialEq, Debug, TypeInfo, codec::Encode)]
+#[derive(Default, Copy, Clone, PartialEq, Eq, Debug, TypeInfo)]
 pub struct Validated<T, U> {
-	pub value: T,
+	value: T,
 	_marker: PhantomData<U>,
 }
 
-pub trait Validate<U> {
-	fn validate(&self) -> Result<(), &'static str>;
+impl<T: Copy, U> Validated<T, U> {
+	#[inline(always)]
+	pub fn value(&self) -> T {
+		self.value
+	}
 }
 
-impl<T: codec::Decode + Validate<U>, U> codec::Decode for Validated<T, U> {
+impl<T, U> Deref for Validated<T, U> {
+	type Target = T;
+	#[inline(always)]
+	fn deref(&self) -> &Self::Target {
+		&self.value
+	}
+}
+
+impl<T, U> AsRef<T> for Validated<T, U> {
+	#[inline(always)]
+	fn as_ref(&self) -> &T {
+		&self.value
+	}
+}
+
+pub trait Validate<U>: Sized {
+	fn validate(self) -> Result<Self, &'static str>;
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct QED;
+
+impl<T> Validate<QED> for T {
+	#[inline(always)]
+	fn validate(self) -> Result<Self, &'static str> {
+		Ok(self)
+	}
+}
+
+impl<T: Validate<U> + Validate<V>, U, V> Validate<(U, V)> for T {
+	#[inline(always)]
+	fn validate(self) -> Result<Self, &'static str> {
+		let value = Validate::<U>::validate(self)?;
+		let value = Validate::<V>::validate(value)?;
+		Ok(value)
+	}
+}
+
+impl<T: codec::Decode + Validate<(U, V)>, U, V> codec::Decode for Validated<T, (U, V)> {
 	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
-		let value = T::decode(input)?;
-		Validate::<U>::validate(&value).map_err(|desc| Into::<codec::Error>::into(desc))?;
+		let value = Validate::validate(T::decode(input)?)
+			.map_err(|desc| Into::<codec::Error>::into(desc))?;
 		Ok(Validated { value, _marker: PhantomData })
 	}
 	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
@@ -23,12 +64,24 @@ impl<T: codec::Decode + Validate<U>, U> codec::Decode for Validated<T, U> {
 	}
 }
 
-impl<T: codec::Encode + codec::Decode + Validate<U>, U> codec::EncodeLike<T> for Validated<T, U> {}
+impl<T: codec::Encode + codec::Decode + Validate<U>, U> codec::WrapperTypeEncode
+	for Validated<T, U>
+{
+}
 
 #[cfg(test)]
 mod test {
 	use super::*;
 	use codec::{Decode, Encode};
+
+	#[derive(Debug, Eq, PartialEq)]
+	struct ValidARange;
+	#[derive(Debug, Eq, PartialEq)]
+	struct ValidBRange;
+
+	type CheckARange = (ValidARange, QED);
+	type CheckBRange = (ValidBRange, QED);
+	type CheckABRange = (ValidARange, (ValidBRange, QED));
 
 	#[derive(Debug, Eq, PartialEq, codec::Encode, codec::Decode)]
 	struct X {
@@ -36,28 +89,22 @@ mod test {
 		b: u32,
 	}
 
-	#[derive(Debug, Eq, PartialEq)]
-	struct ValidateARange;
-
-	impl Validate<ValidateARange> for X {
-		fn validate(&self) -> Result<(), &'static str> {
+	impl Validate<ValidARange> for X {
+		fn validate(self) -> Result<X, &'static str> {
 			if self.a > 10 {
 				Err("Out of range")
 			} else {
-				Ok(())
+				Ok(self)
 			}
 		}
 	}
 
-	#[derive(Debug, Eq, PartialEq)]
-	struct ValidateBRange;
-
-	impl Validate<ValidateBRange> for X {
-		fn validate(&self) -> Result<(), &'static str> {
+	impl Validate<ValidBRange> for X {
+		fn validate(self) -> Result<X, &'static str> {
 			if self.b > 10 {
 				Err("Out of range")
 			} else {
-				Ok(())
+				Ok(self)
 			}
 		}
 	}
@@ -68,7 +115,7 @@ mod test {
 		let bytes = valid.encode();
 		assert_eq!(
 			Ok(Validated { value: valid, _marker: PhantomData }),
-			Validated::<X, ValidateARange>::decode(&mut &bytes[..])
+			Validated::<X, CheckARange>::decode(&mut &bytes[..])
 		);
 	}
 
@@ -76,7 +123,7 @@ mod test {
 	fn test_invalid_a() {
 		let invalid = X { a: 0xDEADC0DE, b: 0xCAFEBABE };
 		let bytes = invalid.encode();
-		assert!(Validated::<X, ValidateARange>::decode(&mut &bytes[..]).is_err());
+		assert!(Validated::<X, CheckARange>::decode(&mut &bytes[..]).is_err());
 	}
 
 	#[test]
@@ -85,7 +132,7 @@ mod test {
 		let bytes = valid.encode();
 		assert_eq!(
 			Ok(Validated { value: valid, _marker: PhantomData }),
-			Validated::<X, ValidateBRange>::decode(&mut &bytes[..])
+			Validated::<X, CheckBRange>::decode(&mut &bytes[..])
 		);
 	}
 
@@ -93,6 +140,37 @@ mod test {
 	fn test_invalid_b() {
 		let invalid = X { a: 0xCAFEBABE, b: 0xDEADC0DE };
 		let bytes = invalid.encode();
-		assert!(Validated::<X, ValidateBRange>::decode(&mut &bytes[..]).is_err());
+		assert!(Validated::<X, CheckBRange>::decode(&mut &bytes[..]).is_err());
+	}
+
+	#[test]
+	fn test_valid_ab() {
+		let valid = X { a: 10, b: 10 };
+		let bytes = valid.encode();
+		assert_eq!(
+			Ok(Validated { value: valid, _marker: PhantomData }),
+			Validated::<X, CheckABRange>::decode(&mut &bytes[..])
+		);
+	}
+
+	#[test]
+	fn test_invalid_ab() {
+		let invalid = X { a: 0xDEADC0DE, b: 0xCAFEBABE };
+		let bytes = invalid.encode();
+		assert!(Validated::<X, CheckABRange>::decode(&mut &bytes[..]).is_err());
+	}
+
+	#[test]
+	fn test_invalid_a_ab() {
+		let invalid = X { a: 0xDEADC0DE, b: 10 };
+		let bytes = invalid.encode();
+		assert!(Validated::<X, CheckABRange>::decode(&mut &bytes[..]).is_err());
+	}
+
+	#[test]
+	fn test_invalid_b_ab() {
+		let invalid = X { a: 10, b: 0xDEADC0DE };
+		let bytes = invalid.encode();
+		assert!(Validated::<X, CheckABRange>::decode(&mut &bytes[..]).is_err());
 	}
 }

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -1,0 +1,98 @@
+use core::marker::PhantomData;
+use scale_info::TypeInfo;
+
+/// Black box that embbed the validated value.
+#[derive(Eq, PartialEq, Debug, TypeInfo, codec::Encode)]
+pub struct Validated<T, U> {
+	pub value: T,
+	_marker: PhantomData<U>,
+}
+
+pub trait Validate<U> {
+	fn validate(&self) -> Result<(), &'static str>;
+}
+
+impl<T: codec::Decode + Validate<U>, U> codec::Decode for Validated<T, U> {
+	fn decode<I: codec::Input>(input: &mut I) -> Result<Self, codec::Error> {
+		let value = T::decode(input)?;
+		Validate::<U>::validate(&value).map_err(|desc| Into::<codec::Error>::into(desc))?;
+		Ok(Validated { value, _marker: PhantomData })
+	}
+	fn skip<I: codec::Input>(input: &mut I) -> Result<(), codec::Error> {
+		T::skip(input)
+	}
+}
+
+impl<T: codec::Encode + codec::Decode + Validate<U>, U> codec::EncodeLike<T> for Validated<T, U> {}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+	use codec::{Decode, Encode};
+
+	#[derive(Debug, Eq, PartialEq, codec::Encode, codec::Decode)]
+	struct X {
+		a: u32,
+		b: u32,
+	}
+
+	#[derive(Debug, Eq, PartialEq)]
+	struct ValidateARange;
+
+	impl Validate<ValidateARange> for X {
+		fn validate(&self) -> Result<(), &'static str> {
+			if self.a > 10 {
+				Err("Out of range")
+			} else {
+				Ok(())
+			}
+		}
+	}
+
+	#[derive(Debug, Eq, PartialEq)]
+	struct ValidateBRange;
+
+	impl Validate<ValidateBRange> for X {
+		fn validate(&self) -> Result<(), &'static str> {
+			if self.b > 10 {
+				Err("Out of range")
+			} else {
+				Ok(())
+			}
+		}
+	}
+
+	#[test]
+	fn test_valid_a() {
+		let valid = X { a: 10, b: 0xCAFEBABE };
+		let bytes = valid.encode();
+		assert_eq!(
+			Ok(Validated { value: valid, _marker: PhantomData }),
+			Validated::<X, ValidateARange>::decode(&mut &bytes[..])
+		);
+	}
+
+	#[test]
+	fn test_invalid_a() {
+		let invalid = X { a: 0xDEADC0DE, b: 0xCAFEBABE };
+		let bytes = invalid.encode();
+		assert!(Validated::<X, ValidateARange>::decode(&mut &bytes[..]).is_err());
+	}
+
+	#[test]
+	fn test_valid_b() {
+		let valid = X { a: 0xCAFEBABE, b: 10 };
+		let bytes = valid.encode();
+		assert_eq!(
+			Ok(Validated { value: valid, _marker: PhantomData }),
+			Validated::<X, ValidateBRange>::decode(&mut &bytes[..])
+		);
+	}
+
+	#[test]
+	fn test_invalid_b() {
+		let invalid = X { a: 0xCAFEBABE, b: 0xDEADC0DE };
+		let bytes = invalid.encode();
+		assert!(Validated::<X, ValidateBRange>::decode(&mut &bytes[..]).is_err());
+	}
+}


### PR DESCRIPTION
This PR introduce a new `composable-support` crate that will allow us to add extra pallet support functionality.

I started to implement a validation trait that would allow us to ensure that complex input structs provided by external sources through extrinsics are validated when doing the actual decoding. In fact, we do have some pallets such as the `bonded-finance` and `lending` that are doing this somehow manually. Such as ensuring that the domain of a type is restricted to some values or clamped within an arbitrary range.