### PR TITLE
[1u5ykup] Oracle Runtime Tests, Runtime Tests deps update, Bugfixes & Cleanup

### DIFF
--- a/integration-tests/runtime-tests/.eslintrc.yml
+++ b/integration-tests/runtime-tests/.eslintrc.yml
@@ -11,4 +11,4 @@ parserOptions:
 plugins:
   - '@typescript-eslint'
 rules: {}
-ignorePatterns: ["src/**/**.d.ts", "src/**/**.js", "src/frontend/generated/*"]
+ignorePatterns: ["src/**/*.d.ts", "src/**/*.js", "src/frontend/generated/*"]

--- a/integration-tests/runtime-tests/.mocharc.json
+++ b/integration-tests/runtime-tests/.mocharc.json
@@ -3,10 +3,20 @@
   "extension": ["js", "cjs", "mjs"],
   "package": "./package.json",
   "reporter": "mochawesome",
-  "slow": "75",
-  "timeout": "2000",
+  "reporterOptions": {
+    "reportFilename": "mochawesome-report",
+    "quiet": false,
+    "overwrite": true,
+    "html": true,
+    "json": true
+  },
+  "slow": 75,
+  "timeout": 2000,
+  "retries": 0,
   "ui": "bdd",
-  "watch-files": ["lib/**/*.js", "test/**/*.js"],
+  "watch-files": ["src/**/*.js", "src/**/*.ts"],
   "watch-ignore": ["lib/vendor"],
-  "require": "src/utils/testSetup.js"
+  "require": "src/utils/testSetup.js",
+  "full-trace": true,
+  "parallel": false
 }

--- a/integration-tests/runtime-tests/package-lock.json
+++ b/integration-tests/runtime-tests/package-lock.json
@@ -19,16 +19,16 @@
         "@polkadot/types-known": "^7.3.1",
         "@polkadot/types-support": "^7.3.1",
         "@types/mocha": "^9.0.0",
-        "@types/node": "^17.0.8",
-        "@types/ramda": "^0.27.62",
-        "bluebird": "^3.7.2",
-        "chai": "^4.3.4",
-        "chai-as-promised": "^7.1.1",
-        "minimist": "^1.2.5",
-        "mocha": "latest",
-        "mochawesome": "^7.0.1",
-        "ramda": "^0.27.1",
-        "web3": "^1.6.1"
+        "@types/node": "17.0.9",
+        "@types/ramda": "0.27.64",
+        "chai": "4.3.4",
+        "chai-as-promised": "7.1.1",
+        "minimist": "1.2.5",
+        "mocha": "8.4.0",
+        "mochawesome": "7.0.1",
+        "ramda": "0.28.0",
+        "tsconfig-paths": "^3.12.0",
+        "web3": "1.7.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.0",
@@ -1462,9 +1462,7 @@
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@types/minimist": {
       "version": "1.2.2",
@@ -1478,8 +1476,9 @@
       "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
     },
     "node_modules/@types/node": {
-      "version": "17.0.8",
-      "license": "MIT"
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
+      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.5.12",
@@ -1499,9 +1498,9 @@
       }
     },
     "node_modules/@types/ramda": {
-      "version": "0.27.62",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.62.tgz",
-      "integrity": "sha512-/s4yTNOk8YXZ2Ys8OqSPmExyWxuKQMCDwjyVowg0RW6F45SlSGSI0sduyhx7RREASowlVJppAvR4KRqMzJnu2g==",
+      "version": "0.27.64",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.64.tgz",
+      "integrity": "sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==",
       "dependencies": {
         "ts-toolbelt": "^6.15.1"
       }
@@ -4591,8 +4590,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -5808,9 +5805,13 @@
       "license": "MIT"
     },
     "node_modules/ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ramda"
+      }
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -6396,8 +6397,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -6748,8 +6747,6 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
       "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
-      "dev": true,
-      "optional": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -7005,27 +7002,27 @@
       }
     },
     "node_modules/web3": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.6.1.tgz",
-      "integrity": "sha512-c299lLiyb2/WOcxh7TinwvbATaMmrgNIeAzbLbmOKHI0LcwyfsB1eu2ReOIrfrCYDYRW2KAjYr7J7gHawqDNPQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.7.0.tgz",
+      "integrity": "sha512-n39O7QQNkpsjhiHMJ/6JY6TaLbdX+2FT5iGs8tb3HbIWOhPm4+a7UDbr5Lkm+gLa9aRKWesZs5D5hWyEvg4aJA==",
       "hasInstallScript": true,
       "dependencies": {
-        "web3-bzz": "1.6.1",
-        "web3-core": "1.6.1",
-        "web3-eth": "1.6.1",
-        "web3-eth-personal": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-shh": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-bzz": "1.7.0",
+        "web3-core": "1.7.0",
+        "web3-eth": "1.7.0",
+        "web3-eth-personal": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-shh": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-bzz": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.6.1.tgz",
-      "integrity": "sha512-JbnFNbRlwwHJZPtVuCxo7rC4U4OTg+mPsyhjgPQJJhS0a6Y54OgVWYk9UA/95HqbmTJwTtX329gJoSsseEfrng==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.7.0.tgz",
+      "integrity": "sha512-XPhTWUnZa8gnARfiqaag3jJ9+6+a66Li8OikgBUJoMUqPuQTCJPncTbGYqOJIfRFGavEAdlMnfYXx9lvgv2ZPw==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/node": "^12.12.6",
@@ -7037,58 +7034,58 @@
       }
     },
     "node_modules/web3-bzz/node_modules/@types/node": {
-      "version": "12.20.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-      "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+      "version": "12.20.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+      "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
     },
     "node_modules/web3-core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.6.1.tgz",
