### PR TITLE
Fix amount_available_to_claim_for RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6509,7 +6509,7 @@ dependencies = [
 [[package]]
 name = "pallet-elections-phragmen"
 version = "5.0.0-dev"
-source = "git+https://github.com/paritytech/substrate.git?branch=polkadot-v0.9.16#4aeb95f7f38fcd519e2628f32f79044a8fef99d5"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.16#4aeb95f7f38fcd519e2628f32f79044a8fef99d5"
 dependencies = [
  "frame-benchmarking",
  "frame-support",

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -372,6 +372,17 @@ pub mod pallet {
 		}
 	}
 
+	/// Returns the amount available to claim for the specified account.
+	pub fn amount_available_to_claim_for<T: Config>(
+		account_id: <T as frame_system::Config>::AccountId,
+	) -> Result<T::Balance, DispatchError> {
+		let association = Associations::<T>::get(account_id).ok_or(Error::<T>::NotAssociated)?;
+		let reward = Rewards::<T>::get(association).ok_or(Error::<T>::NothingToClaim)?;
+		let should_have_claimed = should_have_claimed::<T>(&reward)?;
+		let available_to_claim = should_have_claimed - reward.claimed;
+		Ok(available_to_claim)
+	}
+
 	pub fn get_remote_account<T: Config>(
 		proof: Proof<<T as Config>::RelayChainAccountId>,
 		reward_account: &<T as frame_system::Config>::AccountId,

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -843,13 +843,8 @@ impl_runtime_apis! {
 	impl crowdloan_rewards_runtime_api::CrowdloanRewardsRuntimeApi<Block, AccountId, Balance> for Runtime {
 		fn amount_available_to_claim_for(account_id: AccountId) -> SafeRpcWrapper<Balance> {
 			SafeRpcWrapper(
-			crowdloan_rewards::Associations::<Runtime>::get(account_id)
-				.map(crowdloan_rewards::Rewards::<Runtime>::get)
-				.flatten()
-				.as_ref()
-				.map(crowdloan_rewards::should_have_claimed::<Runtime>)
-				.unwrap_or_else(|| Ok(Balance::zero()))
-				.unwrap_or_else(|_| Balance::zero())
+				crowdloan_rewards::amount_available_to_claim_for::<Runtime>(account_id)
+					.unwrap_or_else(|_| Balance::zero())
 			)
 		}
 	}

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -1093,13 +1093,8 @@ impl_runtime_apis! {
 	impl crowdloan_rewards_runtime_api::CrowdloanRewardsRuntimeApi<Block, AccountId, Balance> for Runtime {
 		fn amount_available_to_claim_for(account_id: AccountId) -> SafeRpcWrapper<Balance> {
 			SafeRpcWrapper (
-			crowdloan_rewards::Associations::<Runtime>::get(account_id)
-				.map(crowdloan_rewards::Rewards::<Runtime>::get)
-				.flatten()
-				.as_ref()
-				.map(crowdloan_rewards::should_have_claimed::<Runtime>)
-				.unwrap_or_else(|| Ok(Balance::zero()))
-				.unwrap_or_else(|_| Balance::zero())
+				crowdloan_rewards::amount_available_to_claim_for::<Runtime>(account_id)
+					.unwrap_or_else(|_| Balance::zero())
 			)
 		}
 	}

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -917,13 +917,8 @@ impl_runtime_apis! {
 	impl crowdloan_rewards_runtime_api::CrowdloanRewardsRuntimeApi<Block, AccountId, Balance> for Runtime {
 		fn amount_available_to_claim_for(account_id: AccountId) -> SafeRpcWrapper<Balance> {
 			SafeRpcWrapper (
-				crowdloan_rewards::Associations::<Runtime>::get(account_id)
-				.map(crowdloan_rewards::Rewards::<Runtime>::get)
-				.flatten()
-				.as_ref()
-				.map(crowdloan_rewards::should_have_claimed::<Runtime>)
-				.unwrap_or_else(|| Ok(Balance::zero()))
-				.unwrap_or_else(|_| Balance::zero())
+				crowdloan_rewards::amount_available_to_claim_for::<Runtime>(account_id)
+					.unwrap_or_else(|_| Balance::zero())
 			)
 		}
 	}


### PR DESCRIPTION
Fixes the `crowdloan_rewards` `amount_available_to_claim_for` RPC to return the amount available to claim, not the amount that should have been claimed.