### PR TITLE
Added 'std' features to Balances

### DIFF
--- a/frame/crowdloan-rewards/Cargo.toml
+++ b/frame/crowdloan-rewards/Cargo.toml
@@ -23,7 +23,7 @@ libsecp256k1 = { version = "0.7.0", default-features = false, features = [
     "static-context",
 ] }
 hex-literal = "0.3"
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false, features = [ "std" ]}
 
 [dependencies]
 ### Benchmarking
@@ -32,7 +32,7 @@ libsecp256k1 = { version = "0.7.0", default-features = false, optional = true, f
     "hmac",
     "static-context",
 ] }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false, optional = true }
+balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false, features = [ "std" ], optional = true }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-application-crypto = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 

--- a/frame/crowdloan-rewards/Cargo.toml
+++ b/frame/crowdloan-rewards/Cargo.toml
@@ -32,7 +32,6 @@ libsecp256k1 = { version = "0.7.0", default-features = false, optional = true, f
     "hmac",
     "static-context",
 ] }
-balances = { package = "pallet-balances", git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13", default-features = false, features = [ "std" ], optional = true }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 sp-application-crypto = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.13" }
 
@@ -70,7 +69,6 @@ std = [
 runtime-benchmarks = [
     "hex-literal",
     "libsecp256k1",
-    "balances",
     "frame-benchmarking",
     "sp-application-crypto",
     "frame-support/runtime-benchmarks",


### PR DESCRIPTION
Small fix to allow for the crowdloan-rewards pallet to pass tests independently from the rest of the project.
Previously, running `cargo test` from inside the `./frame/crowdloan-rewards` directory would fail and say that Balances needs the `std` feature. Running `cargo test` from the project root would pass because the import of Balances in the main `Cargo.toml` file includes the `std` feature.