-      "integrity": "sha512-m+b7UfYvU5cQUAh6NRfxRzH/5B3to1AdEQi1HIQt570cDWlObOOmoO9tY6iJnI5w4acxIO19LqjDMqEJGBYyRQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.0.tgz",
+      "integrity": "sha512-U/CRL53h3T5KHl8L3njzCBT7fCaHkbE6BGJe3McazvFldRbfTDEHXkUJCyM30ZD0RoLi3aDfTVeFIusmEyCctA==",
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-requestmanager": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-requestmanager": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-helpers": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.6.1.tgz",
-      "integrity": "sha512-om2PZvK1uoWcgMq6JfcSx3241LEIVF6qi2JuHz2SLKiKEW5UsBUaVx0mNCmcZaiuYQCyOsLS3r33q5AdM+v8ng==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.0.tgz",
+      "integrity": "sha512-kFiqsZFHJliKF8VKZNjt2JvKu3gu7h3N1/ke3EPhdp9Li/rLmiyzFVr6ApryZ1FSjbSx6vyOkibG3m6xQ5EHJA==",
       "dependencies": {
-        "web3-eth-iban": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-eth-iban": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-method": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.6.1.tgz",
-      "integrity": "sha512-szH5KyIWIaULQDBdDvevQUCHV9lsExJ/oV0ePqK+w015D2SdMPMuhii0WB+HCePaksWO+rr/GAypvV9g2T3N+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.0.tgz",
+      "integrity": "sha512-43Om+kZX8wU5u1pJ28TltF9e9pSTRph6b8wrOb6wgXAfPHqMulq6UTBJWjXXIRVN46Eiqv0nflw35hp9bbgnbA==",
       "dependencies": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-promievent": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.6.1.tgz",
-      "integrity": "sha512-byJ5s2MQxrWdXd27pWFmujfzsTZK4ik8rDgIV1RFDFc+rHZ2nZhq+VWk7t/Nkrj7EaVXncEgTdPEHc18nx+ocQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.0.tgz",
+      "integrity": "sha512-xPH66XeC0K0k29GoRd0vyPQ07yxERPRd4yVPrbMzGAz/e9E4M3XN//XK6+PdfGvGw3fx8VojS+tNIMiw+PujbQ==",
       "dependencies": {
         "eventemitter3": "4.0.4"
       },
@@ -7102,27 +7099,27 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "node_modules/web3-core-requestmanager": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.6.1.tgz",
-      "integrity": "sha512-4y7etYEUtkfflyYVBfN1oJtCbVFNhNX1omlEYzezhTnPj3/dT7n+dhUXcqvIhx9iKA13unGfpFge80XNFfcB8A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.0.tgz",
+      "integrity": "sha512-rA3dBTBPrt+eIfTAQ2/oYNTN/2wbZaYNR3pFZGqG8+2oCK03+7oQyz4sWISKy/nYQhURh4GK01rs9sN4o/Tq9w==",
       "dependencies": {
         "util": "^0.12.0",
-        "web3-core-helpers": "1.6.1",
-        "web3-providers-http": "1.6.1",
-        "web3-providers-ipc": "1.6.1",
-        "web3-providers-ws": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-providers-http": "1.7.0",
+        "web3-providers-ipc": "1.7.0",
+        "web3-providers-ws": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-subscriptions": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.6.1.tgz",
-      "integrity": "sha512-WZwxsYttIojyGQ5RqxuQcKg0IJdDCFpUe4EncS3QKZwxPqWzGmgyLwE0rm7tP+Ux1waJn5CUaaoSCBxWGSun1g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.0.tgz",
+      "integrity": "sha512-6giF8pyJrPmWrRpc2WLoVCvQdMMADp20ZpAusEW72axauZCNlW1XfTjs0i4QHQBfdd2lFp65qad9IuATPhuzrQ==",
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.6.1"
+        "web3-core-helpers": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -7134,48 +7131,48 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-      "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+      "version": "12.20.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+      "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
     },
     "node_modules/web3-eth": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.6.1.tgz",
-      "integrity": "sha512-kOV1ZgCKypSo5BQyltRArS7ZC3bRpIKAxSgzl7pUFinUb/MxfbM9KGeNxUXoCfTSErcCQJaDjcS6bSre5EMKuQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.0.tgz",
+      "integrity": "sha512-3uYwjMjn/MZjKIzXCt4YL9ja/k9X5shfa4lKparZhZE6uesmu+xmSmrEFXA/e9qcveF50jkV7frjkT8H+cLYtw==",
       "dependencies": {
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-eth-accounts": "1.6.1",
-        "web3-eth-contract": "1.6.1",
-        "web3-eth-ens": "1.6.1",
-        "web3-eth-iban": "1.6.1",
-        "web3-eth-personal": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-eth-accounts": "1.7.0",
+        "web3-eth-contract": "1.7.0",
+        "web3-eth-ens": "1.7.0",
+        "web3-eth-iban": "1.7.0",
+        "web3-eth-personal": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-abi": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.6.1.tgz",
-      "integrity": "sha512-svhYrAlXP9XQtV7poWKydwDJq2CaNLMtmKydNXoOBLcQec6yGMP+v20pgrxF2H6wyTK+Qy0E3/5ciPOqC/VuoQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz",
+      "integrity": "sha512-heqR0bWxgCJwjWIhq2sGyNj9bwun5+Xox/LdZKe+WMyTSy0cXDXEAgv3XKNkXC4JqdDt/ZlbTEx4TWak4TRMSg==",
       "dependencies": {
         "@ethersproject/abi": "5.0.7",
-        "web3-utils": "1.6.1"
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-accounts": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.6.1.tgz",
-      "integrity": "sha512-rGn3jwnuOKwaQRu4SiShz0YAQ87aVDBKs4HO43+XTCI1q1Y1jn3NOsG3BW9ZHaOckev4+zEyxze/Bsh2oEk24w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.0.tgz",
+      "integrity": "sha512-Zwm7TlQXdXGRuS6+ib1YsR5fQwpfnFyL6UAZg1zERdrUrs3IkCZSL3yCP/8ZYbAjdTEwWljoott2iSqXNH09ug==",
       "dependencies": {
         "@ethereumjs/common": "^2.5.0",
         "@ethereumjs/tx": "^3.3.2",
@@ -7184,10 +7181,10 @@
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
         "uuid": "3.3.2",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -7213,93 +7210,93 @@
       }
     },
     "node_modules/web3-eth-contract": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.6.1.tgz",
-      "integrity": "sha512-GXqTe3mF6kpbOAakiNc7wtJ120/gpuKMTZjuGFKeeY8aobRLfbfgKzM9IpyqVZV2v5RLuGXDuurVN2KPgtu3hQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.0.tgz",
+      "integrity": "sha512-2LY1Xwxu5rx468nqHuhvupQAIpytxIUj3mGL9uexszkhrQf05THVe3i4OnUCzkeN6B2cDztNOqLT3j9SSnVQDg==",
       "dependencies": {
         "@types/bn.js": "^4.11.5",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-ens": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.6.1.tgz",
-      "integrity": "sha512-ngprtbnoRgxg8s1wXt9nXpD3h1P+p7XnKXrp/8GdFI9uDmrbSQPRfzBw86jdZgOmy78hAnWmrHI6pBInmgi2qQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.7.0.tgz",
+      "integrity": "sha512-I1bikYJJWQ/FJZIAvwsGOvzAgcRIkosWG4s1L6veRoXaU8OEJFeh4s00KcfHDxg7GWZZGbUSbdbzKpwRbWnvkg==",
       "dependencies": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-eth-contract": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-eth-contract": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-iban": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.6.1.tgz",
-      "integrity": "sha512-91H0jXZnWlOoXmc13O9NuQzcjThnWyAHyDn5Yf7u6mmKOhpJSGF/OHlkbpXt1Y4v2eJdEPaVFa+6i8aRyagE7Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.0.tgz",
+      "integrity": "sha512-1PFE/Og+sPZaug+M9TqVUtjOtq0HecE+SjDcsOOysXSzslNC2CItBGkcRwbvUcS+LbIkA7MFsuqYxOL0IV/gyA==",
       "dependencies": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.6.1"
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-personal": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.6.1.tgz",
-      "integrity": "sha512-ItsC89Ln02+irzJjK6ALcLrMZfbVUCqVbmb/ieDKJ+eLW3pNkBNwoUzaydh92d5NzxNZgNxuQWVdlFyYX2hkEw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.7.0.tgz",
+      "integrity": "sha512-Dr9RZTNOR80PhrPKGdktDUXpOgExEcCcosBj080lKCJFU1paSPj9Zfnth3u6BtIOXyKsVFTrpqekqUDyAwXnNw==",
       "dependencies": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-personal/node_modules/@types/node": {
-      "version": "12.20.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-      "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+      "version": "12.20.42",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+      "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
     },
     "node_modules/web3-net": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.6.1.tgz",
-      "integrity": "sha512-gpnqKEIwfUHh5ik7wsQFlCje1DfcmGv+Sk7LCh1hCqn++HEDQxJ/mZCrMo11ZZpZHCH7c87imdxTg96GJnRxDw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.0.tgz",
+      "integrity": "sha512-8pmfU1Se7DmG40Pu8nOCKlhuI12VsVzCtdFDnLAai0zGVAOUuuOCK71B2aKm6u9amWBJjtOlyrCwvsG+QEd6dw==",
       "dependencies": {
-        "web3-core": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-http": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.6.1.tgz",
-      "integrity": "sha512-xBoKOJxu10+kO3ikamXmBfrWZ/xpQOGy0ocdp7Y81B17En5TXELwlmMXt1UlIgWiyYDhjq4OwlH/VODYqHXy3A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.0.tgz",
+      "integrity": "sha512-Y9reeEiApfvQKLUUtrU4Z0c+H6b7BMWcsxjgoXndI1C5NB297mIUfltXxfXsh5C/jk5qn4Q3sJp3SwQTyVjH7Q==",
       "dependencies": {
-        "web3-core-helpers": "1.6.1",
+        "web3-core-helpers": "1.7.0",
         "xhr2-cookies": "1.1.0"
       },
       "engines": {
@@ -7307,24 +7304,24 @@
       }
     },
     "node_modules/web3-providers-ipc": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.6.1.tgz",
-      "integrity": "sha512-anyoIZlpMzwEQI4lwylTzDrHsVp20v0QUtSTp2B5jInBinmQtyCE7vnbX20jEQ4j5uPwfJabKNtoJsk6a3O4WQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.0.tgz",
+      "integrity": "sha512-U5YLXgu6fvAK4nnMYqo9eoml3WywgTym0dgCdVX/n1UegLIQ4nctTubBAuWQEJzmAzwh+a6ValGcE7ZApTRI7Q==",
       "dependencies": {
         "oboe": "2.1.5",
-        "web3-core-helpers": "1.6.1"
+        "web3-core-helpers": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-ws": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.6.1.tgz",
-      "integrity": "sha512-FWMEFYb4rYFYRgSFBf/O1Ex4p/YKSlN+JydCtdlJwRimd89qm95CTfs4xGjCskwvXMjV2sarH+f1NPwJXicYpg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.0.tgz",
+      "integrity": "sha512-0a8+lVV3JBf+eYnGOsdzOpftK1kis5X7s35QAdoaG5SDapnEylXFlR4xDSSSU88ZwMwvse8hvng2xW6A7oeWxw==",
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.6.1",
+        "web3-core-helpers": "1.7.0",
         "websocket": "^1.0.32"
       },
       "engines": {
@@ -7337,24 +7334,24 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "node_modules/web3-shh": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.6.1.tgz",
-      "integrity": "sha512-oP00HbAtybLCGlLOZUYXOdeB9xq88k2l0TtStvKBtmFqRt+zVk5TxEeuOnVPRxNhcA2Un8RUw6FtvgZlWStu9A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.7.0.tgz",
+      "integrity": "sha512-RZhxcevALIPK178VZCpwMBvQeW+IoWtRJ4EMdegpbnETeZaC3aRUcs6vKnrf0jXJjm4J/E2Dt438Y1Ord/1IMw==",
       "hasInstallScript": true,
       "dependencies": {
-        "web3-core": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-net": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-net": "1.7.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.6.1.tgz",
-      "integrity": "sha512-RidGKv5kOkcerI6jQqDFDoTllQQqV+rPhTzZHhmbqtFObbYpU93uc+yG1LHivRTQhA6llIx67iudc/vzisgO+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.0.tgz",
+      "integrity": "sha512-O8Tl4Ky40Sp6pe89Olk2FsaUkgHyb5QAXuaKo38ms3CxZZ4d3rPGfjP9DNKGm5+IUgAZBNpF1VmlSmNCqfDI1w==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "ethereum-bloom-filters": "^1.0.6",
@@ -8675,9 +8672,7 @@
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@types/minimist": {
       "version": "1.2.2",
@@ -8691,7 +8686,9 @@
       "integrity": "sha512-scN0hAWyLVAvLR9AyW7HoFF5sJZglyBsbPuHO4fv7JRvfmPBMfp1ozWqOf/e4wwPNxezBZXRfWzMb6iFLgEVRA=="
     },
     "@types/node": {
-      "version": "17.0.8"
+      "version": "17.0.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.9.tgz",
+      "integrity": "sha512-5dNBXu/FOER+EXnyah7rn8xlNrfMOQb/qXnw4NQgLkCygKBKhdmF/CA5oXVOKZLBEahw8s2WP9LxIcN/oDDRgQ=="
     },
     "@types/node-fetch": {
       "version": "2.5.12",
@@ -8711,9 +8708,9 @@
       }
     },
     "@types/ramda": {
-      "version": "0.27.62",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.62.tgz",
-      "integrity": "sha512-/s4yTNOk8YXZ2Ys8OqSPmExyWxuKQMCDwjyVowg0RW6F45SlSGSI0sduyhx7RREASowlVJppAvR4KRqMzJnu2g==",
+      "version": "0.27.64",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.64.tgz",
+      "integrity": "sha512-EDf++ss/JoMiDpvT1MuA8oi88OwpvmqVE+o8Ojm5v/5bdJEPZ6eIQd/XYAeQ0imlwG6Tf0Npfq4Z9w3hAKBk9Q==",
       "requires": {
         "ts-toolbelt": "^6.15.1"
       }
@@ -10885,8 +10882,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
       "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "minimist": "^1.2.0"
       }
@@ -11750,9 +11745,9 @@
       "dev": true
     },
     "ramda": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
-      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
+      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -12172,9 +12167,7 @@
     "strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true,
-      "optional": true
+      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
     },
     "strip-hex-prefix": {
       "version": "1.0.0",
@@ -12426,8 +12419,6 @@
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
       "integrity": "sha512-e5adrnOYT6zqVnWqZu7i/BQ3BnhzvGbjEjejFXO20lKIKpwTaupkCPgEfv4GZK1IBciJUEhYs3J3p75FdaTFVg==",
-      "dev": true,
-      "optional": true,
       "requires": {
         "@types/json5": "^0.0.29",
         "json5": "^1.0.1",
@@ -12604,23 +12595,23 @@
       }
     },
     "web3": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.6.1.tgz",
-      "integrity": "sha512-c299lLiyb2/WOcxh7TinwvbATaMmrgNIeAzbLbmOKHI0LcwyfsB1eu2ReOIrfrCYDYRW2KAjYr7J7gHawqDNPQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.7.0.tgz",
+      "integrity": "sha512-n39O7QQNkpsjhiHMJ/6JY6TaLbdX+2FT5iGs8tb3HbIWOhPm4+a7UDbr5Lkm+gLa9aRKWesZs5D5hWyEvg4aJA==",
       "requires": {
-        "web3-bzz": "1.6.1",
-        "web3-core": "1.6.1",
-        "web3-eth": "1.6.1",
-        "web3-eth-personal": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-shh": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-bzz": "1.7.0",
+        "web3-core": "1.7.0",
+        "web3-eth": "1.7.0",
+        "web3-eth-personal": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-shh": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-bzz": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.6.1.tgz",
-      "integrity": "sha512-JbnFNbRlwwHJZPtVuCxo7rC4U4OTg+mPsyhjgPQJJhS0a6Y54OgVWYk9UA/95HqbmTJwTtX329gJoSsseEfrng==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.7.0.tgz",
+      "integrity": "sha512-XPhTWUnZa8gnARfiqaag3jJ9+6+a66Li8OikgBUJoMUqPuQTCJPncTbGYqOJIfRFGavEAdlMnfYXx9lvgv2ZPw==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
@@ -12628,58 +12619,58 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-          "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+          "version": "12.20.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+          "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
         }
       }
     },
     "web3-core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.6.1.tgz",
