### PR TITLE
add initialize_at

### DIFF
--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -109,6 +109,7 @@ pub mod pallet {
 		NothingToClaim,
 		NotAssociated,
 		AlreadyAssociated,
+		NotClaimableYet,
 	}
 
 	#[pallet::config]
@@ -209,8 +210,8 @@ pub mod pallet {
 		#[transactional]
 		pub fn initialize(origin: OriginFor<T>) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
-			ensure!(!VestingBlockStart::<T>::exists(), Error::<T>::AlreadyInitialized);
 			let current_block = frame_system::Pallet::<T>::block_number();
+			ensure!(!VestingBlockStart::<T>::exists(), Error::<T>::AlreadyInitialized);
 			Self::do_initialize(current_block)
 		}
 
@@ -281,6 +282,9 @@ pub mod pallet {
 			reward_account: T::AccountId,
 			proof: ProofOf<T>,
 		) -> DispatchResultWithPostInfo {
+			let now = frame_system::Pallet::<T>::block_number();
+			let enabled = VestingBlockStart::<T>::get().ok_or(Error::<T>::NotInitialized)? <= now;
+			ensure!(enabled, Error::<T>::NotClaimableYet);
 			let remote_account = get_remote_account::<T>(proof, &reward_account, T::Prefix::get())?;
 			// NOTE(hussein-aitlahcen): this is also checked by the signed extension. theoretically
 			// useless, but 1:1 to make it clear
@@ -320,7 +324,10 @@ pub mod pallet {
 			let (total_rewards, total_contributors) = Rewards::<T>::iter_values().fold(
 				(T::Balance::zero(), 0),
 				|(total_rewards, total_contributors), contributor_reward| {
-					(total_rewards + contributor_reward.total, total_contributors + 1)
+					(
+						total_rewards.saturating_add(contributor_reward.total),
+						total_contributors.saturating_add(1),
+					)
 				},
 			);
 			TotalRewards::<T>::set(total_rewards);
@@ -340,14 +347,14 @@ pub mod pallet {
 					.as_mut()
 					.map(|reward| {
 						let should_have_claimed = should_have_claimed::<T>(reward)?;
-						let available_to_claim = should_have_claimed - reward.claimed;
+						let available_to_claim = should_have_claimed.saturating_sub(reward.claimed);
 						ensure!(
 							available_to_claim > T::Balance::zero(),
 							Error::<T>::NothingToClaim
 						);
 						T::Currency::mint_into(reward_account, available_to_claim)?;
-						(*reward).claimed += available_to_claim;
-						ClaimedRewards::<T>::mutate(|x| *x += available_to_claim);
+						(*reward).claimed = available_to_claim.saturating_add(reward.claimed);
+						ClaimedRewards::<T>::mutate(|x| *x = x.saturating_add(available_to_claim));
 						Ok(available_to_claim)
 					})
 					.unwrap_or_else(|| Err(Error::<T>::InvalidProof.into()))
@@ -371,13 +378,14 @@ pub mod pallet {
 		} else {
 			let vesting_step = T::VestingStep::get();
 			// Current window, rounded to previous window.
-			let vesting_window = vesting_point - (vesting_point % vesting_step);
+			let vesting_window = vesting_point.saturating_sub(vesting_point % vesting_step);
 			// The user should have claimed the upfront payment + the vested
 			// amount until this window point.
-			let vested_reward = reward.total - upfront_payment;
-			Ok(upfront_payment +
-				(vested_reward.saturating_mul(T::Convert::convert(vesting_window)) /
-					T::Convert::convert(reward.vesting_period)))
+			let vested_reward = reward.total.saturating_sub(upfront_payment);
+			Ok(upfront_payment.saturating_add(
+				vested_reward.saturating_mul(T::Convert::convert(vesting_window)) /
+					T::Convert::convert(reward.vesting_period),
+			))
 		}
 	}
 

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -473,6 +473,14 @@ pub mod pallet {
 
 		fn validate_unsigned(_source: TransactionSource, call: &Self::Call) -> TransactionValidity {
 			if let Call::associate { reward_account, proof } = call {
+				let now = frame_system::Pallet::<T>::block_number();
+				let enabled = VestingBlockStart::<T>::get()
+					.ok_or(InvalidTransaction::Custom(ValidityError::NotClaimableYet as u8))? <=
+					now;
+				if !enabled {
+					return InvalidTransaction::Custom(ValidityError::NotClaimableYet as u8).into()
+				}
+
 				if Associations::<T>::get(reward_account).is_some() {
 					return InvalidTransaction::Custom(ValidityError::AlreadyAssociated as u8).into()
 				}
@@ -503,5 +511,6 @@ pub mod pallet {
 		InvalidProof = 0,
 		NoReward = 1,
 		AlreadyAssociated = 2,
+		NotClaimableYet = 3,
 	}
 }

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -96,6 +96,15 @@ fn test_initialize_ok() {
 }
 
 #[test]
+fn test_initialize_at_ok() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_ok!(CrowdloanRewards::initialize_at(Origin::root(), 10));
+		assert_eq!(CrowdloanRewards::total_rewards(), 0);
+		assert_eq!(CrowdloanRewards::claimed_rewards(), 0);
+	});
+}
+
+#[test]
 fn test_initialize_once() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(CrowdloanRewards::initialize(Origin::root()));

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -105,6 +105,27 @@ fn test_initialize_at_ok() {
 }
 
 #[test]
+fn test_invalid_early_at_claim() {
+	with_rewards_default(|set_block, accounts| {
+		let current = System::block_number();
+		assert_ok!(CrowdloanRewards::initialize_at(Origin::root(), current + 10));
+
+		for (picasso_account, remote_account) in accounts.clone().into_iter() {
+			assert_noop!(
+				remote_account.associate(picasso_account.clone()),
+				Error::<Test>::NotClaimableYet
+			);
+			assert_noop!(remote_account.claim(picasso_account), Error::<Test>::NotAssociated);
+		}
+
+		set_block(11);
+		for (picasso_account, remote_account) in accounts.clone().into_iter() {
+			assert_ok!(remote_account.associate(picasso_account.clone()),);
+		}
+	});
+}
+
+#[test]
 fn test_initialize_once() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(CrowdloanRewards::initialize(Origin::root()));


### PR DESCRIPTION
Allows the VestingBlockstart to be set at a specific block, which plays a lot nicer with some other pallets in conjunction with `batch` calls.