### PR TITLE
[CU-22whr0m] Updated local devnet build instructions

### DIFF
--- a/scripts/polkadot-launch/README.md
+++ b/scripts/polkadot-launch/README.md
@@ -7,7 +7,7 @@ Need to do to run 4 relay chain nodes and 1 Composable's collator:
 	```bash
 	old_pwd=$(pwd)
 	cd ../..
-	cargo build --release --features develop
+	cargo build --release
 	target/release/composable --version
 	cd "$old_pwd"
     ```
@@ -49,7 +49,7 @@ Need to do to run 4 relay chain nodes, 2 Composable's collators and 2 Basilisk's
 	```bash
 	old_pwd=$(pwd)
 	cd ../..
-	cargo build --release --features develop
+	cargo build --release
 	target/release/composable --version
 	cd "$old_pwd"
     ```


### PR DESCRIPTION
Greetings, I removed the "--features develop" flag from local build command instructions.
It caused the build command to fail with the following, and could therefore cause confusion.

```error: Package composable v1.0.9 (/home/droth/WebstormProjects/composable) does not have the feature develop```