-      "integrity": "sha512-m+b7UfYvU5cQUAh6NRfxRzH/5B3to1AdEQi1HIQt570cDWlObOOmoO9tY6iJnI5w4acxIO19LqjDMqEJGBYyRQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.7.0.tgz",
+      "integrity": "sha512-U/CRL53h3T5KHl8L3njzCBT7fCaHkbE6BGJe3McazvFldRbfTDEHXkUJCyM30ZD0RoLi3aDfTVeFIusmEyCctA==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-requestmanager": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-requestmanager": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-          "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+          "version": "12.20.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+          "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.6.1.tgz",
-      "integrity": "sha512-om2PZvK1uoWcgMq6JfcSx3241LEIVF6qi2JuHz2SLKiKEW5UsBUaVx0mNCmcZaiuYQCyOsLS3r33q5AdM+v8ng==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.7.0.tgz",
+      "integrity": "sha512-kFiqsZFHJliKF8VKZNjt2JvKu3gu7h3N1/ke3EPhdp9Li/rLmiyzFVr6ApryZ1FSjbSx6vyOkibG3m6xQ5EHJA==",
       "requires": {
-        "web3-eth-iban": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-eth-iban": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-core-method": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.6.1.tgz",
-      "integrity": "sha512-szH5KyIWIaULQDBdDvevQUCHV9lsExJ/oV0ePqK+w015D2SdMPMuhii0WB+HCePaksWO+rr/GAypvV9g2T3N+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.7.0.tgz",
+      "integrity": "sha512-43Om+kZX8wU5u1pJ28TltF9e9pSTRph6b8wrOb6wgXAfPHqMulq6UTBJWjXXIRVN46Eiqv0nflw35hp9bbgnbA==",
       "requires": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-core-promievent": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.6.1.tgz",
-      "integrity": "sha512-byJ5s2MQxrWdXd27pWFmujfzsTZK4ik8rDgIV1RFDFc+rHZ2nZhq+VWk7t/Nkrj7EaVXncEgTdPEHc18nx+ocQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.7.0.tgz",
+      "integrity": "sha512-xPH66XeC0K0k29GoRd0vyPQ07yxERPRd4yVPrbMzGAz/e9E4M3XN//XK6+PdfGvGw3fx8VojS+tNIMiw+PujbQ==",
       "requires": {
         "eventemitter3": "4.0.4"
       },
@@ -12692,24 +12683,24 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.6.1.tgz",
-      "integrity": "sha512-4y7etYEUtkfflyYVBfN1oJtCbVFNhNX1omlEYzezhTnPj3/dT7n+dhUXcqvIhx9iKA13unGfpFge80XNFfcB8A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.7.0.tgz",
+      "integrity": "sha512-rA3dBTBPrt+eIfTAQ2/oYNTN/2wbZaYNR3pFZGqG8+2oCK03+7oQyz4sWISKy/nYQhURh4GK01rs9sN4o/Tq9w==",
       "requires": {
         "util": "^0.12.0",
-        "web3-core-helpers": "1.6.1",
-        "web3-providers-http": "1.6.1",
-        "web3-providers-ipc": "1.6.1",
-        "web3-providers-ws": "1.6.1"
+        "web3-core-helpers": "1.7.0",
+        "web3-providers-http": "1.7.0",
+        "web3-providers-ipc": "1.7.0",
+        "web3-providers-ws": "1.7.0"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.6.1.tgz",
-      "integrity": "sha512-WZwxsYttIojyGQ5RqxuQcKg0IJdDCFpUe4EncS3QKZwxPqWzGmgyLwE0rm7tP+Ux1waJn5CUaaoSCBxWGSun1g==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.7.0.tgz",
+      "integrity": "sha512-6giF8pyJrPmWrRpc2WLoVCvQdMMADp20ZpAusEW72axauZCNlW1XfTjs0i4QHQBfdd2lFp65qad9IuATPhuzrQ==",
       "requires": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.6.1"
+        "web3-core-helpers": "1.7.0"
       },
       "dependencies": {
         "eventemitter3": {
@@ -12720,37 +12711,37 @@
       }
     },
     "web3-eth": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.6.1.tgz",
-      "integrity": "sha512-kOV1ZgCKypSo5BQyltRArS7ZC3bRpIKAxSgzl7pUFinUb/MxfbM9KGeNxUXoCfTSErcCQJaDjcS6bSre5EMKuQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.7.0.tgz",
+      "integrity": "sha512-3uYwjMjn/MZjKIzXCt4YL9ja/k9X5shfa4lKparZhZE6uesmu+xmSmrEFXA/e9qcveF50jkV7frjkT8H+cLYtw==",
       "requires": {
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-eth-accounts": "1.6.1",
-        "web3-eth-contract": "1.6.1",
-        "web3-eth-ens": "1.6.1",
-        "web3-eth-iban": "1.6.1",
-        "web3-eth-personal": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-eth-accounts": "1.7.0",
+        "web3-eth-contract": "1.7.0",
+        "web3-eth-ens": "1.7.0",
+        "web3-eth-iban": "1.7.0",
+        "web3-eth-personal": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-eth-abi": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.6.1.tgz",
-      "integrity": "sha512-svhYrAlXP9XQtV7poWKydwDJq2CaNLMtmKydNXoOBLcQec6yGMP+v20pgrxF2H6wyTK+Qy0E3/5ciPOqC/VuoQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.7.0.tgz",
+      "integrity": "sha512-heqR0bWxgCJwjWIhq2sGyNj9bwun5+Xox/LdZKe+WMyTSy0cXDXEAgv3XKNkXC4JqdDt/ZlbTEx4TWak4TRMSg==",
       "requires": {
         "@ethersproject/abi": "5.0.7",
-        "web3-utils": "1.6.1"
+        "web3-utils": "1.7.0"
       }
     },
     "web3-eth-accounts": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.6.1.tgz",
-      "integrity": "sha512-rGn3jwnuOKwaQRu4SiShz0YAQ87aVDBKs4HO43+XTCI1q1Y1jn3NOsG3BW9ZHaOckev4+zEyxze/Bsh2oEk24w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.7.0.tgz",
+      "integrity": "sha512-Zwm7TlQXdXGRuS6+ib1YsR5fQwpfnFyL6UAZg1zERdrUrs3IkCZSL3yCP/8ZYbAjdTEwWljoott2iSqXNH09ug==",
       "requires": {
         "@ethereumjs/common": "^2.5.0",
         "@ethereumjs/tx": "^3.3.2",
@@ -12759,10 +12750,10 @@
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
         "uuid": "3.3.2",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "dependencies": {
         "eth-lib": {
@@ -12783,99 +12774,99 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.6.1.tgz",
-      "integrity": "sha512-GXqTe3mF6kpbOAakiNc7wtJ120/gpuKMTZjuGFKeeY8aobRLfbfgKzM9IpyqVZV2v5RLuGXDuurVN2KPgtu3hQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.7.0.tgz",
+      "integrity": "sha512-2LY1Xwxu5rx468nqHuhvupQAIpytxIUj3mGL9uexszkhrQf05THVe3i4OnUCzkeN6B2cDztNOqLT3j9SSnVQDg==",
       "requires": {
         "@types/bn.js": "^4.11.5",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-eth-ens": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.6.1.tgz",
-      "integrity": "sha512-ngprtbnoRgxg8s1wXt9nXpD3h1P+p7XnKXrp/8GdFI9uDmrbSQPRfzBw86jdZgOmy78hAnWmrHI6pBInmgi2qQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.7.0.tgz",
+      "integrity": "sha512-I1bikYJJWQ/FJZIAvwsGOvzAgcRIkosWG4s1L6veRoXaU8OEJFeh4s00KcfHDxg7GWZZGbUSbdbzKpwRbWnvkg==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-promievent": "1.6.1",
-        "web3-eth-abi": "1.6.1",
-        "web3-eth-contract": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-promievent": "1.7.0",
+        "web3-eth-abi": "1.7.0",
+        "web3-eth-contract": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-eth-iban": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.6.1.tgz",
-      "integrity": "sha512-91H0jXZnWlOoXmc13O9NuQzcjThnWyAHyDn5Yf7u6mmKOhpJSGF/OHlkbpXt1Y4v2eJdEPaVFa+6i8aRyagE7Q==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.7.0.tgz",
+      "integrity": "sha512-1PFE/Og+sPZaug+M9TqVUtjOtq0HecE+SjDcsOOysXSzslNC2CItBGkcRwbvUcS+LbIkA7MFsuqYxOL0IV/gyA==",
       "requires": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.6.1"
+        "web3-utils": "1.7.0"
       }
     },
     "web3-eth-personal": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.6.1.tgz",
-      "integrity": "sha512-ItsC89Ln02+irzJjK6ALcLrMZfbVUCqVbmb/ieDKJ+eLW3pNkBNwoUzaydh92d5NzxNZgNxuQWVdlFyYX2hkEw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.7.0.tgz",
+      "integrity": "sha512-Dr9RZTNOR80PhrPKGdktDUXpOgExEcCcosBj080lKCJFU1paSPj9Zfnth3u6BtIOXyKsVFTrpqekqUDyAwXnNw==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.6.1",
-        "web3-core-helpers": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-net": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-helpers": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-net": "1.7.0",
+        "web3-utils": "1.7.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.41",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.41.tgz",
-          "integrity": "sha512-f6xOqucbDirG7LOzedpvzjP3UTmHttRou3Mosx3vL9wr9AIQGhcPgVnqa8ihpZYnxyM1rxeNCvTyukPKZtq10Q=="
+          "version": "12.20.42",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.42.tgz",
+          "integrity": "sha512-aI3/oo5DzyiI5R/xAhxxRzfZlWlsbbqdgxfTPkqu/Zt+23GXiJvMCyPJT4+xKSXOnLqoL8jJYMLTwvK2M3a5hw=="
         }
       }
     },
     "web3-net": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.6.1.tgz",
-      "integrity": "sha512-gpnqKEIwfUHh5ik7wsQFlCje1DfcmGv+Sk7LCh1hCqn++HEDQxJ/mZCrMo11ZZpZHCH7c87imdxTg96GJnRxDw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.7.0.tgz",
+      "integrity": "sha512-8pmfU1Se7DmG40Pu8nOCKlhuI12VsVzCtdFDnLAai0zGVAOUuuOCK71B2aKm6u9amWBJjtOlyrCwvsG+QEd6dw==",
       "requires": {
-        "web3-core": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-utils": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-utils": "1.7.0"
       }
     },
     "web3-providers-http": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.6.1.tgz",
-      "integrity": "sha512-xBoKOJxu10+kO3ikamXmBfrWZ/xpQOGy0ocdp7Y81B17En5TXELwlmMXt1UlIgWiyYDhjq4OwlH/VODYqHXy3A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.7.0.tgz",
+      "integrity": "sha512-Y9reeEiApfvQKLUUtrU4Z0c+H6b7BMWcsxjgoXndI1C5NB297mIUfltXxfXsh5C/jk5qn4Q3sJp3SwQTyVjH7Q==",
       "requires": {
-        "web3-core-helpers": "1.6.1",
+        "web3-core-helpers": "1.7.0",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.6.1.tgz",
-      "integrity": "sha512-anyoIZlpMzwEQI4lwylTzDrHsVp20v0QUtSTp2B5jInBinmQtyCE7vnbX20jEQ4j5uPwfJabKNtoJsk6a3O4WQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.7.0.tgz",
+      "integrity": "sha512-U5YLXgu6fvAK4nnMYqo9eoml3WywgTym0dgCdVX/n1UegLIQ4nctTubBAuWQEJzmAzwh+a6ValGcE7ZApTRI7Q==",
       "requires": {
         "oboe": "2.1.5",
-        "web3-core-helpers": "1.6.1"
+        "web3-core-helpers": "1.7.0"
       }
     },
     "web3-providers-ws": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.6.1.tgz",
