### PR TITLE
CU-24fwjma Add support of polkadot-v0.9.16 in pallet-oracle

### DIFF
--- a/frame/oracle/src/mock.rs
+++ b/frame/oracle/src/mock.rs
@@ -1,6 +1,8 @@
 use crate as pallet_oracle;
 use crate::*;
-use frame_support::{ord_parameter_types, parameter_types, traits::Everything};
+use frame_support::{
+	ord_parameter_types, pallet_prelude::ConstU32, parameter_types, traits::Everything,
+};
 use frame_system as system;
 use frame_system::EnsureSignedBy;
 use sp_core::{sr25519::Signature, H256};
@@ -56,6 +58,7 @@ impl system::Config for Test {
 	type SystemWeightInfo = ();
 	type SS58Prefix = SS58Prefix;
 	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
 }
 
 parameter_types! {
@@ -81,6 +84,7 @@ parameter_types! {
 	pub const MaxAnswerBound: u32 = 5;
 	pub const MaxAssetsCount: u32 = 2;
 	pub const MaxHistory: u32 = 3;
+	pub const MaxPrePrices: u32 = 12;
 }
 
 ord_parameter_types! {
@@ -130,6 +134,7 @@ impl pallet_oracle::Config for Test {
 	type MaxAnswerBound = MaxAnswerBound;
 	type MaxAssetsCount = MaxAssetsCount;
 	type MaxHistory = MaxHistory;
+	type MaxPrePrices = MaxPrePrices;
 	type WeightInfo = ();
 	type LocalAssets = ();
 }
@@ -139,7 +144,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = system::GenesisConfig::default().build_storage::<Test>().unwrap();
 	let genesis = pallet_balances::GenesisConfig::<Test> {
 		balances: vec![
-			(Default::default(), 100),
+			(get_account_1(), 100),
 			(get_account_2(), 100),
 			(get_account_4(), 100),
 			(get_account_5(), 100),
@@ -147,6 +152,18 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 	};
 	genesis.assimilate_storage(&mut t).unwrap();
 	t.into()
+}
+
+pub fn get_account_1() -> AccountId {
+	const PHRASE: &str =
+		"elite reward rabbit exotic course desk miracle involve old surface educate direct";
+	let keystore = KeyStore::new();
+	SyncCryptoStore::sr25519_generate_new(
+		&keystore,
+		crate::crypto::Public::ID,
+		Some(&format!("{}/hunter1", PHRASE)),
+	)
+	.unwrap()
 }
 
 pub fn get_account_2() -> AccountId {

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -421,6 +421,7 @@ parameter_types! {
 	pub const MaxAnswerBound: u32 = 25;
 	pub const MaxAssetsCount: u32 = 100_000;
 	pub const MaxHistory: u32 = 20;
+	pub const MaxPrePrices: u32 = 40;
 }
 
 impl oracle::Config for Runtime {
@@ -436,6 +437,7 @@ impl oracle::Config for Runtime {
 	type MaxAnswerBound = MaxAnswerBound;
 	type MaxAssetsCount = MaxAssetsCount;
 	type MaxHistory = MaxHistory;
+	type MaxPrePrices = MaxPrePrices;
 	type WeightInfo = weights::oracle::WeightInfo<Runtime>;
 	type LocalAssets = Factory;
 }


### PR DESCRIPTION
```
$ cargo test
    Finished test [unoptimized + debuginfo] target(s) in 0.54s

running 27 tests
test mock::__construct_runtime_integrity_test::runtime_integrity_tests ... ok
test tests::inverses ... ok
test tests::knows_how_to_mock_several_http_calls ... ok
test tests::check_request - should panic ... ok
test tests::is_requested ... ok
test tests::add_stake ... ok
test tests::get_twap ... ok
test tests::add_price ... ok
test tests::parse_price_works ... ok
test tests::not_check_request ... ok
test tests::medianize_price ... ok
test tests::historic_pricing ... ok
test tests::price_of_amount ... ok
test tests::on_init_over_max_answers ... ok
test tests::on_init ... ok
test tests::on_init_prune_scenerios ... ok
test tests::prune_old_pre_prices_edgecase ... ok
test tests::ratio_base_is_way_less_smaller ... ok
test tests::ratio_human_case ... ok
test tests::should_make_http_call_and_parse_result ... ok
test tests::add_asset_and_info ... ok
test tests::should_check_oracles_max_answer - should panic ... ok
test tests::should_check_oracles_submitted_price - should panic ... ok
test tests::remove_and_reclaim_stake ... ok
test tests::should_submit_signed_transaction_on_chain ... ok
test tests::set_signer ... ok
test tests::test_payout_slash ... ok

test result: ok. 27 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 4.08s

   Doc-tests pallet-oracle

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```