### PR TITLE
Inverted Validate trait

### DIFF
--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -6,50 +6,61 @@
 //! # Example
 //! ## Single Validation
 //! ```
-//! pub struct SomeExtrinsicInput;
-//! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
-//! pub struct ValidateSomeExtrinsicInput;
+//! use composable_support::validation::{self, Validate, Validated};
+//! use scale_info::TypeInfo;
 //!
-//! impl Validate<SomeExtrinsicInput, ValidateSomeExtrinsicInput>
-//!     for ValidateSomeExtrinsicInput {
-//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//! pub struct SomeInput;
+//!
+//! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
+//! pub struct ValidateSomeInput;
+//!
+//! impl Validate<SomeInput, ValidateSomeInput>
+//!     for ValidateSomeInput {
+//!     fn validate(input: SomeInput) -> Result<SomeInput, &'static str> {
 //!         // ... validation code
+//!         Ok(input)
 //!     }
 //! }
 //!
-//! pub type CheckSomeCondition = (ValidateSomeExtrinsicInput, validation::Valid);
+//! pub type CheckSomeCondition = (ValidateSomeInput, validation::Valid);
 //!
-//! pub someExtrinsic(input: Validated<SomeExtrinsicInput, CheckSomeCondition>) {
+//! pub fn someExtrinsic(input: Validated<SomeInput, CheckSomeCondition>) {
 //!     // ... extrinsic code
 //! }
 //! ```
 //!
 //! ## Multiple Validations (Up to 3)
 //! ```
-//! pub struct SomeExtrinsicInput;
+//! use composable_support::validation::{self, Validate, Validated};
+//! use scale_info::TypeInfo;
+//!
+//! pub struct SomeInput;
+//!
 //! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
-//! pub struct ValidateSomeExtrinsicInput;
+//! pub struct ValidateSomeInput;
 //!
 //! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
 //! pub struct ValidateAnotherCondition;
 //!
-//! impl Validate<SomeExtrinsicInput, ValidateSomeExtrinsicInput>
-//!     for ValidateSomeExtrinsicInput {
-//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//! impl Validate<SomeInput, ValidateSomeInput>
+//!     for ValidateSomeInput {
+//!     fn validate(input: SomeInput) -> Result<SomeInput, &'static str> {
 //!         // ... validation code
+//!         return Ok(input)
 //!     }
 //! }
 //!
-//! impl Validate<SomeExtrinsicInput, ValidateAnotherCondition>
+//! impl Validate<SomeInput, ValidateAnotherCondition>
 //!     for ValidateAnotherCondition {
-//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//!     fn validate(input: SomeInput) -> Result<SomeInput, &'static str> {
 //!         // ... validation code
+//!         return Ok(input)
 //!     }
 //! }
 //!
-//! pub type CheckSomeConditions = (ValidateSomeExtrinsicInput, ValidateAnotherCondition, validation::Valid);
+//! pub type CheckSomeConditions = (ValidateSomeInput, ValidateAnotherCondition, validation::Valid);
 //!
-//! pub someExtrinsic(input: Validated<SomeExtrinsicInput, CheckSomeConditions>) {
+//! pub fn someExtrinsic(input: Validated<SomeInput, CheckSomeConditions>) {
 //!     // ... extrinsic code
 //! }
 //! ```

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -106,7 +106,7 @@ pub struct Invalid;
 
 impl<T> Validate<T, Invalid> for Invalid {
 	#[inline(always)]
-	fn validate(_extinsic_input: T) -> Result<T, &'static str> {
+	fn validate(_input: T) -> Result<T, &'static str> {
 		Err("not valid")
 	}
 }
@@ -125,8 +125,8 @@ where
 {
 	#[inline(always)]
 	fn validate(input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(input)?;
-		let value = <V as Validate<T, V>>::validate(value)?;
+		let value = U::validate(input)?;
+		let value = V::validate(value)?;
 		Ok(value)
 	}
 }