-      "integrity": "sha512-FWMEFYb4rYFYRgSFBf/O1Ex4p/YKSlN+JydCtdlJwRimd89qm95CTfs4xGjCskwvXMjV2sarH+f1NPwJXicYpg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.7.0.tgz",
+      "integrity": "sha512-0a8+lVV3JBf+eYnGOsdzOpftK1kis5X7s35QAdoaG5SDapnEylXFlR4xDSSSU88ZwMwvse8hvng2xW6A7oeWxw==",
       "requires": {
         "eventemitter3": "4.0.4",
-        "web3-core-helpers": "1.6.1",
+        "web3-core-helpers": "1.7.0",
         "websocket": "^1.0.32"
       },
       "dependencies": {
@@ -12887,20 +12878,20 @@
       }
     },
     "web3-shh": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.6.1.tgz",
-      "integrity": "sha512-oP00HbAtybLCGlLOZUYXOdeB9xq88k2l0TtStvKBtmFqRt+zVk5TxEeuOnVPRxNhcA2Un8RUw6FtvgZlWStu9A==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.7.0.tgz",
+      "integrity": "sha512-RZhxcevALIPK178VZCpwMBvQeW+IoWtRJ4EMdegpbnETeZaC3aRUcs6vKnrf0jXJjm4J/E2Dt438Y1Ord/1IMw==",
       "requires": {
-        "web3-core": "1.6.1",
-        "web3-core-method": "1.6.1",
-        "web3-core-subscriptions": "1.6.1",
-        "web3-net": "1.6.1"
+        "web3-core": "1.7.0",
+        "web3-core-method": "1.7.0",
+        "web3-core-subscriptions": "1.7.0",
+        "web3-net": "1.7.0"
       }
     },
     "web3-utils": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.6.1.tgz",
