### PR TITLE
feat(runtimes): filter Tokens and unfilter Balance

### DIFF
--- a/frame/curve-amm/src/benchmarking.rs
+++ b/frame/curve-amm/src/benchmarking.rs
@@ -10,8 +10,8 @@ benchmarks! {
   where_clause { where T::Balance: From<u128>, T::AssetId: From<u128> }
 
   create {
-	  let usdc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let usdc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pair = CurrencyPair::new(usdc, usdt);
 	  let amplification_factor = 100_u16;
@@ -20,8 +20,8 @@ benchmarks! {
   } : _(RawOrigin::Signed(owner), pair, amplification_factor, fee, protocol_fee)
 
   buy {
-	  let usdc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let usdc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pool_id = StableSwap::<T>::do_create_pool(
 		  &owner,
@@ -52,8 +52,8 @@ benchmarks! {
   }: _(RawOrigin::Signed(user), pool_id, usdc, (1000_u128 * unit).into(), false)
 
   sell {
-	  let usdc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let usdc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pool_id = StableSwap::<T>::do_create_pool(
 		  &owner,
@@ -84,8 +84,8 @@ benchmarks! {
   }: _(RawOrigin::Signed(user), pool_id, usdc, (1000_u128 * unit).into(), false)
 
   swap {
-	  let usdc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let usdc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pair = CurrencyPair::new(usdc, usdt);
 	  let pool_id = StableSwap::<T>::do_create_pool(

--- a/frame/uniswap-v2/src/benchmarking.rs
+++ b/frame/uniswap-v2/src/benchmarking.rs
@@ -10,8 +10,8 @@ benchmarks! {
   where_clause { where T::Balance: From<u128>, T::AssetId: From<u128> }
 
   create {
-	  let btc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let btc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pair = CurrencyPair::new(btc, usdt);
 	  let fee = Permill::from_percent(1);
@@ -19,8 +19,8 @@ benchmarks! {
   }: _(RawOrigin::Signed(owner), pair, fee, owner_fee)
 
   buy {
-	  let btc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let btc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pool_id = Uni::<T>::do_create_pool(
 		  &owner,
@@ -53,8 +53,8 @@ benchmarks! {
   }: _(RawOrigin::Signed(user), pool_id, btc, unit.into(), false)
 
   sell {
-	  let btc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let btc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pool_id = Uni::<T>::do_create_pool(
 		  &owner,
@@ -85,8 +85,8 @@ benchmarks! {
   }: _(RawOrigin::Signed(user), pool_id, btc, unit.into(), false)
 
   swap {
-	  let btc: T::AssetId = 0.into();
-	  let usdt: T::AssetId = 1.into();
+	  let btc: T::AssetId = 100.into();
+	  let usdt: T::AssetId = 101.into();
 	  let owner = whitelisted_caller();
 	  let pair = CurrencyPair::new(btc, usdt);
 	  let pool_id = Uni::<T>::do_create_pool(

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -718,10 +718,7 @@ pub struct BaseCallFilter;
 
 impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
-		!matches!(
-			call,
-			Call::Balances(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_)
-		)
+		!matches!(call, Call::Tokens(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_))
 	}
 }
 

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -827,10 +827,7 @@ impl Contains<Call> for BaseCallFilter {
 		if call_filter::Pallet::<Runtime>::contains(call) {
 			return false
 		}
-		!matches!(
-			call,
-			Call::Balances(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_)
-		)
+		!matches!(call, Call::Tokens(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_))
 	}
 }
 
@@ -974,7 +971,7 @@ impl uniswap_v2::Config for Runtime {
 	type AssetId = CurrencyId;
 	type Balance = Balance;
 	type CurrencyFactory = CurrencyFactory;
-	type Assets = Tokens;
+	type Assets = Assets;
 	type Convert = ConvertInto;
 	type PoolId = PoolId;
 	type PalletId = ConstantProductPalletId;
@@ -990,7 +987,7 @@ impl curve_amm::Config for Runtime {
 	type AssetId = CurrencyId;
 	type Balance = Balance;
 	type CurrencyFactory = CurrencyFactory;
-	type Assets = Tokens;
+	type Assets = Assets;
 	type Convert = ConvertInto;
 	type PoolId = PoolId;
 	type PalletId = StableSwapPalletId;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -27,7 +27,7 @@ pub use xcmp::{MaxInstructions, UnitWeightCost};
 use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
 	CouncilInstance, EnsureRootOrHalfCouncil, Hash, MosaicRemoteAssetId, Signature,
-	AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO,
+	AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MINUTES, NORMAL_DISPATCH_RATIO,
 	SLOT_DURATION,
 };
 use composable_support::rpc_helpers::SafeRpcWrapper;
@@ -801,7 +801,7 @@ impl assets::Config for Runtime {
 parameter_types! {
 	  pub const CrowdloanRewardsId: PalletId = PalletId(*b"pal_crow");
 	  pub const InitialPayment: Perbill = Perbill::from_percent(50);
-	  pub const VestingStep: BlockNumber = 7 * DAYS;
+	  pub const VestingStep: BlockNumber = 1 * MINUTES;
 	  pub const Prefix: &'static [u8] = b"picasso-";
 }
 

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -771,10 +771,7 @@ pub struct BaseCallFilter;
 
 impl Contains<Call> for BaseCallFilter {
 	fn contains(call: &Call) -> bool {
-		!matches!(
-			call,
-			Call::Balances(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_)
-		)
+		!matches!(call, Call::Tokens(_) | Call::Indices(_) | Call::Democracy(_) | Call::Treasury(_))
 	}
 }
 


### PR DESCRIPTION
- do not filter balance as filtering this pallet does not result in any benefit (some services might be already based on balances)
- filter tokens as we rely on assets for operations
- faster crowdloan on dali
- use assets instead of tokens for dex and fix benchmarking