### PR TITLE
Introduce ControlOrigin

### DIFF
--- a/frame/mosaic/src/lib.rs
+++ b/frame/mosaic/src/lib.rs
@@ -70,6 +70,10 @@ pub mod pallet {
 			+ PartialEq;
 
 		type NetworkId: FullCodec + TypeInfo + Clone + Debug + PartialEq;
+
+		/// Origin capable of setting the relayer. Inteded to be RootOrHalfCouncil, as it is also
+		/// used as the origin capable of stopping attackers.
+		type ControlOrigin: EnsureOrigin<Self::Origin>;
 	}
 
 	#[pallet::pallet]
@@ -254,7 +258,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			relayer: T::AccountId,
 		) -> DispatchResultWithPostInfo {
-			ensure_root(origin)?;
+			T::ControlOrigin::ensure_origin(origin)?;
 			Relayer::<T>::set(Some(StaleRelayer::new(relayer.clone())));
 			Self::deposit_event(Event::RelayerSet { relayer });
 			Ok(().into())
@@ -308,7 +312,7 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// Can also be token governance associated I reckon, as Angular holders should be able
 			// to grant mosaic permission to mint. We'll save that for phase 3.
-			ensure_root(origin)?;
+			T::ControlOrigin::ensure_origin(origin)?;
 			let current_block = <frame_system::Pallet<T>>::block_number();
 
 			AssetsInfo::<T>::mutate(asset_id, |item| {
@@ -549,7 +553,7 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			period: BlockNumberOf<T>,
 		) -> DispatchResultWithPostInfo {
-			ensure_root(origin)?;
+			T::ControlOrigin::ensure_origin(origin)?;
 			ensure!(period > T::MinimumTimeLockPeriod::get(), Error::<T>::BadTimelockPeriod);
 			TimeLockPeriod::<T>::set(period);
 			Ok(().into())

--- a/frame/mosaic/src/mock.rs
+++ b/frame/mosaic/src/mock.rs
@@ -13,6 +13,7 @@ use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
 };
+use system::EnsureRoot;
 
 pub type AccountId = u128;
 pub type BlockNumber = u64;

--- a/frame/mosaic/src/mock.rs
+++ b/frame/mosaic/src/mock.rs
@@ -105,6 +105,7 @@ impl pallet_mosaic::Config for Test {
 	type BudgetPenaltyDecayer = pallet_mosaic::BudgetPenaltyDecayer<Balance, BlockNumber>;
 
 	type NetworkId = NetworkId;
+	type ControlOrigin = EnsureRoot<Self::AccountId>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -860,7 +860,7 @@ impl dutch_auction::Config for Runtime {
 }
 
 parameter_types! {
-  pub const MosaicId: PalletId = PalletId(*b"plmosaic");
+	  pub const MosaicId: PalletId = PalletId(*b"plmosaic");
 	pub const MinimumTTL: BlockNumber = 10;
 	pub const MinimumTimeLockPeriod: BlockNumber = 20;
 }
@@ -873,6 +873,7 @@ impl mosaic::Config for Runtime {
 	type MinimumTimeLockPeriod = MinimumTimeLockPeriod;
 	type BudgetPenaltyDecayer = mosaic::BudgetPenaltyDecayer<Balance, BlockNumber>;
 	type NetworkId = u32;
+	type ControlOrigin = EnsureRootOrHalfCouncil;
 }
 
 construct_runtime!(


### PR DESCRIPTION
Makes it so that the origin capable of admin operations for Mosaic is configurable, and sets it in Dali to be `RootOrHalfCouncil`.