@@ -142,9 +142,9 @@ where
 {
 	#[inline(always)]
 	fn validate(input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(input)?;
-		let value = <V as Validate<T, V>>::validate(value)?;
-		let value = <W as Validate<T, W>>::validate(value)?;
+		let value = U::validate(input)?;
+		let value = V::validate(value)?;
+		let value = W::validate(value)?;
 		Ok(value)
 	}
 }
@@ -158,10 +158,10 @@ where
 {
 	#[inline(always)]
 	fn validate(input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(input)?;
-		let value = <V as Validate<T, V>>::validate(value)?;
-		let value = <W as Validate<T, W>>::validate(value)?;
-		let value = <Z as Validate<T, Z>>::validate(value)?;
+		let value = U::validate(input)?;
+		let value = V::validate(value)?;
+		let value = W::validate(value)?;
+		let value = Z::validate(value)?;
 		Ok(value)
 	}
 }

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -82,8 +82,6 @@ where
 	U: Validate<T, U>,
 {
 	pub fn new(value: T, _validator_tag: U) -> Result<Self, &'static str> {
-		// Validate::<U>::validate(Self { value, _marker: PhantomData })
-		// Ok(Self { value: Validate::<T, U>::validate(value), _marker: PhantomData })
 		match <U as Validate<T, U>>::validate(value) {
 			Ok(value) => Ok(Self { value, _marker: PhantomData }),
 			Err(e) => Err(e),
@@ -203,11 +201,6 @@ impl<T: codec::Encode + codec::Decode, U: Validate<T, U>> codec::WrapperTypeEnco
 	for Validated<T, U>
 {
 }
-
-// impl<T: codec::Encode + codec::Decode, U: Validate<T, U>> codec::WrapperTypeDecode
-// 	for Validated<T, U>
-// {
-// }
 
 impl<T, U: Validate<T, U>> Validate<T, U> for Validated<T, U> {
 	fn validate(extrinsic_input: T) -> Result<T, &'static str> {

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -53,7 +53,7 @@ impl<T> Validate<T, Valid> for Valid {
 	}
 }
 
-impl<T, U, V> Validate<T, (U, V)> for U
+impl<T, U, V> Validate<T, (U, V)> for (U, V)
 where
 	U: Validate<T, U>,
 	V: Validate<T, V>,
@@ -69,7 +69,7 @@ where
 // as per substrate pattern and existing macroses for similar purposes, they tend to make things
 // flat like `#[impl_trait_for_tuples::impl_for_tuples(30)]`
 // so if we will need more than 3, can consider it
-impl<T, U, V, W> Validate<T, (U, V, W)> for U
+impl<T, U, V, W> Validate<T, (U, V, W)> for (U, V, W)
 where
 	U: Validate<T, U>,
 	V: Validate<T, V>,
@@ -84,7 +84,7 @@ where
 	}
 }
 
-impl<T, U, V, W, Z> Validate<T, (U, V, W, Z)> for U
+impl<T, U, V, W, Z> Validate<T, (U, V, W, Z)> for (U, V, W, Z)
 where
 	U: Validate<T, U>,
 	V: Validate<T, V>,
@@ -220,7 +220,7 @@ mod test {
 		let value = X { a: 10, b: 0xCAFEBABE };
 
 		assert!(
-			<ValidARange as Validate<X, ManyValidatorsTagsFlatInvalid>>::validate(value).is_err()
+			<ManyValidatorsTagsFlatInvalid as Validate<X, ManyValidatorsTagsFlatInvalid>>::validate(value).is_err()
 		);
 	}
 
