### PR TITLE
Add <Bytes> tag for polkadotjs signature in crowdloan

### DIFF
--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -411,8 +411,12 @@ pub mod pallet {
 		relay_account: RelayChainAccountId,
 		proof: &MultiSignature,
 	) -> bool {
-		let mut msg = prefix.to_vec();
+		let wrapped_prefix: &[u8] = b"<Bytes>";
+		let wrapped_postfix: &[u8] = b"</Bytes>";
+		let mut msg = wrapped_prefix.to_vec();
+		msg.append(&mut prefix.to_vec());
 		msg.append(&mut reward_account.using_encoded(|x| hex::encode(x).as_bytes().to_vec()));
+		msg.append(&mut wrapped_postfix.to_vec());
 		proof.verify(&msg[..], &relay_account.into())
 	}
 

--- a/frame/crowdloan-rewards/src/mocks.rs
+++ b/frame/crowdloan-rewards/src/mocks.rs
@@ -167,12 +167,11 @@ impl ClaimKey {
 	}
 }
 
-pub fn relay_proof(
-	relay_account: &RelayKey,
-	reward_account: AccountId,
-) -> Proof<RelayChainAccountId> {
-	let mut msg = PROOF_PREFIX.to_vec();
+fn relay_proof(relay_account: &RelayKey, reward_account: AccountId) -> Proof<RelayChainAccountId> {
+	let mut msg = b"<Bytes>".to_vec();
+	msg.append(&mut PROOF_PREFIX.to_vec());
 	msg.append(&mut reward_account.using_encoded(|x| hex::encode(x).as_bytes().to_vec()));
+	msg.append(&mut b"</Bytes>".to_vec());
 	Proof::RelayChain(relay_account.public().into(), relay_account.sign(&msg).into())
 }
 

--- a/integration-tests/runtime-tests/src/tests/tx/crowdloanRewards/txCrowdloanRewardsTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/crowdloanRewards/txCrowdloanRewardsTests.ts
@@ -11,7 +11,7 @@ const toHexString = bytes =>
 
 // The prefix is defined as pallet config
 const proofMessage = (account: IKeyringPair) =>
-  "picasso-" + toHexString(account.publicKey);
+  "<Bytes>picasso-" + toHexString(account.publicKey) + "</Bytes>";
 
 const ethAccount = (seed: number) =>
   web3.eth.accounts.privateKeyToAccount("0x" + seed.toString(16).padStart(64, '0'))


### PR DESCRIPTION
[The public polkadotjs api signRaw is wrapping the message in this tag.](https://github.com/polkadot-js/extension/blob/master/packages/extension-base/src/background/RequestBytesSign.ts#L24)