### PR TITLE
fix 'liquidation' typos

### DIFF
--- a/frame/lending/README.md
+++ b/frame/lending/README.md
@@ -1,14 +1,12 @@
-
-
 # [Overview](https://app.clickup.com/20465559/v/dc/kghwq-20761/kghwq-3621)
 
 See overview of more bussiness and architectural state of lending and all know features.
 
 ## Technical Reference
 
-Lending = Self + [Liquidations](liqudaitons) + [Oracle](../oracle) + [Vault](../vault) + OCW
+Lending = Self + [Liquidations](liquidations) + [Oracle](../oracle) + [Vault](../vault) + OCW
 
-Market = Isolated Currency Pair  + Configuration. 
+Market = Isolated Currency Pair + Configuration.
 
 Oracle = only Pairs with Prices are allowed.
 
@@ -24,4 +22,4 @@ Lending is executed after Vault. On block initialization. If can withdraw from V
 
 Borrowing is not allowed if we must liquidate (the vault is expecting the strategy to be liquidated) or if we market have enough funds or if have not enough collateral.
 
-When repaying, we do not transfer the amount back to the vault. This is done within the pallet hooks on each block update.. It actually allows to use some deposit asset by other transactions in same block to borrow. 
+When repaying, we do not transfer the amount back to the vault. This is done within the pallet hooks on each block update.. It actually allows to use some deposit asset by other transactions in same block to borrow.

--- a/frame/lending/lending.plantuml
+++ b/frame/lending/lending.plantuml
@@ -3,7 +3,7 @@
   actor Bob as bob
   actor Charlie as charlie
   participant Lending as lending
-  participant Liquidation as liqudation
+  participant Liquidation as liquidation
   control Governance as governance
 
   participant Vault as vault
@@ -37,20 +37,20 @@
 
   ...
 
-  group Liqudaiton (IN PROGRESS)
+  group Liquidation (IN PROGRESS)
     charlie -> lending : Borrow
     ...
     oracle_bot -> oracle : Make collateral factor bad
     lending_bot -> lending : Liquidate Charlie collateral
-    lending -> liqudation: Liquidate
-    liqudation -> sell: Sell via choses strategy
+    lending -> liquidation: Liquidate
+    liquidation -> sell: Sell via choses strategy
     note left
       - default is auction (multiblock)
       - can be DEX or external (XCMP) DEX 
       - XCMP is multi block process
     end note
     ...
-    lending_bot -> lending : Finalize liqudaiton
+    lending_bot -> lending : Finalize liquidation
   end
 
 @enduml

--- a/frame/lending/src/lib.rs
+++ b/frame/lending/src/lib.rs
@@ -290,7 +290,7 @@ pub mod pallet {
 				return
 			}
 			for (market_id, account, _) in DebtIndex::<T>::iter() {
-				// TODO: check that it should liqudate before liqudaitons
+				// TODO: check that it should liquidate before liquidations
 				let results = signer.send_signed_transaction(|_account| Call::liquidate {
 					market_id,
 					borrowers: vec![account.clone()],

--- a/frame/lending/src/tests.rs
+++ b/frame/lending/src/tests.rs
@@ -1,7 +1,7 @@
 //! Test for Lending. Runtime is almost real.
 //! TODO: cover testing events - so make sure that each even is handled at least once
 //! (events can be obtained from System pallet as in banchmarking.rs before this commit)
-//! TODO: OCW of liqudaitons (like in Oracle)
+//! TODO: OCW of liquidations (like in Oracle)
 //! TODO: test on small numbers via proptests - detect edge case what is minimal amounts it starts
 //! to accure(and miminal block delta), and maximal amounts when it overflows
 

--- a/frame/liquidations/README.md
+++ b/frame/liquidations/README.md
@@ -1,12 +1,13 @@
 # Overview
 
-Liquidation uses DEX and auctions for swaps. 
+Liquidation uses DEX and auctions for swaps.
 
-Uses different engines depending on available liquidity and configuration. 
+Uses different engines depending on available liquidity and configuration.
 
-Each liqudaiton strategy parameters can be changed by strategy's owner.
+Each liquidation strategy parameters can be changed by strategy's owner.
 
 Default engine is [Dutch Auction](../dutch-auction)
+
 ## References
 
 https://docs.makerdao.com/smart-contract-modules/dog-and-clipper-detailed-documentation

--- a/frame/liquidations/external-dex-liqudation.sequence.plantuml
+++ b/frame/liquidations/external-dex-liqudation.sequence.plantuml
@@ -3,7 +3,7 @@
 box Composable #LightYellow
   participant "Assets" as pallet_assets
   participant "Lending" as pallet_lending
-  control "OCW Liqudation" as ocw_liquidation
+  control "OCW Liquidation" as ocw_liquidation
 end box
 
 box HydraDx #SkyBlue
@@ -11,9 +11,9 @@ box HydraDx #SkyBlue
   participant "HydraDx Auction" as pauh
 end box
 
-ocw_liquidation -> pallet_lending: Detect liqudate condition
+ocw_liquidation -> pallet_lending: Detect liquidate condition
 
-ocw_liquidation -> pallet_lending: Liqudate
+ocw_liquidation -> pallet_lending: Liquidate
 
 alt OB
   pallet_lending --> pah: XCM sell via 'Transfer' + 'Exchange'

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -119,11 +119,11 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::weight(T::WeightInfo::add_liquidation_strategy())]
-		pub fn add_liqudation_strategy(
+		pub fn add_liquidation_strategy(
 			_origin: OriginFor<T>,
 			_configuraiton: LiquidationStrategyConfiguration<T::ParachainId>,
 		) -> DispatchResultWithPostInfo {
-			Err(DispatchError::Other("add_liqudation_strategy: no implemented").into())
+			Err(DispatchError::Other("add_liquidation_strategy: no implemented").into())
 		}
 	}
 
@@ -187,7 +187,7 @@ pub mod pallet {
 		 * liquidation --> dutch_auction_strategy: Invoke Dispatchable
 		 * dutch_auction_strategy -> dutch_auction_strategy: Get liquidation configuration by id previosly baked into call
 		 * dutch_auction_strategy --> liquidation: Pop next order
-		 * dutch_auction_strategy -> dutch_auction_strategy: Start liqudaiton
+		 * dutch_auction_strategy -> dutch_auction_strategy: Start liquidation
 		 * ```
 		 *Dynamic { liquidate: Dispatch, minimum_price: Balance }, */
 	}

--- a/frame/liquidations/src/tests.rs
+++ b/frame/liquidations/src/tests.rs
@@ -31,7 +31,7 @@ fn successfull_liquidate() {
 }
 
 #[test]
-fn do_not_have_amount_to_liqudate() {
+fn do_not_have_amount_to_liquidate() {
 	new_test_externalities().execute_with(|| {
 		let who = AccountId::from_raw(CHARLIE.0);
 		let amount = 100;


### PR DESCRIPTION
When reading the source code and docs I spotted what I think are a few typos.
Let me know if it would be useful to fix it (or if these aren't typos at all :sweat_smile:)