@@ -228,7 +228,12 @@ mod test {
 	fn flat_validator_multiple_valid() {
 		let value = X { a: 10, b: 0xCAFEBABE };
 
-		assert!(<ValidARange as Validate<X, ManyValidatorsTagsFlatValid>>::validate(value).is_err());
+		assert!(
+			<ManyValidatorsTagsFlatValid as Validate<X, ManyValidatorsTagsFlatValid>>::validate(
+				value
+			)
+			.is_err()
+		);
 	}
 
 	#[test]
@@ -237,8 +242,6 @@ mod test {
 		assert_ok!(value);
 		let value = Validated::new(42, Invalid);
 		assert!(value.is_err());
-		let some_x = X { a: 10, b: 0xCAFEBABE };
-		let value = Validated::new(some_x, ValidARange);
 	}
 
 	#[test]

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -95,7 +95,7 @@ pub trait ValidateDispatch<U>: Sized {
 
 pub trait Validate<T, U> {
 	// use string here because in serde layer there is not dispatch
-	fn validate(extrinsic_input: T) -> Result<T, &'static str>;
+	fn validate(input: T) -> Result<T, &'static str>;
 }
 
 #[derive(Debug, Eq, PartialEq, Default)]
@@ -113,8 +113,8 @@ impl<T> Validate<T, Invalid> for Invalid {
 
 impl<T> Validate<T, Valid> for Valid {
 	#[inline(always)]
-	fn validate(extrinsic_input: T) -> Result<T, &'static str> {
-		Ok(extrinsic_input)
+	fn validate(input: T) -> Result<T, &'static str> {
+		Ok(input)
 	}
 }
 
@@ -124,8 +124,8 @@ where
 	V: Validate<T, V>,
 {
 	#[inline(always)]
-	fn validate(extrinsic_input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(extrinsic_input)?;
+	fn validate(input: T) -> Result<T, &'static str> {
+		let value = <U as Validate<T, U>>::validate(input)?;
 		let value = <V as Validate<T, V>>::validate(value)?;
 		Ok(value)
 	}
@@ -141,8 +141,8 @@ where
 	W: Validate<T, W>,
 {
 	#[inline(always)]
-	fn validate(extrinsic_input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(extrinsic_input)?;
+	fn validate(input: T) -> Result<T, &'static str> {
+		let value = <U as Validate<T, U>>::validate(input)?;
 		let value = <V as Validate<T, V>>::validate(value)?;
 		let value = <W as Validate<T, W>>::validate(value)?;
 		Ok(value)
@@ -157,8 +157,8 @@ where
 	Z: Validate<T, Z>,
 {
 	#[inline(always)]
-	fn validate(extrinsic_input: T) -> Result<T, &'static str> {
-		let value = <U as Validate<T, U>>::validate(extrinsic_input)?;
+	fn validate(input: T) -> Result<T, &'static str> {
+		let value = <U as Validate<T, U>>::validate(input)?;
 		let value = <V as Validate<T, V>>::validate(value)?;
 		let value = <W as Validate<T, W>>::validate(value)?;
 		let value = <Z as Validate<T, Z>>::validate(value)?;
@@ -203,8 +203,8 @@ impl<T: codec::Encode + codec::Decode, U: Validate<T, U>> codec::WrapperTypeEnco
 }
 
 impl<T, U: Validate<T, U>> Validate<T, U> for Validated<T, U> {
-	fn validate(extrinsic_input: T) -> Result<T, &'static str> {
-		<U as Validate<T, U>>::validate(extrinsic_input)
+	fn validate(input: T) -> Result<T, &'static str> {
+		<U as Validate<T, U>>::validate(input)
 	}
 }
 
@@ -239,21 +239,21 @@ mod test {
 	}
 
 	impl Validate<X, ValidARange> for ValidARange {
-		fn validate(extrinsic_input: X) -> Result<X, &'static str> {
-			if extrinsic_input.a > 10 {
+		fn validate(input: X) -> Result<X, &'static str> {
+			if input.a > 10 {
 				Err("Out of range")
 			} else {
-				Ok(extrinsic_input)
+				Ok(input)
 			}
 		}
 	}
 
 	impl Validate<X, ValidBRange> for ValidBRange {
-		fn validate(extrinsic_input: X) -> Result<X, &'static str> {
-			if extrinsic_input.b > 10 {
+		fn validate(input: X) -> Result<X, &'static str> {
+			if input.b > 10 {
 				Err("Out of range")
 			} else {
-				Ok(extrinsic_input)
+				Ok(input)
 			}
 		}
 	}

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -222,7 +222,8 @@ mod test {
 	type CheckARangeTag = (ValidARange, Valid);
 	type CheckBRangeTag = (ValidBRange, Valid);
 	type CheckABRangeTag = (ValidARange, (ValidBRange, Valid));
-	// type ManyValidatorsTagsNested = (ValidARange, (ValidBRange, (Invalid, Valid)));
+	type ManyValidatorsTagsNestedInvalid = (ValidARange, (ValidBRange, (Invalid, Valid)));
+	type ManyValidatorsTagsNestedValid = (ValidARange, (ValidBRange, Valid));
 	type ManyValidatorsTagsFlatInvalid = (ValidARange, ValidBRange, Invalid, Valid);
 	type ManyValidatorsTagsFlatValid = (ValidARange, ValidBRange, Valid);
 	// note: next seems is not supported yet
@@ -257,23 +258,25 @@ mod test {
 		}
 	}
 
-	// #[test]
-	// fn nested_validator() {
-	// 	let valid = X { a: 10, b: 0xCAFEBABE };
-	//
-	// 	assert!(Validate::<X, ManyValidatorsTagsNested>::validate(valid).is_err());
-	// }
-	//
-	// #[test]
-	// fn either_nested_or_flat() {
-	// 	let valid = X { a: 10, b: 0xCAFEBABE };
-	// 	assert_eq!(
-	// 		<ManyValidatorsTagsNested as Validate<X, ManyValidatorsTagsNested>>::validate(
-	// 			valid.clone()
-	// 		),
-	// 		Validate::<X, ManyValidatorsTagsFlat>::validate(valid)
-	// 	);
-	// }
+	#[test]
+	fn nested_validator() {
+		let valid = X { a: 10, b: 0xCAFEBABE };
+		assert!(<ManyValidatorsTagsNestedInvalid as Validate<X, ManyValidatorsTagsNestedInvalid>>::validate(valid).is_err());
+
+		let valid = X { a: 10, b: 10};
+        assert_ok!(<ManyValidatorsTagsNestedValid as Validate<X, ManyValidatorsTagsNestedValid>>::validate(valid));
+	}
+
+	#[test]
+	fn either_nested_or_flat() {
+		let valid = X { a: 10, b: 0xCAFEBABE };
+		assert_eq!(
+			<ManyValidatorsTagsNestedInvalid as Validate<X, ManyValidatorsTagsNestedInvalid>>::validate(
+				valid.clone()
+			),
+			<ManyValidatorsTagsFlatInvalid as Validate<X, ManyValidatorsTagsFlatInvalid>>::validate(valid)
+		);
+	}
 
 	#[test]
 	fn flat_validator_multiple_invalid() {

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -261,10 +261,18 @@ mod test {
 	#[test]
 	fn nested_validator() {
 		let valid = X { a: 10, b: 0xCAFEBABE };
-		assert!(<ManyValidatorsTagsNestedInvalid as Validate<X, ManyValidatorsTagsNestedInvalid>>::validate(valid).is_err());
+		assert!(<ManyValidatorsTagsNestedInvalid as Validate<
+			X,
+			ManyValidatorsTagsNestedInvalid,
+		>>::validate(valid)
+		.is_err());
 
-		let valid = X { a: 10, b: 10};
-        assert_ok!(<ManyValidatorsTagsNestedValid as Validate<X, ManyValidatorsTagsNestedValid>>::validate(valid));
+		let valid = X { a: 10, b: 10 };
+		assert_ok!(
+			<ManyValidatorsTagsNestedValid as Validate<X, ManyValidatorsTagsNestedValid>>::validate(
+				valid
+			)
+		);
 	}
 
 	#[test]

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -1,3 +1,59 @@
+//! Module for validating extrinsic inputs
+//!
+//! This module is made of two main parts that are needed to validate an
+//! extrinsic input, the `Validated` struct and the `Valitate` trait.
+//!
+//! # Example
+//! ## Single Validation
+//! ```
+//! pub struct SomeExtrinsicInput;
+//! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
+//! pub struct ValidateSomeExtrinsicInput;
+//!
+//! impl Validate<SomeExtrinsicInput, ValidateSomeExtrinsicInput>
+//!     for ValidateSomeExtrinsicInput {
+//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//!         // ... validation code
+//!     }
+//! }
+//!
+//! pub type CheckSomeCondition = (ValidateSomeExtrinsicInput, validation::Valid);
+//!
+//! pub someExtrinsic(input: Validated<SomeExtrinsicInput, CheckSomeCondition>) {
+//!     // ... extrinsic code
+//! }
+//! ```
+//!
+//! ## Multiple Validations (Up to 3)
+//! ```
+//! pub struct SomeExtrinsicInput;
+//! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
+//! pub struct ValidateSomeExtrinsicInput;
+//!
+//! #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
+//! pub struct ValidateAnotherCondition;
+//!
+//! impl Validate<SomeExtrinsicInput, ValidateSomeExtrinsicInput>
+//!     for ValidateSomeExtrinsicInput {
+//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//!         // ... validation code
+//!     }
+//! }
+//!
+//! impl Validate<SomeExtrinsicInput, ValidateAnotherCondition>
+//!     for ValidateAnotherCondition {
+//!     fn validate(input: SomeExtrinsicInput) -> Result<SomeExtrinsicInput, &'static str> {
+//!         // ... validation code
+//!     }
+//! }
+//!
+//! pub type CheckSomeConditions = (ValidateSomeExtrinsicInput, ValidateAnotherCondition, validation::Valid);
+//!
+//! pub someExtrinsic(input: Validated<SomeExtrinsicInput, CheckSomeConditions>) {
+//!     // ... extrinsic code
+//! }
+//! ```
+
 use core::marker::PhantomData;
 use scale_info::TypeInfo;
 use sp_runtime::DispatchError;

--- a/frame/composable-traits/src/lending/math.rs
+++ b/frame/composable-traits/src/lending/math.rs
@@ -24,7 +24,7 @@ pub fn calc_utilization_ratio(
 	borrows: LiftedFixedBalance,
 ) -> Result<Percent, ArithmeticError> {
 	if borrows.is_zero() {
-		return Ok(Percent::zero());
+		return Ok(Percent::zero())
 	}
 
 	let total = cash.safe_add(&borrows)?;
@@ -117,14 +117,12 @@ impl Validate<InterestRateModel, InteresteRateModelIsValid> for InteresteRateMod
 	fn validate(interest_rate_model: InterestRateModel) -> Result<InterestRateModel, &'static str> {
 		const ERROR: &str = "interest rate model is not valid";
 		match interest_rate_model {
-			InterestRateModel::Jump(x) => {
+			InterestRateModel::Jump(x) =>
 				JumpModel::new(x.base_rate, x.jump_rate, x.full_rate, x.target_utilization)
 					.ok_or(ERROR)
-					.map(InterestRateModel::Jump)
-			},
-			InterestRateModel::Curve(x) => {
-				CurveModel::new(x.base_rate).ok_or(ERROR).map(InterestRateModel::Curve)
-			},
+					.map(InterestRateModel::Jump),
+			InterestRateModel::Curve(x) =>
+				CurveModel::new(x.base_rate).ok_or(ERROR).map(InterestRateModel::Curve),
 			InterestRateModel::DynamicPIDController(x) => DynamicPIDControllerModel::new(
 				x.proportional_parameter,
 				x.integral_parameter,
@@ -148,12 +146,10 @@ impl InterestRate for InterestRateModel {
 		match self {
 			Self::Jump(jump) => jump.get_borrow_rate(utilization),
 			Self::Curve(curve) => curve.get_borrow_rate(utilization),
-			Self::DynamicPIDController(dynamic_pid_model) => {
-				dynamic_pid_model.get_borrow_rate(utilization)
-			},
-			Self::DoubleExponent(double_exponents_model) => {
-				double_exponents_model.get_borrow_rate(utilization)
-			},
+			Self::DynamicPIDController(dynamic_pid_model) =>
+				dynamic_pid_model.get_borrow_rate(utilization),
+			Self::DoubleExponent(double_exponents_model) =>
+				double_exponents_model.get_borrow_rate(utilization),
 		}
 	}
 }
@@ -189,11 +185,11 @@ impl JumpModel {
 		full_rate: ZeroToOneFixedU128,
 		target_utilization: Percent,
 	) -> Option<JumpModel> {
-		if base_rate <= Self::MAX_BASE_RATE
-			&& jump_rate <= Self::MAX_JUMP_RATE
-			&& full_rate <= Self::MAX_FULL_RATE
-			&& base_rate <= jump_rate
-			&& jump_rate <= full_rate
+		if base_rate <= Self::MAX_BASE_RATE &&
+			jump_rate <= Self::MAX_JUMP_RATE &&
+			full_rate <= Self::MAX_FULL_RATE &&
+			base_rate <= jump_rate &&
+			jump_rate <= full_rate
 		{
 			let model = Self { base_rate, jump_rate, full_rate, target_utilization };
 			Some(model)
@@ -301,8 +297,8 @@ impl DynamicPIDControllerModel {
 		utilization_ratio: FixedU128,
 	) -> Result<Rate, ArithmeticError> {
 		// compute error term `et = uo - ut`
-		let et: i128 = self.target_utilization.into_inner().try_into().unwrap_or(0_i128)
-			- utilization_ratio.into_inner().try_into().unwrap_or(0_i128);
+		let et: i128 = self.target_utilization.into_inner().try_into().unwrap_or(0_i128) -
+			utilization_ratio.into_inner().try_into().unwrap_or(0_i128);
 		let et: FixedI128 = FixedI128::from_inner(et);
 		// compute proportional term `pt = kp * et`
 		let pt = self.proportional_parameter.checked_mul(&et).ok_or(ArithmeticError::Overflow)?;
@@ -366,7 +362,7 @@ impl InterestRate for DynamicPIDControllerModel {
 		// const NINE: usize = 9;
 		let utilization: Rate = utilization.into();
 		if let Ok(interest_rate) = Self::get_output_utilization_ratio(self, utilization) {
-			return Some(interest_rate);
+			return Some(interest_rate)
 		}
 		None
 	}
@@ -390,7 +386,7 @@ impl DoubleExponentModel {
 	pub fn new(coefficients: [u8; 16]) -> Option<Self> {
 		let sum_of_coefficients = coefficients.iter().fold(0_u16, |acc, &c| acc + c as u16);
 		if sum_of_coefficients == EXPECTED_COEFFICIENTS_SUM {
-			return Some(DoubleExponentModel { coefficients });
+			return Some(DoubleExponentModel { coefficients })
 		}
 		None
 	}

--- a/frame/composable-traits/src/lending/math.rs
+++ b/frame/composable-traits/src/lending/math.rs
@@ -24,7 +24,7 @@ pub fn calc_utilization_ratio(
 	borrows: LiftedFixedBalance,
 ) -> Result<Percent, ArithmeticError> {
 	if borrows.is_zero() {
-		return Ok(Percent::zero())
+		return Ok(Percent::zero());
 	}
 
 	let total = cash.safe_add(&borrows)?;
@@ -113,16 +113,18 @@ impl InterestRateModel {
 }
 
 pub struct InteresteRateModelIsValid;
-impl Validate<InteresteRateModelIsValid> for InterestRateModel {
-	fn validate(self) -> Result<Self, &'static str> {
+impl Validate<InterestRateModel, InteresteRateModelIsValid> for InteresteRateModelIsValid {
+	fn validate(interest_rate_model: InterestRateModel) -> Result<InterestRateModel, &'static str> {
 		const ERROR: &str = "interest rate model is not valid";
-		match self {
-			InterestRateModel::Jump(x) =>
+		match interest_rate_model {
+			InterestRateModel::Jump(x) => {
 				JumpModel::new(x.base_rate, x.jump_rate, x.full_rate, x.target_utilization)
 					.ok_or(ERROR)
-					.map(InterestRateModel::Jump),
-			InterestRateModel::Curve(x) =>
-				CurveModel::new(x.base_rate).ok_or(ERROR).map(InterestRateModel::Curve),
+					.map(InterestRateModel::Jump)
+			},
+			InterestRateModel::Curve(x) => {
+				CurveModel::new(x.base_rate).ok_or(ERROR).map(InterestRateModel::Curve)
+			},
 			InterestRateModel::DynamicPIDController(x) => DynamicPIDControllerModel::new(
 				x.proportional_parameter,
 				x.integral_parameter,
@@ -146,10 +148,12 @@ impl InterestRate for InterestRateModel {
 		match self {
 			Self::Jump(jump) => jump.get_borrow_rate(utilization),
 			Self::Curve(curve) => curve.get_borrow_rate(utilization),
-			Self::DynamicPIDController(dynamic_pid_model) =>
-				dynamic_pid_model.get_borrow_rate(utilization),
-			Self::DoubleExponent(double_exponents_model) =>
-				double_exponents_model.get_borrow_rate(utilization),
+			Self::DynamicPIDController(dynamic_pid_model) => {
+				dynamic_pid_model.get_borrow_rate(utilization)
+			},
+			Self::DoubleExponent(double_exponents_model) => {
+				double_exponents_model.get_borrow_rate(utilization)
+			},
 		}
 	}
 }
@@ -185,11 +189,11 @@ impl JumpModel {
 		full_rate: ZeroToOneFixedU128,
 		target_utilization: Percent,
 	) -> Option<JumpModel> {
-		if base_rate <= Self::MAX_BASE_RATE &&
-			jump_rate <= Self::MAX_JUMP_RATE &&
-			full_rate <= Self::MAX_FULL_RATE &&
-			base_rate <= jump_rate &&
-			jump_rate <= full_rate
+		if base_rate <= Self::MAX_BASE_RATE
+			&& jump_rate <= Self::MAX_JUMP_RATE
+			&& full_rate <= Self::MAX_FULL_RATE
+			&& base_rate <= jump_rate
+			&& jump_rate <= full_rate
 		{
 			let model = Self { base_rate, jump_rate, full_rate, target_utilization };
 			Some(model)
@@ -297,8 +301,8 @@ impl DynamicPIDControllerModel {
 		utilization_ratio: FixedU128,
 	) -> Result<Rate, ArithmeticError> {
 		// compute error term `et = uo - ut`
-		let et: i128 = self.target_utilization.into_inner().try_into().unwrap_or(0_i128) -
-			utilization_ratio.into_inner().try_into().unwrap_or(0_i128);
+		let et: i128 = self.target_utilization.into_inner().try_into().unwrap_or(0_i128)
+			- utilization_ratio.into_inner().try_into().unwrap_or(0_i128);
 		let et: FixedI128 = FixedI128::from_inner(et);
 		// compute proportional term `pt = kp * et`
 		let pt = self.proportional_parameter.checked_mul(&et).ok_or(ArithmeticError::Overflow)?;
@@ -362,7 +366,7 @@ impl InterestRate for DynamicPIDControllerModel {
 		// const NINE: usize = 9;
 		let utilization: Rate = utilization.into();
 		if let Ok(interest_rate) = Self::get_output_utilization_ratio(self, utilization) {
-			return Some(interest_rate)
+			return Some(interest_rate);
 		}
 		None
 	}
@@ -386,7 +390,7 @@ impl DoubleExponentModel {
 	pub fn new(coefficients: [u8; 16]) -> Option<Self> {
 		let sum_of_coefficients = coefficients.iter().fold(0_u16, |acc, &c| acc + c as u16);
 		if sum_of_coefficients == EXPECTED_COEFFICIENTS_SUM {
-			return Some(DoubleExponentModel { coefficients })
+			return Some(DoubleExponentModel { coefficients });
 		}
 		None
 	}

--- a/frame/composable-traits/src/lending/mod.rs
+++ b/frame/composable-traits/src/lending/mod.rs
@@ -54,7 +54,7 @@ impl<LiquidationStrategyId, Asset: Eq>
 		create_input: CreateInput<LiquidationStrategyId, Asset>,
 	) -> Result<CreateInput<LiquidationStrategyId, Asset>, &'static str> {
 		if create_input.updatable.collateral_factor < MoreThanOneFixedU128::one() {
-			return Err("collateral factor must be >= 1");
+			return Err("collateral factor must be >= 1")
 		}
 
 		let interest_rate_model = <InteresteRateModelIsValid as Validate<

--- a/frame/composable-traits/src/lending/mod.rs
+++ b/frame/composable-traits/src/lending/mod.rs
@@ -47,29 +47,39 @@ pub struct MarketModelValid;
 #[derive(Clone, Copy, Debug, PartialEq, TypeInfo)]
 pub struct CurrencyPairIsNotSame;
 
-impl<LiquidationStrategyId, Asset: Eq> Validate<MarketModelValid>
-	for CreateInput<LiquidationStrategyId, Asset>
+impl<LiquidationStrategyId, Asset: Eq>
+	Validate<CreateInput<LiquidationStrategyId, Asset>, MarketModelValid> for MarketModelValid
 {
-	fn validate(self) -> Result<Self, &'static str> {
-		if self.updatable.collateral_factor < MoreThanOneFixedU128::one() {
-			return Err("collateral factor must be >=1")
+	fn validate(
+		create_input: CreateInput<LiquidationStrategyId, Asset>,
+	) -> Result<CreateInput<LiquidationStrategyId, Asset>, &'static str> {
+		if create_input.updatable.collateral_factor < MoreThanOneFixedU128::one() {
+			return Err("collateral factor must be >= 1");
 		}
 
-		let interest_rate_model =
-			Validate::<InteresteRateModelIsValid>::validate(self.updatable.interest_rate_model)?;
+		let interest_rate_model = <InteresteRateModelIsValid as Validate<
+			InterestRateModel,
+			InteresteRateModelIsValid,
+		>>::validate(create_input.updatable.interest_rate_model)?;
 
-		Ok(Self { updatable: UpdateInput { interest_rate_model, ..self.updatable }, ..self })
+		Ok(CreateInput {
+			updatable: UpdateInput { interest_rate_model, ..create_input.updatable },
+			..create_input
+		})
 	}
 }
 
-impl<LiquidationStrategyId, Asset: Eq> Validate<CurrencyPairIsNotSame>
-	for CreateInput<LiquidationStrategyId, Asset>
+impl<LiquidationStrategyId, Asset: Eq>
+	Validate<CreateInput<LiquidationStrategyId, Asset>, CurrencyPairIsNotSame>
+	for CurrencyPairIsNotSame
 {
-	fn validate(self) -> Result<Self, &'static str> {
-		if self.currency_pair.base == self.currency_pair.quote {
+	fn validate(
+		create_input: CreateInput<LiquidationStrategyId, Asset>,
+	) -> Result<CreateInput<LiquidationStrategyId, Asset>, &'static str> {
+		if create_input.currency_pair.base == create_input.currency_pair.quote {
 			Err("currency pair must be different assets")
 		} else {
-			Ok(self)
+			Ok(create_input)
 		}
 	}
 }


### PR DESCRIPTION
These changes invert to `Validate` trait so that instead of `impl Validate<ValidationType> for ExtrinsicInputType` we do `impl Validate<ExtrinsicInputType, ValidationType> for ValidationType.
This will allow us to create validations for types we don't have direct ownership of.

I've also gone ahead and updated existing implementations of `Validate` so that this branch won't fail. @dzmitry-lahoda, please make sure I didn't miss anything in converting these. Thanks.