### PR TITLE
[CU-1ux39mq] Validate vault extrinsics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7245,6 +7245,7 @@ name = "pallet-vault"
 version = "0.0.1"
 dependencies = [
  "bitflags",
+ "composable-support",
  "composable-tests-helpers",
  "composable-traits",
  "frame-benchmarking",

--- a/frame/lending/src/tests.rs
+++ b/frame/lending/src/tests.rs
@@ -6,6 +6,7 @@ use crate::{
 	models::BorrowerData,
 	Error, MarketIndex,
 };
+use composable_support::validation::Validated;
 use composable_tests_helpers::{prop_assert_acceptable_computation_error, prop_assert_ok};
 use composable_traits::{
 	defi::{CurrencyPair, LiftedFixedBalance, MoreThanOneFixedU128, Rate, ZeroToOneFixedU128},
@@ -36,15 +37,13 @@ const INITIAL_BORROW_ASSET_AMOUNT: u128 = 10 ^ 30;
 fn create_simple_vault(
 	asset_id: CurrencyId,
 ) -> (VaultId, VaultInfo<AccountId, Balance, CurrencyId, BlockNumber>) {
-	let v = Vault::do_create_vault(
-		Deposit::Existential,
-		VaultConfig {
-			asset_id,
-			manager: *ALICE,
-			reserved: Perquintill::from_percent(100),
-			strategies: [].iter().cloned().collect(),
-		},
-	);
+	let config = VaultConfig {
+		asset_id,
+		manager: *ALICE,
+		reserved: Perquintill::from_percent(100),
+		strategies: [].iter().cloned().collect(),
+	};
+	let v = Vault::do_create_vault(Deposit::Existential, Validated::new(config).unwrap());
 	assert_ok!(&v);
 	v.expect("unreachable; qed;")
 }

--- a/frame/vault/Cargo.toml
+++ b/frame/vault/Cargo.toml
@@ -27,6 +27,7 @@ sp-core = { default-features = false,  git = "https://github.com/paritytech/subs
 sp-std = { default-features = false,  git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.16" }
 
 composable-traits = {  path = "../composable-traits", default-features = false }
+composable-support = { path = "../composable-support", default-features = false }
 
 log = { version = "0.4.14", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }

--- a/frame/vault/src/benchmarking.rs
+++ b/frame/vault/src/benchmarking.rs
@@ -1,6 +1,7 @@
 use super::*;
 
 use crate::Pallet as Vault;
+use composable_support::validation::Validated;
 use composable_traits::vault::{CapabilityVault, Deposit, Vault as VaultTrait, VaultConfig};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::{
@@ -10,7 +11,6 @@ use frame_support::{
 use frame_system::{EventRecord, Pallet as System, RawOrigin};
 use sp_runtime::Perquintill;
 use sp_std::prelude::*;
-use composable_support::validation::Validated;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::Event) {
 	let events = frame_system::Pallet::<T>::events();
@@ -31,16 +31,13 @@ fn create_vault_extended<T: Config>(
 	reserved: Perquintill,
 	deposit_: Deposit<BalanceOf<T>, BlockNumberOf<T>>,
 ) -> (T::VaultId, VaultInfo<T>) {
-    let config = VaultConfig {
-			asset_id: T::AssetId::from(asset_id),
-			manager: whitelisted_caller(),
-			reserved,
-			strategies: [(strategy_account_id, strategy_share)].iter().cloned().collect(),
-		};
-	let v = Vault::<T>::do_create_vault(
-		deposit_,
-		Validated::new(config).unwrap(),
-	);
+	let config = VaultConfig {
+		asset_id: T::AssetId::from(asset_id),
+		manager: whitelisted_caller(),
+		reserved,
+		strategies: [(strategy_account_id, strategy_share)].iter().cloned().collect(),
+	};
+	let v = Vault::<T>::do_create_vault(deposit_, Validated::new(config).unwrap());
 	assert_ok!(&v);
 	v.expect("unreachable; qed;")
 }

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -41,6 +41,7 @@ mod capabilities;
 pub mod models;
 mod rent;
 mod traits;
+mod validation;
 
 pub use crate::weights::WeightInfo;
 pub use capabilities::Capabilities;
@@ -102,6 +103,9 @@ pub mod pallet {
 		ArithmeticError, DispatchError, FixedPointNumber, Perquintill,
 	};
 	use sp_std::fmt::Debug;
+    use crate::validation::ValidateCreationDeposit;
+    use composable_support::validation::Validated;
+
 	#[allow(missing_docs)]
 	pub type AssetIdOf<T> =
 		<<T as Config>::Currency as Inspect<<T as SystemConfig>::AccountId>>::AssetId;
@@ -531,11 +535,12 @@ pub mod pallet {
 		pub fn add_surcharge(
 			origin: OriginFor<T>,
 			dest: T::VaultId,
-			amount: T::Balance,
+			amount: Validated<BalanceOf<T>, ValidateCreationDeposit<T>>,
 		) -> DispatchResultWithPostInfo {
 			let origin = ensure_signed(origin)?;
 
-			ensure!(amount >= T::CreationDeposit::get(), Error::<T>::InsufficientCreationDeposit);
+			// ensure!(amount >= T::CreationDeposit::get(), Error::<T>::InsufficientCreationDeposit);
+            let amount = amount.value();
 
 			Vaults::<T>::try_mutate_exists(dest, |vault| -> DispatchResultWithPostInfo {
 				let mut vault = vault.as_mut().ok_or(Error::<T>::VaultDoesNotExist)?;

--- a/frame/vault/src/tests.rs
+++ b/frame/vault/src/tests.rs
@@ -26,6 +26,7 @@ use frame_support::{
 };
 use proptest::prelude::*;
 use sp_runtime::{helpers_128bit::multiply_by_rational, FixedPointNumber, Perbill, Perquintill};
+use composable_support::validation::Validated;
 
 const DEFAULT_STRATEGY_SHARE: Perquintill = Perquintill::from_percent(90);
 // dependent on the previous value, both should be changed
@@ -828,7 +829,8 @@ fn test_vault_add_surcharge() {
 		assert!(Balances::balance(&CHARLIE) > 0);
 		let vault = Vaults::vault_data(id).unwrap();
 		assert!(vault.capabilities.is_tombstoned());
-		Vaults::add_surcharge(Origin::signed(ALICE), id, CreationDeposit::get()).unwrap();
+		// Vaults::add_surcharge(Origin::signed(ALICE), id, CreationDeposit::get()).unwrap();
+		Vaults::add_surcharge(Origin::signed(ALICE), id, Validated::new(CreationDeposit::get()).unwrap()).unwrap();
 		let vault = Vaults::vault_data(id).unwrap();
 		assert!(!vault.capabilities.is_tombstoned());
 	})

--- a/frame/vault/src/tests.rs
+++ b/frame/vault/src/tests.rs
@@ -829,7 +829,6 @@ fn test_vault_add_surcharge() {
 		assert!(Balances::balance(&CHARLIE) > 0);
 		let vault = Vaults::vault_data(id).unwrap();
 		assert!(vault.capabilities.is_tombstoned());
-		// Vaults::add_surcharge(Origin::signed(ALICE), id, CreationDeposit::get()).unwrap();
 		Vaults::add_surcharge(
 			Origin::signed(ALICE),
 			id,

--- a/frame/vault/src/validation.rs
+++ b/frame/vault/src/validation.rs
@@ -1,19 +1,39 @@
+use crate::pallet::{BalanceOf, Config};
 use composable_support::validation::Validate;
+use composable_traits::vault::VaultConfig;
 use core::marker::PhantomData;
 use frame_support::traits::Get;
-use crate::pallet::{BalanceOf, Config};
 
 #[derive(Clone, Copy)]
 pub struct ValidateCreationDeposit<T> {
-    _marker: PhantomData<T>,
+	_marker: PhantomData<T>,
+}
+
+#[derive(Clone, Copy)]
+pub struct ValidateMaxStrategies<T> {
+	_marker: PhantomData<T>,
 }
 
 impl<T: Config> Validate<BalanceOf<T>, ValidateCreationDeposit<T>> for ValidateCreationDeposit<T> {
-    fn validate(input: BalanceOf<T>) -> Result<BalanceOf<T>, &'static str> {
-       if input < T::CreationDeposit::get() {
-            return Err("Insufficent Creation Deposit")
-        }
+	fn validate(input: BalanceOf<T>) -> Result<BalanceOf<T>, &'static str> {
+		if input < T::CreationDeposit::get() {
+			return Err("Insufficent Creation Deposit")
+		}
 
-        Ok(input)
-    }
+		Ok(input)
+	}
+}
+
+impl<T: Config> Validate<VaultConfig<T::AccountId, T::AssetId>, ValidateMaxStrategies<T>>
+	for ValidateMaxStrategies<T>
+{
+	fn validate(
+		input: VaultConfig<T::AccountId, T::AssetId>,
+	) -> Result<VaultConfig<T::AccountId, T::AssetId>, &'static str> {
+		if input.strategies.len() > T::MaxStrategies::get() {
+			return Err("Too Many Strategies")
+		}
+
+		Ok(input)
+	}
 }

--- a/frame/vault/src/validation.rs
+++ b/frame/vault/src/validation.rs
@@ -1,0 +1,19 @@
+use composable_support::validation::Validate;
+use core::marker::PhantomData;
+use frame_support::traits::Get;
+use crate::pallet::{BalanceOf, Config};
+
+#[derive(Clone, Copy)]
+pub struct ValidateCreationDeposit<T> {
+    _marker: PhantomData<T>,
+}
+
+impl<T: Config> Validate<BalanceOf<T>, ValidateCreationDeposit<T>> for ValidateCreationDeposit<T> {
+    fn validate(input: BalanceOf<T>) -> Result<BalanceOf<T>, &'static str> {
+       if input < T::CreationDeposit::get() {
+            return Err("Insufficent Creation Deposit")
+        }
+
+        Ok(input)
+    }
+}


### PR DESCRIPTION
Added validation for Creation Deposit and Max Strategies.

Validating any input that was checked against `origin` or anything that was derived from `origin` proved to be more cumbersome than any existing validation.

Be sure to check that I didn't miss any other extrinsic inputs.