-      "integrity": "sha512-RidGKv5kOkcerI6jQqDFDoTllQQqV+rPhTzZHhmbqtFObbYpU93uc+yG1LHivRTQhA6llIx67iudc/vzisgO+w==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.7.0.tgz",
+      "integrity": "sha512-O8Tl4Ky40Sp6pe89Olk2FsaUkgHyb5QAXuaKo38ms3CxZZ4d3rPGfjP9DNKGm5+IUgAZBNpF1VmlSmNCqfDI1w==",
       "requires": {
         "bn.js": "^4.11.9",
         "ethereum-bloom-filters": "^1.0.6",

--- a/integration-tests/runtime-tests/package.json
+++ b/integration-tests/runtime-tests/package.json
@@ -6,11 +6,11 @@
   "type": "commonjs",
   "scripts": {
     "compile": "tsc --declaration",
-    "lint": "eslint src/* --fix-dry-run",
+    "lint": "eslint src/**/*.ts --fix-dry-run",
     "prepare": "npm run compile",
     "init": "node src/initializeState.js",
     "init_and_test": "npm run init && mocha src/test.js --reporter mochawesome",
-    "test": "ts-mocha --paths --full-trace --async-stack-traces -p tsconfig.json src/test.ts --require src/utils/testSetup.ts",
+    "test": "ts-mocha --paths -p tsconfig.json src/test.ts",
     "gen": "npm run gen:defs && npm run gen:meta",
     "gen:defs": "ts-node --skip-project node_modules/.bin/polkadot-types-from-defs --package @composable/types/interfaces --input ./src/types/interfaces",
     "gen:meta": "ts-node --skip-project node_modules/.bin/polkadot-types-from-chain --package @composable/types/interfaces --endpoint ws://localhost:9988 --output src/types/interfaces/"
@@ -25,39 +25,39 @@
   "devDependencies": {
     "@types/chai": "^4.3.0",
     "@types/minimist": "^1.2.2",
-    "@typescript-eslint/eslint-plugin": "^5.9.0",
-    "@typescript-eslint/parser": "^5.9.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.0",
+    "@typescript-eslint/parser": "^5.10.0",
     "assert": "^2.0.0",
-    "eslint": "^8.6.0",
+    "eslint": "^8.7.0",
     "eslint-config-google": "^0.14.0",
     "mocha-prepare": "^0.1.0",
     "ts-mocha": "^8.0.0",
-    "ts-node": "^9.1.1",
-    "typescript": "^4.2.4"
+    "ts-node": "^10.4.0",
+    "typescript": "^4.5.4"
   },
   "engines": {
     "node": ">=12.0.0"
   },
   "dependencies": {
-    "@polkadot/api": "^7.3.1",
-    "@polkadot/ts": "latest",
-    "@polkadot/typegen": "^7.3.1",
-    "@polkadot/types": "^7.3.1",
-    "@polkadot/types-augment": "^7.3.1",
-    "@polkadot/types-codec": "^7.3.1",
-    "@polkadot/types-create": "^7.3.1",
-    "@polkadot/types-known": "^7.3.1",
-    "@polkadot/types-support": "^7.3.1",
+    "@polkadot/api": "^7.4.1",
+    "@polkadot/ts": "^0.4.22",
+    "@polkadot/typegen": "^7.4.1",
+    "@polkadot/types": "^7.4.1",
+    "@polkadot/types-augment": "^7.4.1",
+    "@polkadot/types-codec": "^7.4.1",
+    "@polkadot/types-create": "^7.4.1",
+    "@polkadot/types-known": "^7.4.1",
+    "@polkadot/types-support": "^7.4.1",
     "@types/mocha": "^9.0.0",
-    "@types/node": "^17.0.8",
-    "@types/ramda": "^0.27.62",
-    "bluebird": "^3.7.2",
+    "@types/node": "^17.0.9",
+    "@types/ramda": "^0.27.64",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "minimist": "^1.2.5",
-    "mocha": "latest",
+    "mocha": "^8.4.0",
     "mochawesome": "^7.0.1",
-    "ramda": "^0.27.1",
-    "web3": "^1.6.1"
+    "ramda": "^0.28.0",
+    "tsconfig-paths": "^3.12.0",
+    "web3": "^1.7.0"
   }
 }

--- a/integration-tests/runtime-tests/src/test.ts
+++ b/integration-tests/runtime-tests/src/test.ts
@@ -6,21 +6,47 @@
 import { QueryCrowdloanRewardsTests } from './tests/query/crowdloanRewards/queryCrowdloanRewardsTests';
 import { TxCrowdloanRewardsTests } from './tests/tx/crowdloanRewards/txCrowdloanRewardsTests';
 import { TxBondedFinanceTests } from "@composable/tests/tx/bondedFinance/txBondedFinanceTests";
+import { runBefore, runAfter } from "@composable/utils/testSetup";
+import { TxOracleTests } from "@composable/tests/tx/oracle/txOracleTests";
+
+
+describe('Picasso Runtime Tests', function() {
+  before(async function () {
+    // Set timeout to 1 minute.
+    this.timeout(60*1000);
+    await runBefore();
+  });
+
+  after(async function() {
+    // Set timeout to 1 minute.
+    this.timeout(60*1000);
+    await runAfter();
+  });
+
+  // Query Tests
+  describe('Query Tests', function() {
+    // Query Crowdloan Rewards Tests
+    QueryCrowdloanRewardsTests.runQueryCrowdloanRewardsTests();
+  });
+
+  // TX Tests
+  describe('TX Tests', function () {
+    // TX Crowdloan Rewards Tests
+    TxCrowdloanRewardsTests.runTxCrowdloanRewardsTests();
+
+    // TX bondedFinance Tests
+    TxBondedFinanceTests.runTxBondedFinanceTests();
+
+    // TX Oracle Tests
+    TxOracleTests.runTxOracleTests();
+  });
+
+  // RPC Tests
+  describe('RPC Tests', function () {
+    // No RPC tests implemented yet!
+  });
+});
 
 
 
-// Query Tests
 
-// Query Crowdloan Rewards Tests
-QueryCrowdloanRewardsTests.runQueryCrowdloanRewardsTests();
-
-
-// TX Tests
-
-// TX Crowdloan Rewards Tests
-TxCrowdloanRewardsTests.runTxCrowdloanRewardsTests();
-
-// TX bondedFinance Tests
-TxBondedFinanceTests.runTxBondedFinanceTests();
-
-// RPC Tests

--- a/integration-tests/runtime-tests/src/tests/query/crowdloanRewards/queryCrowdloanRewardsTests.ts
+++ b/integration-tests/runtime-tests/src/tests/query/crowdloanRewards/queryCrowdloanRewardsTests.ts
@@ -40,7 +40,6 @@ export class QueryCrowdloanRewardsTests {
    * query.crowdloanRewards.totalContributors()
    */
   private static async queryCrowdloanRewardsTotalContributorsTest() {
-    console.debug('queryCrowdloanRewardsTotalContributorsTest');
     const totalContributors = await api.query.crowdloanRewards.totalContributors();
     expect(totalContributors.toNumber()).to.be.a('number');
   }

--- a/integration-tests/runtime-tests/src/tests/tx/bondedFinance/txBondedFinanceTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/bondedFinance/txBondedFinanceTests.ts
@@ -14,8 +14,6 @@ import {txBondedFinanceBondSuccessTest} from "@composable/tests/tx/bondedFinance
 /**
  * Contains all TX tests for the pallet:
  * bondedFinance
- *
- * ToDo (D. Roth): Split this up into multiple files for each function. To keep it clean.
  */
 export class TxBondedFinanceTests {
   /**
@@ -24,151 +22,153 @@ export class TxBondedFinanceTests {
    * ToDo (D. Roth): The tests assume you're running them on a fresh chain. Instead of assuming, use the test returns.
    */
   public static runTxBondedFinanceTests() {
-    /**
-     * bondedFinance.offer(...) Success Tests
-     */
-    describe('tx.bondedFinance.offer & .bond Success Tests', function () {
-      // Timeout set to 2 minutes
-      this.timeout(2*60*1000);
-      // #1 Create offer using Alice's wallet.
-      it('Can create a new offer', async function () {
-        const requestParameters = {
-          beneficiary: walletAlice.publicKey,
-          asset: api.createType('u128', 1),
-          bondPrice: api.consts.bondedFinance.stake,
-          nbOfBonds: api.createType('u128', 10),
-          maturity: { Finite: { returnIn: api.createType('u32', 16) } },
-          reward: {
+    describe('tx.bondedFinance Tests', function() {
+      /**
+       * bondedFinance.offer(...) Success Tests
+       */
+      describe('tx.bondedFinance.offer & .bond Success Tests', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2*60*1000);
+        // #1 Create offer using Alice's wallet.
+        it('Can create a new offer', async function () {
+          const requestParameters = {
+            beneficiary: walletAlice.publicKey,
             asset: api.createType('u128', 1),
-            amount: api.consts.bondedFinance.minReward,
-            maturity: api.createType('u32', 1)
-          }
-        };
-        const { data: [result], } = await txBondedFinanceOfferSuccessTest(walletAlice, requestParameters);
-        expect(result.toNumber()).to.be.a('number');
-      });
+            bondPrice: api.consts.bondedFinance.stake,
+            nbOfBonds: api.createType('u128', 10),
+            maturity: { Finite: { returnIn: api.createType('u32', 16) } },
+            reward: {
+              asset: api.createType('u128', 1),
+              amount: api.consts.bondedFinance.minReward,
+              maturity: api.createType('u32', 1)
+            }
+          };
+          const { data: [result], } = await txBondedFinanceOfferSuccessTest(walletAlice, requestParameters);
+          expect(result.toNumber()).to.be.a('number');
+        });
 
-      // #2 Create offer using Bob's wallet.
-      it('Can create a second new offer', async function () {
-        const requestParameters = {
-          beneficiary: walletBob.publicKey,
-          asset: api.createType('u128', 1),
-          bondPrice: api.consts.bondedFinance.stake,
-          nbOfBonds: api.createType('u128', 10),
-          maturity: { Finite: { returnIn: api.createType('u32', 16) } },
-          reward: {
+        // #2 Create offer using Bob's wallet.
+        it('Can create a second new offer', async function () {
+          const requestParameters = {
+            beneficiary: walletBob.publicKey,
             asset: api.createType('u128', 1),
-            amount: api.consts.bondedFinance.minReward,
-            maturity: api.createType('u32', 1)
-          }
-        };
-        const { data: [result], } = await txBondedFinanceOfferSuccessTest(walletBob, requestParameters);
-        expect(result.toNumber()).to.be.a('number');
+            bondPrice: api.consts.bondedFinance.stake,
+            nbOfBonds: api.createType('u128', 10),
+            maturity: { Finite: { returnIn: api.createType('u32', 16) } },
+            reward: {
+              asset: api.createType('u128', 1),
+              amount: api.consts.bondedFinance.minReward,
+              maturity: api.createType('u32', 1)
+            }
+          };
+          const { data: [result], } = await txBondedFinanceOfferSuccessTest(walletBob, requestParameters);
+          expect(result.toNumber()).to.be.a('number');
+        });
+
+        /**
+         * bondedFinance.bond(offerId:u64, nbOfBonds:u128) Tests
+         */
+        // #3 Bob can bond to the offer Alice has created.
+        it('Can bond to newly created offer', async function () {
+          const offerId = api.createType('u64', 1);
+          const nbOfBonds = api.createType('u128', 1);
+          await txBondedFinanceBondSuccessTest(walletBob, offerId, nbOfBonds);
+        });
       });
 
       /**
-       * bondedFinance.bond(offerId:u64, nbOfBonds:u128) Tests
+       * Runs all tx FAILURE tests for the bondedFinance pallet.
        */
-      // #3 Bob can bond to the offer Alice has created.
-      it('Can bond to newly created offer', async function () {
-        const offerId = api.createType('u64', 1);
-        const nbOfBonds = api.createType('u128', 1);
-        await txBondedFinanceBondSuccessTest(walletBob, offerId, nbOfBonds);
-      });
-    });
-
-    /**
-     * Runs all tx FAILURE tests for the bondedFinance pallet.
-     */
-    describe('tx.bondedFinance.offer Failure Tests', function () {
-      // Timeout set to 2 minutes
-      this.timeout(2*60*1000);
-      // #4 Alice can't create am offer with the bond price too low.
-      it('Should not be able to create offer (bondPrice < MIN_VESTED_TRANSFER)', async function () {
-        const requestParameters = {
-          beneficiary: walletAlice.publicKey,
-          asset: api.createType('u128', 1),
-          bondPrice: api.createType('u128', api.consts.bondedFinance.stake.toNumber()-1),
-          nbOfBonds: api.createType('u128', 10),
-          maturity: {Finite: {returnIn: api.createType('u32', 16)}},
-          reward: {
+      describe('tx.bondedFinance.offer Failure Tests', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2*60*1000);
+        // #4 Alice can't create am offer with the bond price too low.
+        it('Should not be able to create offer (bondPrice < MIN_VESTED_TRANSFER)', async function () {
+          const requestParameters = {
+            beneficiary: walletAlice.publicKey,
             asset: api.createType('u128', 1),
-            amount: api.consts.bondedFinance.minReward,
-            maturity: api.createType('u32', 1)
-          }
-        };
-        const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
-        expect(result.toNumber()).to.be.a('number');
-      });
+            bondPrice: api.createType('u128', api.consts.bondedFinance.stake.toNumber()-1),
+            nbOfBonds: api.createType('u128', 10),
+            maturity: {Finite: {returnIn: api.createType('u32', 16)}},
+            reward: {
+              asset: api.createType('u128', 1),
+              amount: api.consts.bondedFinance.minReward,
+              maturity: api.createType('u32', 1)
+            }
+          };
+          const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
+          expect(result.toNumber()).to.be.a('number');
+        });
 
-      // #5 Alice can't create offer with the reward amount too low.
-      it('Should not be able to create offer (reward.amount < MinReward)', async function () {
-        const requestParameters = {
-          beneficiary: walletAlice.publicKey,
-          asset: api.createType('u128', 1),
-          bondPrice: api.consts.bondedFinance.stake,
-          nbOfBonds: api.createType('u128', 10),
-          maturity: {Finite: {returnIn: api.createType('u32', 16)}},
-          reward: {
+        // #5 Alice can't create offer with the reward amount too low.
+        it('Should not be able to create offer (reward.amount < MinReward)', async function () {
+          const requestParameters = {
+            beneficiary: walletAlice.publicKey,
             asset: api.createType('u128', 1),
-            amount: api.createType('u128', api.consts.bondedFinance.minReward.toNumber()-1),
-            maturity: api.createType('u32', 1)
-          }
-        };
-        const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
-        expect(result.toNumber()).to.be.a('number');
+            bondPrice: api.consts.bondedFinance.stake,
+            nbOfBonds: api.createType('u128', 10),
+            maturity: {Finite: {returnIn: api.createType('u32', 16)}},
+            reward: {
+              asset: api.createType('u128', 1),
+              amount: api.createType('u128', api.consts.bondedFinance.minReward.toNumber()-1),
+              maturity: api.createType('u32', 1)
+            }
+          };
+          const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
+          expect(result.toNumber()).to.be.a('number');
+        });
+
+        // #5 Alice can't create offer with the reward amount too low.
+        it('Should not be able to create offer (reward.asset does not exist)', async function () {
+          const requestParameters = {
+            beneficiary: walletAlice.publicKey,
+            asset: api.createType('u128', 1),
+            bondPrice: api.consts.bondedFinance.stake,
+            nbOfBonds: api.createType('u128', 10),
+            maturity: {Finite: {returnIn: api.createType('u32', 16)}},
+            reward: {
+              asset: api.createType('u128', 1337),
+              amount: api.consts.bondedFinance.minReward,
+              maturity: api.createType('u32', 1)
+            }
+          };
+          const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
+          expect(result.toNumber()).to.be.a('number');
+        });
       });
 
-      // #5 Alice can't create offer with the reward amount too low.
-      it('Should not be able to create offer (reward.asset does not exist)', async function () {
-        const requestParameters = {
-          beneficiary: walletAlice.publicKey,
-          asset: api.createType('u128', 1),
-          bondPrice: api.consts.bondedFinance.stake,
-          nbOfBonds: api.createType('u128', 10),
-          maturity: {Finite: {returnIn: api.createType('u32', 16)}},
-          reward: {
-            asset: api.createType('u128', 1337),
-            amount: api.consts.bondedFinance.minReward,
-            maturity: api.createType('u32', 1)
-          }
-        };
-        const {data: [result],} = await txBondedFinanceOfferFailureTest(walletAlice, requestParameters);
-        expect(result.toNumber()).to.be.a('number');
-      });
-    });
-
-    /**
-     * Runs FAILURE tests for bondedFinance.cancel(offerId)
-     */
-    describe('tx.bondedFinance.cancel Failure Tests', function () {
-      // Timeout set to 2 minutes
-      this.timeout(2*60*1000);
-      it('Should not be able to cancel offer that doesn\'t exist', async function () {
-        const offerId = 1337;
-        const { data: [result], } = await txBondedFinanceCancelFailureTest(walletAlice, offerId);
-        expect(result.toNumber()).to.be.a('number');
-      });
-    });
-
-    /**
-     * Runs SUCCESS tests for bondedFinance.cancel(offerId)
-     */
-    describe('tx.bondedFinance.cancel Success Tests', function () {
-      // Timeout set to 2 minutes
-      this.timeout(2*60*1000);
-      // #6 Alice should be able to cancel her offer.
-      it('Can cancel offer created in first bondedFinance.offer test by creator', async function () {
-        const offerId = 1;
-        const { data: [result], } = await txBondedFinanceCancelSuccessTest(walletAlice, offerId);
-        expect(result.toNumber()).to.be.a('number');
+      /**
+       * Runs FAILURE tests for bondedFinance.cancel(offerId)
+       */
+      describe('tx.bondedFinance.cancel Failure Tests', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2*60*1000);
+        it('Should not be able to cancel offer that doesn\'t exist', async function () {
+          const offerId = 1337;
+          const { data: [result], } = await txBondedFinanceCancelFailureTest(walletAlice, offerId);
+          expect(result.toNumber()).to.be.a('number');
+        });
       });
 
-      // #7 A sudo command should be able to cancel an offer.
-      it('Can sudo (diff. account) cancel offer created in second bondedFinance.offer', async function () {
-        const offerId = 2;
-        const { data: [result], } = await txBondedFinanceCancelSudoSuccessTest(walletAlice, offerId);
-        expect(result.isOk).to.be.true;
+      /**
+       * Runs SUCCESS tests for bondedFinance.cancel(offerId)
+       */
+      describe('tx.bondedFinance.cancel Success Tests', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2*60*1000);
+        // #6 Alice should be able to cancel her offer.
+        it('Can cancel offer created in first bondedFinance.offer test by creator', async function () {
+          const offerId = 1;
+          const { data: [result], } = await txBondedFinanceCancelSuccessTest(walletAlice, offerId);
+          expect(result.toNumber()).to.be.a('number');
+        });
+
+        // #7 A sudo command should be able to cancel an offer.
+        it('Can sudo (diff. account) cancel offer created in second bondedFinance.offer', async function () {
+          const offerId = 2;
+          const { data: [result], } = await txBondedFinanceCancelSudoSuccessTest(walletAlice, offerId);
+          expect(result.isOk).to.be.true;
+        });
       });
     });
   }

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/addAssetAndInfoTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/addAssetAndInfoTests.ts
@@ -1,0 +1,42 @@
+import {IKeyringPair} from "@polkadot/types/types";
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+
+
+/**
+ * Tests tx.oracle.addAssetAndInfo with provided parameters that should succeed.
+ * @param {IKeyringPair} sudoKey Connected API Promise w/ sudo rights.
+ * @param assetId Id for the asset
+ * @param threshold Percent close to mean to be rewarded
+ * @param minAnswers Min answers before aggregation
+ * @param maxAnswers Max answers to aggregate
+ * @param blockInterval blocks until oracle triggered
+ * @param reward reward amount for correct answer
+ * @param slash slash amount for bad answer
+ */
+export async function txOracleAddAssetAndInfoSuccessTest(
+  sudoKey: IKeyringPair,
+  assetId,
+  threshold,
+  minAnswers,
+  maxAnswers,
+  blockInterval,
+  reward,
+  slash
+) {
+  return await sendAndWaitForSuccess(
+    api,
+    sudoKey,
+    api.events.sudo.Sudid.is,
+    api.tx.sudo.sudo(
+      api.tx.oracle.addAssetAndInfo(
+        assetId,
+        threshold,
+        minAnswers,
+        maxAnswers,
+        blockInterval,
+        reward,
+        slash
+      ),
+    )
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/addStakeTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/addStakeTests.ts
@@ -1,0 +1,41 @@
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+import {u128} from "@polkadot/types-codec";
+import {expect} from "chai";
+
+
+export async function runBeforeTxOracleAddStake(sudoKey, wallet1, wallet2) {
+  const {data: [result1],} = await sendAndWaitForSuccess(
+    api,
+    sudoKey,
+    api.events.sudo.Sudid.is,
+    api.tx.sudo.sudo(
+      api.tx.assets.mintInto(1, wallet1.publicKey, 555555555555)
+    )
+  );
+  expect(result1.isOk).to.be.true;
+  const {data: [result2],} = await sendAndWaitForSuccess(
+    api,
+    sudoKey,
+    api.events.sudo.Sudid.is,
+    api.tx.sudo.sudo(
+      api.tx.assets.mintInto(1, wallet2.publicKey, 555555555555)
+    )
+  );
+  expect(result2.isOk).to.be.true;
+  return
+}
+
+/**
+ * Tests tx.oracle.submitPrice with provided parameters that should succeed.
+ * @param sender Connected API Promise w/ sudo rights.
+ * @param {u128} stake Staking amount.
+ */
+export async function txOracleAddStakeSuccessTest(sender, stake:u128) {
+  return await sendAndWaitForSuccess(
+    api,
+    sender,
+    api.events.oracle.StakeAdded.is,
+    api.tx.oracle.addStake(stake),
+    false
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/reclaimStakeTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/reclaimStakeTests.ts
@@ -1,0 +1,15 @@
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+
+/**
+ * Tests tx.oracle.reclaimStake with provided parameters that should succeed.
+ * @param controller KeyringPair which is a controller.
+ */
+export async function txOracleReclaimStakeSuccessTest(controller) {
+  return await sendAndWaitForSuccess(
+    api,
+    controller,
+    api.events.oracle.StakeReclaimed.is,
+    api.tx.oracle.reclaimStake(),
+    false
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/removeStakeTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/removeStakeTests.ts
@@ -1,0 +1,15 @@
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+
+/**
+ * Tests tx.oracle.removeStake with provided parameters that should succeed.
+ * @param controller KeyringPair which is a controller.
+ */
+export async function txOracleRemoveStakeSuccessTest(controller) {
+  return await sendAndWaitForSuccess(
+    api,
+    controller,
+    api.events.oracle.StakeRemoved.is,
+    api.tx.oracle.removeStake(),
+    false
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/setSignerTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/setSignerTests.ts
@@ -1,0 +1,28 @@
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+
+
+export async function runBeforeTxOracleSetSigner(sudoKey, signer) {
+  return await sendAndWaitForSuccess(
+    api,
+    sudoKey,
+    api.events.sudo.Sudid.is,
+    api.tx.sudo.sudo(
+      api.tx.assets.mintInto(1, signer.publicKey, 555555555555)
+    )
+  );
+}
+
+/**
+ * Tests tx.oracle.submitPrice with provided parameters that should succeed.
+ * @param controller Keyring which is a controller.
+ * @param signer Keyring which will be set as a signer.
+ */
+export async function txOracleSetSignerSuccessTest(controller, signer) {
+  return await sendAndWaitForSuccess(
+    api,
+    controller,
+    api.events.oracle.SignerSet.is,
+    api.tx.oracle.setSigner(signer.address),
+    false
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/submitPriceTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/testHandlers/submitPriceTests.ts
@@ -1,0 +1,18 @@
+import {sendAndWaitForSuccess} from "@composable/utils/polkadotjs";
+
+
+/**
+ * Tests tx.oracle.submitPrice with provided parameters that should succeed.
+ * @param signer Connected API Promise w/ sudo rights.
+ * @param price Price to be submitted.
+ * @param assetId Specifies asset id.
+ */
+export async function txOracleSubmitPriceSuccessTest(signer, price, assetId) {
+  return await sendAndWaitForSuccess(
+    api,
+    signer,
+    api.events.oracle.PriceSubmitted.is,
+    api.tx.oracle.submitPrice(price, assetId),
+    false
+  );
+}

--- a/integration-tests/runtime-tests/src/tests/tx/oracle/txOracleTests.ts
+++ b/integration-tests/runtime-tests/src/tests/tx/oracle/txOracleTests.ts
@@ -1,0 +1,204 @@
+/* eslint-disable no-trailing-spaces */
+import {expect} from "chai";
+import {txOracleSubmitPriceSuccessTest} from "@composable/tests/tx/oracle/testHandlers/submitPriceTests";
+import {txOracleAddAssetAndInfoSuccessTest} from "@composable/tests/tx/oracle/testHandlers/addAssetAndInfoTests";
+import {
+  runBeforeTxOracleSetSigner,
+  txOracleSetSignerSuccessTest
+} from "@composable/tests/tx/oracle/testHandlers/setSignerTests";
+import {KeyringPair} from "@polkadot/keyring/types";
+import {
+  runBeforeTxOracleAddStake,
+  txOracleAddStakeSuccessTest
+} from "@composable/tests/tx/oracle/testHandlers/addStakeTests";
+import {txOracleReclaimStakeSuccessTest} from "@composable/tests/tx/oracle/testHandlers/reclaimStakeTests";
+import {txOracleRemoveStakeSuccessTest} from "@composable/tests/tx/oracle/testHandlers/removeStakeTests";
+
+/**
+ * Contains all TX tests for the pallet:
+ * Oracle
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export class TxOracleTests {
+  /**
+   * Runs all tx tests for the Oracle pallet.
+   */
+  public static runTxOracleTests() {
+    let assetsCountStart:number;
+    let newAsset1:number;
+    let signedWallet: KeyringPair;
+    let controllerWallet: KeyringPair;
+
+    describe('tx.oracle Tests', function () {
+      before(async function() {
+        // Getting the id for the about to be created asset.
+        assetsCountStart = (await api.query.oracle.assetsCount()).toNumber();
+        newAsset1=assetsCountStart+1;
+
+        signedWallet = walletAlice.derive('/oracleSigner');
+        controllerWallet = walletAlice;
+      });
+      /**
+       * oracle.addAssetAndInfo Success Tests
+       *
+       * Sudo command success is checked with `.isOk`.
+       */
+      describe('tx.addAssetAndInfo Success Test', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2 * 60 * 1000);
+        it('Can add new asset and info', async function () {
+          const assetId = api.createType('u128', newAsset1);
+          const threshold = api.createType('Percent', 50);
+          const minAnswers = api.createType('u32', 2);
+          const maxAnswers = api.createType('u32', 5);
+          const blockInterval = api.createType('u32', 6);
+          const reward = api.createType('u128', 150000000000);
+          const slash = api.createType('u128', 100000000000);
+          const {data: [result],} = await txOracleAddAssetAndInfoSuccessTest(
+            controllerWallet,
+            assetId,
+            threshold,
+            minAnswers,
+            maxAnswers,
+            blockInterval,
+            reward,
+            slash
+          );
+          if (result.isErr)
+            console.debug(result.asErr.toString());
+          expect(result.isOk).to.be.true;
+        });
+      });
+
+      /**
+       * oracle.setSigner Success Tests
+       * To be called by controller.
+       *
+       * In `before` we give the signer wallet enough funds to become a signer.
+       *
+       * We get 2 results here.
+       * resultAccount0: The signer wallets public key.
+       * resultAccount1: The controller wallets public key.
+       */
+      describe('tx.setSigner Success Test', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2 * 60 * 1000);
+        before(async function() {
+          const sudoKey = walletAlice;
+          const {data: [result],} = await runBeforeTxOracleSetSigner(sudoKey, signedWallet);
+          expect(result.isOk).to.be.true;
+        });
+        it('Can set signer', async function () {
+          const {data: [resultAccount0, resultAccount1],} = await txOracleSetSignerSuccessTest(controllerWallet, signedWallet).catch(function(exc) {
+            return {data:[exc]}; // We can't call this.skip() from here.
+          });
+          if (resultAccount0.message == "oracle.SignerUsed: This signer is already in use" ||
+              resultAccount0.message == "oracle.ControllerUsed: This controller is already in use")
+            return this.skip(); // If the test is run a second time on the same chain, we already have a signer set.
+          expect(resultAccount0).to.not.be.an('Error');
+          expect(resultAccount1).to.not.be.an('Error');
+          expect(resultAccount0.toString()).to.be.equal(api.createType('AccountId32', signedWallet.publicKey).toString());
+          expect(resultAccount1.toString()).to.be.equal(api.createType('AccountId32', controllerWallet.publicKey).toString());
+        });
+      });
+
+      /**
+       * oracle.addStake Success Tests
+       * To be called by controller.
+       *
+       * Result is the signer wallets public key.
+       */
+      describe('tx.addStake Success Test', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2 * 60 * 1000);
+        before(async function() {
+          const sudoKey = walletAlice;
+          await runBeforeTxOracleAddStake(sudoKey, controllerWallet, signedWallet);
+        });
+        it('Can add stake from creator/controller', async function () {
+          const stake = api.createType('u128', 250000000000);
+          const {data: [result],} = await txOracleAddStakeSuccessTest(controllerWallet, stake);
+          expect(result).to.not.be.an('Error');
+          expect(result.toString()).to.be
+            .equal(api.createType('AccountId32', signedWallet.publicKey).toString());
+        });
+      });
+
+      /**
+       * oracle.submitPrice Success Tests
+       * To be called by signer or controller.
+       *
+       * Result is the signer wallets public key.
+       */
+      describe('tx.submitPrice Success Test', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2 * 60 * 1000);
+        it('Can submit new price by signer', async function () {
+          const price = api.createType('u128', 10000);
+          const assetId = api.createType('u128', newAsset1);
+          const {data: [result],} = await txOracleSubmitPriceSuccessTest(signedWallet, price, assetId);
+          expect(result).to.not.be.an('Error');
+          expect(result.toString()).to.be
+            .equal(api.createType('AccountId32', signedWallet.publicKey).toString());
+        });
+      });
+
+      /**
+       * oracle.removeStake Success Tests
+       * To be called by controller.
+       *
+       * Result is the signer wallets public key.
+       */
+      describe('tx.removeStake Success Test', function () {
+        // Timeout set to 2 minutes
+        this.timeout(2 * 60 * 1000);
+        it('Can remove stake', async function () {
+          const controllerWallet = walletAlice;
+          const {data: [result],} = await txOracleRemoveStakeSuccessTest(controllerWallet);
+          expect(result).to.not.be.an('Error');
+          expect(result.toString()).to.be
+            .equal(api.createType('AccountId32', signedWallet.publicKey).toString());
+        });
+      });
+
+      /**
+       * oracle.reclaimStake Success Tests
+       * To be called by controller.
+       * Can only work after a successful removeStake(), and waiting for unblockBlock to be reached.
+       *
+       * Result is the signer wallets public key.
+       */
+      describe('tx.reclaimStake Success Test', function () {
+        let unlockBlock;
+        // Timeout set to 15 minutes
+        this.timeout(15 * 60 * 1000);
+        before(async function() {
+          // Get the block number at which the funds are unlocked.
+          const result = await api.query.oracle.declaredWithdraws(signedWallet.address);
+          unlockBlock = result.unwrap().unlockBlock;
+          expect(unlockBlock.toNumber()).to.be.a('Number');
+        });
+
+        it('Can reclaim stake', async function () {
+          let currentBlock = await api.query.system.number();
+          // Taking a nap until we reach the unlocking block.
+          while (unlockBlock.toNumber() >= currentBlock.toNumber()) {
+            await sleep(9000);
+            currentBlock = await api.query.system.number();
+          }
+          const controllerWallet = walletAlice; // Controller
+          const {data: [result],} = await txOracleReclaimStakeSuccessTest(controllerWallet);
+          expect(result).to.not.be.an('Error');
+          expect(result.toString()).to.be
+            .equal(api.createType('AccountId32', signedWallet.publicKey).toString());
+        });
+      });
+    });
+  }
+}
+
+// Uncomment to debug
+//TxOracleTests.runTxOracleTests();

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-query.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-query.ts
@@ -432,7 +432,7 @@ declare module '@polkadot/api-base/types/storage' {
       /**
        * Information about asset, including precision threshold and max/min answers
        **/
-      assetsInfo: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<PalletOracleAssetInfo>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
+      assetsInfo: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<PalletOracleAssetInfo>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
       /**
        * Mapping Controller key to signer key
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-tx.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-tx.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import type { ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsAuctionAuctionStepFunction, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletDemocracyConviction, PalletDemocracyVoteAccountVote, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, XcmVersionedMultiAsset } from '@composable/types/interfaces/default';
+import type { ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletDemocracyConviction, PalletDemocracyVoteAccountVote, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, XcmVersionedMultiAsset } from '@composable/types/interfaces/default';
 import type { ApiTypes } from '@polkadot/api-base/types';
 import type { Data } from '@polkadot/types';
 import type { Bytes, Compact, Option, U8aFixed, Vec, WrapperKeepOpaque, bool, u128, u16, u32, u64, u8 } from '@polkadot/types-codec';
@@ -881,7 +881,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * sell `order` in auction with `configuration`
        * some deposit is taken for storing sell order
        **/
-      ask: AugmentedSubmittable<(order: ComposableTraitsDefiSell | { pair?: any; take?: any } | string | Uint8Array, configuration: ComposableTraitsAuctionAuctionStepFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSell, ComposableTraitsAuctionAuctionStepFunction]>;
+      ask: AugmentedSubmittable<(order: ComposableTraitsDefiSell | { pair?: any; take?: any } | string | Uint8Array, configuration: ComposableTraitsTimeTimeReleaseFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSell, ComposableTraitsTimeTimeReleaseFunction]>;
       /**
        * allows to remove `order_id` from storage
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsAuctionAuctionStepFunction, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundStatus, CumulusPalletXcmpQueueOutboundStatus, CumulusPalletXcmpQueueQueueConfigData, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsReward, PalletDemocracyConviction, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOraclePrice, PalletOracleWithdraw, PalletSchedulerReleases, PalletSchedulerScheduledV2, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotParachainPrimitivesXcmpMessageFormat, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public, XcmVersionedMultiAsset } from '@composable/types/interfaces/default';
+import type { ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsAuctionAuctionStepFunction, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundStatus, CumulusPalletXcmpQueueOutboundStatus, CumulusPalletXcmpQueueQueueConfigData, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsReward, PalletDemocracyConviction, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOraclePrice, PalletOracleWithdraw, PalletSchedulerReleases, PalletSchedulerScheduledV2, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotParachainPrimitivesXcmpMessageFormat, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public, XcmVersionedMultiAsset } from '@composable/types/interfaces/default';
 import type { Data, StorageKey } from '@polkadot/types';
 import type { BitVec, Bool, Bytes, I128, I16, I256, I32, I64, I8, Json, Null, Raw, Text, Type, U128, U16, U256, U32, U64, U8, USize, bool, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types-codec';
 import type { AssetApproval, AssetApprovalKey, AssetBalance, AssetDestroyWitness, AssetDetails, AssetMetadata, TAssetBalance, TAssetDepositBalance } from '@polkadot/types/interfaces/assets';
@@ -19,7 +19,7 @@ import type { StatementKind } from '@polkadot/types/interfaces/claims';
 import type { CollectiveOrigin, MemberCount, ProposalIndex, Votes, VotesTo230 } from '@polkadot/types/interfaces/collective';
 import type { AuthorityId, RawVRFOutput } from '@polkadot/types/interfaces/consensus';
 import type { AliveContractInfo, CodeHash, ContractCallFlags, ContractCallRequest, ContractExecResult, ContractExecResultErr, ContractExecResultErrModule, ContractExecResultOk, ContractExecResultResult, ContractExecResultSuccessTo255, ContractExecResultSuccessTo260, ContractExecResultTo255, ContractExecResultTo260, ContractExecResultTo267, ContractInfo, ContractInstantiateResult, ContractInstantiateResultTo267, ContractReturnFlags, ContractStorageKey, DeletedContract, ExecReturnValue, Gas, HostFnWeights, HostFnWeightsTo264, InstantiateRequest, InstantiateReturnValue, InstantiateReturnValueTo267, InstructionWeights, Limits, LimitsTo264, PrefabWasmModule, RentProjection, Schedule, ScheduleTo212, ScheduleTo258, ScheduleTo264, SeedOf, StorageDeposit, TombstoneContractInfo, TrieId } from '@polkadot/types/interfaces/contracts';
-import type { ContractConstructorSpecLatest, ContractConstructorSpecV0, ContractConstructorSpecV2, ContractContractSpecV0, ContractContractSpecV2, ContractCryptoHasher, ContractDiscriminant, ContractDisplayName, ContractEventParamSpecLatest, ContractEventParamSpecV0, ContractEventParamSpecV2, ContractEventSpecLatest, ContractEventSpecV0, ContractEventSpecV2, ContractLayoutArray, ContractLayoutCell, ContractLayoutEnum, ContractLayoutHash, ContractLayoutHashingStrategy, ContractLayoutKey, ContractLayoutStruct, ContractLayoutStructField, ContractMessageParamSpecLatest, ContractMessageParamSpecV0, ContractMessageParamSpecV2, ContractMessageSpecLatest, ContractMessageSpecV0, ContractMessageSpecV2, ContractMetadata, ContractMetadataLatest, ContractMetadataV0, ContractMetadataV1, ContractMetadataV2, ContractProject, ContractProjectContract, ContractProjectInfo, ContractProjectSource, ContractProjectV0, ContractSelector, ContractStorageLayout, ContractTypeSpec } from '@polkadot/types/interfaces/contractsAbi';
+import type { ContractConstructorSpecLatest, ContractConstructorSpecV0, ContractConstructorSpecV1, ContractConstructorSpecV2, ContractConstructorSpecV3, ContractContractSpecV0, ContractContractSpecV1, ContractContractSpecV2, ContractContractSpecV3, ContractCryptoHasher, ContractDiscriminant, ContractDisplayName, ContractEventParamSpecLatest, ContractEventParamSpecV0, ContractEventParamSpecV2, ContractEventSpecLatest, ContractEventSpecV0, ContractEventSpecV1, ContractEventSpecV2, ContractLayoutArray, ContractLayoutCell, ContractLayoutEnum, ContractLayoutHash, ContractLayoutHashingStrategy, ContractLayoutKey, ContractLayoutStruct, ContractLayoutStructField, ContractMessageParamSpecLatest, ContractMessageParamSpecV0, ContractMessageParamSpecV2, ContractMessageSpecLatest, ContractMessageSpecV0, ContractMessageSpecV1, ContractMessageSpecV2, ContractMetadata, ContractMetadataLatest, ContractMetadataV0, ContractMetadataV1, ContractMetadataV2, ContractMetadataV3, ContractProject, ContractProjectContract, ContractProjectInfo, ContractProjectSource, ContractProjectV0, ContractSelector, ContractStorageLayout, ContractTypeSpec } from '@polkadot/types/interfaces/contractsAbi';
 import type { FundIndex, FundInfo, LastContribution, TrieIndex } from '@polkadot/types/interfaces/crowdloan';
 import type { ConfigData, MessageId, OverweightIndex, PageCounter, PageIndexData } from '@polkadot/types/interfaces/cumulus';
 import type { AccountVote, AccountVoteSplit, AccountVoteStandard, Conviction, Delegations, PreimageStatus, PreimageStatusAvailable, PriorLock, PropIndex, Proposal, ProxyState, ReferendumIndex, ReferendumInfo, ReferendumInfoFinished, ReferendumInfoTo239, ReferendumStatus, Tally, Voting, VotingDelegating, VotingDirect, VotingDirectVote } from '@polkadot/types/interfaces/democracy';
@@ -216,6 +216,7 @@ declare module '@polkadot/types/types/registry' {
     ComposableTraitsDefiSell: ComposableTraitsDefiSell;
     ComposableTraitsDefiTake: ComposableTraitsDefiTake;
     ComposableTraitsGovernanceSignedRawOrigin: ComposableTraitsGovernanceSignedRawOrigin;
+    ComposableTraitsTimeTimeReleaseFunction: ComposableTraitsTimeTimeReleaseFunction;
     ComposableTraitsVaultVaultConfig: ComposableTraitsVaultVaultConfig;
     ComposableTraitsVestingVestingSchedule: ComposableTraitsVestingVestingSchedule;
     ConfigData: ConfigData;
@@ -226,9 +227,13 @@ declare module '@polkadot/types/types/registry' {
     ContractCallRequest: ContractCallRequest;
     ContractConstructorSpecLatest: ContractConstructorSpecLatest;
     ContractConstructorSpecV0: ContractConstructorSpecV0;
+    ContractConstructorSpecV1: ContractConstructorSpecV1;
     ContractConstructorSpecV2: ContractConstructorSpecV2;
+    ContractConstructorSpecV3: ContractConstructorSpecV3;
     ContractContractSpecV0: ContractContractSpecV0;
+    ContractContractSpecV1: ContractContractSpecV1;
     ContractContractSpecV2: ContractContractSpecV2;
+    ContractContractSpecV3: ContractContractSpecV3;
     ContractCryptoHasher: ContractCryptoHasher;
     ContractDiscriminant: ContractDiscriminant;
     ContractDisplayName: ContractDisplayName;
@@ -237,6 +242,7 @@ declare module '@polkadot/types/types/registry' {
     ContractEventParamSpecV2: ContractEventParamSpecV2;
     ContractEventSpecLatest: ContractEventSpecLatest;
     ContractEventSpecV0: ContractEventSpecV0;
+    ContractEventSpecV1: ContractEventSpecV1;
     ContractEventSpecV2: ContractEventSpecV2;
     ContractExecResult: ContractExecResult;
     ContractExecResultErr: ContractExecResultErr;
@@ -264,12 +270,14 @@ declare module '@polkadot/types/types/registry' {
     ContractMessageParamSpecV2: ContractMessageParamSpecV2;
     ContractMessageSpecLatest: ContractMessageSpecLatest;
     ContractMessageSpecV0: ContractMessageSpecV0;
+    ContractMessageSpecV1: ContractMessageSpecV1;
     ContractMessageSpecV2: ContractMessageSpecV2;
     ContractMetadata: ContractMetadata;
     ContractMetadataLatest: ContractMetadataLatest;
     ContractMetadataV0: ContractMetadataV0;
     ContractMetadataV1: ContractMetadataV1;
     ContractMetadataV2: ContractMetadataV2;
+    ContractMetadataV3: ContractMetadataV3;
     ContractProject: ContractProject;
     ContractProjectContract: ContractProjectContract;
     ContractProjectInfo: ContractProjectInfo;

--- a/integration-tests/runtime-tests/src/types/interfaces/default/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/default/types.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { Enum, Null } from '@polkadot/types-codec';
+import type { Enum, Null, Struct, u128, u32 } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
 import type { EthereumAccountId } from '@polkadot/types/interfaces/eth';
 import type { EcdsaSignature, MultiSignature } from '@polkadot/types/interfaces/extrinsics';
@@ -28,6 +28,9 @@ export interface ComposableTraitsDefiTake extends Null {}
 
 /** @name ComposableTraitsGovernanceSignedRawOrigin */
 export interface ComposableTraitsGovernanceSignedRawOrigin extends Null {}
+
+/** @name ComposableTraitsTimeTimeReleaseFunction */
+export interface ComposableTraitsTimeTimeReleaseFunction extends Null {}
 
 /** @name ComposableTraitsVaultVaultConfig */
 export interface ComposableTraitsVaultVaultConfig extends Null {}
@@ -147,7 +150,10 @@ export interface PalletOraclePrePrice extends Null {}
 export interface PalletOraclePrice extends Null {}
 
 /** @name PalletOracleWithdraw */
-export interface PalletOracleWithdraw extends Null {}
+export interface PalletOracleWithdraw extends Struct {
+  readonly stake: u128;
+  readonly unlockBlock: u32;
+}
 
 /** @name PalletSchedulerReleases */
 export interface PalletSchedulerReleases extends Null {}

--- a/integration-tests/runtime-tests/src/types/interfaces/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/definitions.ts
@@ -27,7 +27,10 @@ export default {
     PalletIdentityRegistration: "Null",
     PalletIdentityRegistrarInfo: "Null",
     PalletOracleAssetInfo: "Null",
-    PalletOracleWithdraw: "Null",
+    PalletOracleWithdraw: {
+      stake: 'u128',
+      unlockBlock: 'u32'
+    },
     PalletOraclePrePrice: "Null",
     PalletOraclePrice: "Null",
     PolkadotPrimitivesV1AbridgedHostConfiguration: "Null",
@@ -56,6 +59,7 @@ export default {
     ComposableTraitsDefiSell: "Null",
     ComposableTraitsAuctionAuctionStepFunction: "Null",
     ComposableTraitsDefiTake: "Null",
+    ComposableTraitsTimeTimeReleaseFunction: "Null",
     PalletIdentityJudgement: "Null",
     PalletIdentityBitFlags: "Null",
     PalletIdentityIdentityInfo: "Null",

--- a/integration-tests/runtime-tests/src/utils/polkadotjs.ts
+++ b/integration-tests/runtime-tests/src/utils/polkadotjs.ts
@@ -35,9 +35,9 @@ export function sendUnsignedAndWaitFor<T extends AnyTuple>(
   call: SubmittableExtrinsic<"promise">,
   intendedToFail:boolean
 ): Promise<IEvent<T>> {
-  return new Promise<IEvent<T>>((resolve, reject) => {
+  return new Promise<IEvent<T>>(function (resolve, reject) {
     call
-      .send(res => {
+      .send(function (res) {
         const { dispatchError, status } = res;
         if (dispatchError) {
           if (dispatchError.isModule) {
@@ -49,6 +49,8 @@ export function sendUnsignedAndWaitFor<T extends AnyTuple>(
           }
         }
         if (status.isInBlock || status.isFinalized) {
+          if (res.events.find(e => filter(e.event)) == undefined)
+            return reject(status.toString());
           const event = res.events.find(e => filter(e.event)).event;
           if (filter(event)) {
             resolve(event);
@@ -57,8 +59,8 @@ export function sendUnsignedAndWaitFor<T extends AnyTuple>(
           }
         }
       })
-      .catch((e) => {
-        reject(Error(e.message));
+      .catch(function (e) {
+        reject(Error(e.stack));
       });
   });
 }
@@ -79,9 +81,9 @@ export function sendAndWaitFor<T extends AnyTuple>(
   call: SubmittableExtrinsic<"promise">,
   intendedToFail:boolean
 ): Promise<IEvent<T>> {
-  return new Promise<IEvent<T>>((resolve, reject) => {
+  return new Promise<IEvent<T>>(function (resolve, reject) {
     call
-      .signAndSend(sender, { nonce: -1 }, res => {
+      .signAndSend(sender, { nonce: -1 }, function (res) {
         const { dispatchError, status } = res;
         if (dispatchError) {
           if (dispatchError.isModule) {
@@ -104,6 +106,8 @@ export function sendAndWaitFor<T extends AnyTuple>(
           }
         }
         if (status.isInBlock || status.isFinalized) {
+          if (res.events.find(e => filter(e.event)) == undefined)
+            return reject(status.toString());
           const event = res.events.find(e => filter(e.event)).event;
           if (filter(event)) {
             if (intendedToFail) {
@@ -122,8 +126,8 @@ export function sendAndWaitFor<T extends AnyTuple>(
           }
         }
       })
-      .catch((e) => {
-        reject(Error(e.message));
+      .catch(function (e) {
+        reject(Error(e.stack));
       });
   });
 }

--- a/integration-tests/runtime-tests/src/utils/testSetup.ts
+++ b/integration-tests/runtime-tests/src/utils/testSetup.ts
@@ -12,34 +12,32 @@ global.testSudoCommands = true;
 // ToDo (D. Roth): Read public/private keys from external file to be usable in live environment.
 //       and ability to specify keys using env variables or using run parameters.
 
-exports.mochaHooks = {
-  beforeAll: [async() => {
-    // extract all types from definitions - fast and dirty approach, flatted on 'types'
-    const types = Object.values(definitions).reduce((res, { types }): object => ({ ...res, ...types }), {});
+export async function runBefore() {
+  // extract all types from definitions - fast and dirty approach, flatted on 'types'
+  const types = Object.values(definitions).reduce((res, {types}): object => ({...res, ...types}), {});
 
-    global.endpoint = `ws://${args.h}:${args.p}`;
-    const provider = new WsProvider(global.endpoint);
-    console.debug(`Establishing connection to ${global.endpoint}...`);
-    // async or Promise-returning functions allowed
-    global.api = await ApiPromise.create({ provider, types });
-    global.web3 = new Web3();
+  global.endpoint = `ws://${args.h}:${args.p}`;
+  const provider = new WsProvider(global.endpoint);
+  console.debug(`Establishing connection to ${global.endpoint}...`);
+  // async or Promise-returning functions allowed
+  global.api = await ApiPromise.create({provider, types});
+  global.web3 = new Web3();
 
-    // do something before every test,
-    // then run the next hook in this array
-    global.keyring = new Keyring({type: 'sr25519'});
+  // do something before every test,
+  // then run the next hook in this array
+  global.keyring = new Keyring({type: 'sr25519'});
 
-    if (global.useTestnetWallets === true) {
-      global.walletAlice = global.keyring.addFromUri('//Alice');
-      global.walletBob = global.keyring.addFromUri('//Bob');
-      global.walletCharlie = global.keyring.addFromUri('//Charlie');
-      global.walletDave = global.keyring.addFromUri('//Dave');
-      global.walletEve = global.keyring.addFromUri('//Eve');
-      global.walletFerdie = global.keyring.addFromUri('//Ferdie');
-    }
-    return;
-  }],
-  afterAll: [async() => {
-    global.api.disconnect();
-    process.exit(0);
-  }]
+  if (global.useTestnetWallets === true) {
+    global.walletAlice = global.keyring.addFromUri('//Alice');
+    global.walletBob = global.keyring.addFromUri('//Bob');
+    global.walletCharlie = global.keyring.addFromUri('//Charlie');
+    global.walletDave = global.keyring.addFromUri('//Dave');
+    global.walletEve = global.keyring.addFromUri('//Eve');
+    global.walletFerdie = global.keyring.addFromUri('//Ferdie');
+  }
+  return;
+}
+
+export async function runAfter () {
+    await global.api.disconnect();
 }

--- a/integration-tests/runtime-tests/tsconfig.json
+++ b/integration-tests/runtime-tests/tsconfig.json
@@ -11,6 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "baseUrl": "./",
     "paths":{
       "@composable/*": [


### PR DESCRIPTION
**Greetings**, this PR for the runtime integration-tests contains the following:

1. **Oracle** Extrinsics Runtime Integration Tests
2. **Dependency** reduction & update.
3. **Bugfix**: When polkadotjs.ts received specific error returns, it forwarded them into .isInBlock state & .isFinalized state for successful answers. Leading to undefined objects.
4. **Bugfix**: Mochawesome reporter didn't work, now does. :) The application now reports its results in JSON and HTML. (Example see below)
5. **Bugfix**: The failed tests had no descriptions after the finishing.
6. The tests.ts file now wraps all calls within describe() functions, this way we get nice formatting together with mochawesome.
7. Removed most lambda functions from the code. According to the mocha documentation are lambda (arrow) functions overwriting "this" within their context, which is normally occupied by a special mocha-crafted object. And can therefore cause problems. Reference: https://mochajs.org/#arrow-functions

# In Depth:
## 1. Oracle Extrinsics Runtime Integration Tests
~~As of right now, 67% (4/6) success tests for the extrinsics are integrated. All of them are working, but some might require more result checks.~~ All success tests are implemented, see updates below.

## 2. Dependency reduction & update.
tsconfig-paths: Added!
bluebird: Removed!
Updated:
- ts-node
- typescript
- ramda & @types/ramda
- web3
- @types/node
- @polkadotapi & types
~~I tried to update mocha to v.9 but it stopped finding tests. I found a thread referring to this, but it'd require some restructuring, so I'll come back later to this.~~ See comment below!


## 4. We now have awesome-looking test summaries.
Attached is a screenshot and a link for a live preview.
https://report-example.roth.systems/
Edit: The screenshot can be found here: 
https://report-example.roth.systems/Screenshot%202022-01-20%20at%2016-46-19%20Mochawesome%20Report.png
The image was so big it made the thread hard to read.

Up to date test results, with our latest changes can be found below.

## 5. New Bugs / Problems

~~Since the latest update to the **crowdloan** pallet, the **associate** tests fail. I'll figure out why this happens and provide an update to this thread.
Since the error was so vague (See test report above), I ran the type generator. This didn't solve the problem but leads us to the second point.~~

~~With the newest changes to the **dutchAuction** pallet, the type generator generates a faulty line in **augment-api-tx.ts** for the **ask()** extrinsic. In this context it doesn't know what **ComposableTraitsTimeTimeReleaseFunction** is.
For debug purposes I replaced it with any and the code works. It is just about this item it doesn't know.~~
```typescript
ask: AugmentedSubmittable<(order: ComposableTraitsDefiSell | { pair?: any; take?: any } | string | Uint8Array, configuration: ComposableTraitsTimeTimeReleaseFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSell, ComposableTraitsTimeTimeReleaseFunction]>;
```