### PR TITLE
Refactored Validated Traits

### DIFF
--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -65,15 +65,43 @@
 //! }
 //! ```
 
-use core::marker::PhantomData;
+use core::{marker::PhantomData, fmt};
 use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 
 /// Black box that embbed the validated value.
-#[derive(Default, Copy, Clone, PartialEq, Eq, Debug, TypeInfo)]
+#[derive(Default, Copy, Clone)]
 pub struct Validated<T, U> {
 	value: T,
 	_marker: PhantomData<U>,
+}
+
+impl<T, U> TypeInfo for Validated<T, U>
+where T: TypeInfo,
+{
+    type Identity = <T as TypeInfo>::Identity;
+
+    fn type_info() -> scale_info::Type {
+        T::type_info()
+    }
+}
+
+impl<T, U> PartialEq for Validated<T, U>
+where T: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl<T, U> Eq for Validated<T, U> where T: PartialEq + Eq {}
+
+impl<T, U> fmt::Debug for Validated<T, U>
+where T: core::fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
 }
 
 impl<T, U> Validated<T, U>

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -70,10 +70,19 @@ use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 
 /// Black box that embbed the validated value.
-#[derive(Default, Copy, Clone)]
+#[derive(Copy, Clone)]
 pub struct Validated<T, U> {
 	value: T,
 	_marker: PhantomData<U>,
+}
+
+impl <T, U> Default for Validated<T, U>
+where
+    T: Default
+{
+    fn default() -> Self {
+        Validated { value: T::default(), _marker: PhantomData }
+    }
 }
 
 impl<T, U> TypeInfo for Validated<T, U>

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -65,7 +65,7 @@
 //! }
 //! ```
 
-use core::{marker::PhantomData, fmt};
+use core::{fmt, marker::PhantomData};
 use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 
@@ -77,31 +77,34 @@ pub struct Validated<T, U> {
 }
 
 impl<T, U> TypeInfo for Validated<T, U>
-where T: TypeInfo,
+where
+	T: TypeInfo,
 {
-    type Identity = <T as TypeInfo>::Identity;
+	type Identity = <T as TypeInfo>::Identity;
 
-    fn type_info() -> scale_info::Type {
-        T::type_info()
-    }
+	fn type_info() -> scale_info::Type {
+		T::type_info()
+	}
 }
 
 impl<T, U> PartialEq for Validated<T, U>
-where T: PartialEq,
+where
+	T: PartialEq,
 {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
+	fn eq(&self, other: &Self) -> bool {
+		self.value == other.value
+	}
 }
 
 impl<T, U> Eq for Validated<T, U> where T: PartialEq + Eq {}
 
 impl<T, U> fmt::Debug for Validated<T, U>
-where T: core::fmt::Debug,
+where
+	T: core::fmt::Debug,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.value.fmt(f)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		self.value.fmt(f)
+	}
 }
 
 impl<T, U> Validated<T, U>

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -76,13 +76,13 @@ pub struct Validated<T, U> {
 	_marker: PhantomData<U>,
 }
 
-impl <T, U> Default for Validated<T, U>
+impl<T, U> Default for Validated<T, U>
 where
-    T: Default
+	T: Default,
 {
-    fn default() -> Self {
-        Validated { value: T::default(), _marker: PhantomData }
-    }
+	fn default() -> Self {
+		Validated { value: T::default(), _marker: PhantomData }
+	}
 }
 
 impl<T, U> TypeInfo for Validated<T, U>

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -70,19 +70,10 @@ use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 
 /// Black box that embbed the validated value.
-#[derive(Copy, Clone)]
+#[derive(Default, Copy, Clone)]
 pub struct Validated<T, U> {
 	value: T,
 	_marker: PhantomData<U>,
-}
-
-impl<T, U> Default for Validated<T, U>
-where
-	T: Default,
-{
-	fn default() -> Self {
-		Validated { value: T::default(), _marker: PhantomData }
-	}
 }
 
 impl<T, U> TypeInfo for Validated<T, U>

--- a/frame/composable-support/src/validation.rs
+++ b/frame/composable-support/src/validation.rs
@@ -112,7 +112,7 @@ where
 	Validated<T, U>: Validate<T, U>,
 	U: Validate<T, U>,
 {
-	pub fn new(value: T, _validator_tag: U) -> Result<Self, &'static str> {
+	pub fn new(value: T) -> Result<Self, &'static str> {
 		match <U as Validate<T, U>>::validate(value) {
 			Ok(value) => Ok(Self { value, _marker: PhantomData }),
 			Err(e) => Err(e),
@@ -340,9 +340,9 @@ mod test {
 
 	#[test]
 	fn value() {
-		let value = Validated::new(42, Valid);
+		let value = Validated::<_, Valid>::new(42);
 		assert_ok!(value);
-		let value = Validated::new(42, Invalid);
+		let value = Validated::<_, Invalid>::new(42);
 		assert!(value.is_err());
 	}
 


### PR DESCRIPTION
Explicitly implemented `TypeInfo`, `PartialEq`, `Eq`, and `Debug` for `Validated` and redirected them to `T`'s implementations.

This allows us to create `Validated` structs where `U` and its types do not implement the traits. `derive` would otherwise require that both `T` and `U` would implement these traits.

This has been tested on the CreationDeposit amount in the Vault pallet here https://github.com/ComposableFi/composable/tree/connor/validate-vault-extrinsics/frame/vault/src
See:
validation.rs
lib.rs
tests.rs