### PR TITLE
feat(tests): custom precision for proptests to avoid edge cases

### DIFF
--- a/frame/assets/src/lib.rs
+++ b/frame/assets/src/lib.rs
@@ -350,11 +350,11 @@ pub mod pallet {
 				match T::GovernanceRegistry::get(asset_id) {
 					Ok(SignedRawOrigin::Root) => Ok(()),
 					Ok(SignedRawOrigin::Signed(acc)) if acc == account => Ok(()),
-					_ => Err(DispatchError::BadOrigin.into()),
+					_ => Err(DispatchError::BadOrigin),
 				}
 			},
 			Ok(frame_system::RawOrigin::Root) => Ok(()),
-			_ => Err(DispatchError::BadOrigin.into()),
+			_ => Err(DispatchError::BadOrigin),
 		}
 	}
 

--- a/frame/assets/src/mocks.rs
+++ b/frame/assets/src/mocks.rs
@@ -84,7 +84,6 @@ parameter_types! {
 	pub const MaxLocks: u32 = 256;
 }
 
-
 impl orml_tokens::Config for Test {
 	type Event = Event;
 	type Balance = Balance;

--- a/frame/assets/src/tests/traits.rs
+++ b/frame/assets/src/tests/traits.rs
@@ -399,7 +399,7 @@ mod multicurrency {
 
 				prop_assert_ok!(<Pallet::<Test> as MultiReservableCurrency<AccountId>>::reserve(asset_id, &account, third));
 				prop_assert_eq!(<Pallet::<Test> as MultiCurrency<AccountId>>::free_balance(asset_id,&account),  0);
-				
+
 				let remaining = <Pallet::<Test> as MultiReservableCurrency<AccountId>>::unreserve(asset_id, &account, first);
 				prop_assert_eq!(<Pallet::<Test> as MultiCurrency<AccountId>>::free_balance(asset_id,&account),  first - remaining);
 
@@ -410,7 +410,7 @@ mod multicurrency {
 				let free_balance = <Pallet::<Test> as MultiCurrency<AccountId>>::free_balance(asset_id,&account);
 				let remaining = <Pallet::<Test> as MultiReservableCurrency<AccountId>>::unreserve(asset_id, &account, third);
 				prop_assert_eq!(<Pallet::<Test> as MultiCurrency<AccountId>>::free_balance(asset_id,&account),  free_balance + ( third - remaining));
-				
+
 				prop_assert_ok!(<Pallet::<Test> as MultiLockableCurrency<AccountId>>::set_lock(*b"prelocks", asset_id, &account, first));
 				prop_assert_eq!(<Pallet::<Test> as MultiCurrency<AccountId>>::free_balance(asset_id, &account),  first + second + third);
 

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -242,10 +242,10 @@ proptest! {
 					  // Alice cancel the offer
 					  prop_assert_ok!(BondedFinance::cancel(Origin::signed(ALICE), offer_id));
 
-					  // The remaining half is refunded to alice
-            let precision = 100;
-            let epsilon = 5;
-						prop_assert_acceptable_computation_error!(Tokens::balance(offer.reward.asset, &ALICE), half_reward, precision, epsilon);
+					// The remaining half is refunded to alice
+		  let precision = 100;
+				let epsilon = 5;
+				  prop_assert_acceptable_computation_error!(Tokens::balance(offer.reward.asset, &ALICE), half_reward, precision, epsilon);
 
 					  Ok(())
 			  })?;
@@ -402,8 +402,8 @@ proptest! {
 					  prop_assert_ok!(charlie_reward);
 					  let charlie_reward = charlie_reward.expect("impossible; qed;");
 
-            let precision = 100;
-            let epsilon = 5;
+			let precision = 100;
+			let epsilon = 5;
 					  prop_assert_acceptable_computation_error!(bob_reward, half_reward, precision, epsilon);
 					  prop_assert_acceptable_computation_error!(charlie_reward, half_reward, precision, epsilon);
 

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -243,7 +243,9 @@ proptest! {
 					  prop_assert_ok!(BondedFinance::cancel(Origin::signed(ALICE), offer_id));
 
 					  // The remaining half is refunded to alice
-						prop_assert_acceptable_computation_error!(Tokens::balance(offer.reward.asset, &ALICE), half_reward);
+            let precision = 100;
+            let epsilon = 5;
+						prop_assert_acceptable_computation_error!(Tokens::balance(offer.reward.asset, &ALICE), half_reward, precision, epsilon);
 
 					  Ok(())
 			  })?;
@@ -400,8 +402,10 @@ proptest! {
 					  prop_assert_ok!(charlie_reward);
 					  let charlie_reward = charlie_reward.expect("impossible; qed;");
 
-					  prop_assert_acceptable_computation_error!(bob_reward, half_reward, 3);
-					  prop_assert_acceptable_computation_error!(charlie_reward, half_reward, 3);
+            let precision = 100;
+            let epsilon = 5;
+					  prop_assert_acceptable_computation_error!(bob_reward, half_reward, precision, epsilon);
+					  prop_assert_acceptable_computation_error!(charlie_reward, half_reward, precision, epsilon);
 
 					  prop_assert!(Tokens::can_withdraw(offer.reward.asset, &BOB, bob_reward) == WithdrawConsequence::Frozen);
 					  prop_assert!(Tokens::can_withdraw(offer.reward.asset, &CHARLIE, charlie_reward) == WithdrawConsequence::Frozen);

--- a/frame/composable-tests-helpers/src/test/helper.rs
+++ b/frame/composable-tests-helpers/src/test/helper.rs
@@ -1,13 +1,21 @@
 use sp_runtime::{FixedPointNumber, FixedU128};
 
-/// Default is 0.1%
-pub const DEFAULT_ACCEPTABLE_DEVIATION: u128 = 1000;
+/// Default is percent
+pub const DEFAULT_PRECISION: u128 = 1000;
 
-/// Check that x/y ~ 1 up to a certain precision
-pub fn acceptable_computation_error(x: u128, y: u128, precision: u128) -> Result<(), FixedU128> {
+/// Per mill
+pub const DEFAULT_EPSILON: u128 = 1;
+
+/// This function should be used in context of approximation.
+/// It is extensively used in conjunction with proptest because of random input generation.
+pub fn acceptable_computation_error(
+	x: u128,
+	y: u128,
+	precision: u128,
+	epsilon: u128,
+) -> Result<(), FixedU128> {
 	let delta = i128::abs(x as i128 - y as i128);
 	if delta > 1 {
-		let epsilon: u128 = 1;
 		let lower =
 			FixedU128::saturating_from_rational(precision, precision.saturating_add(epsilon));
 		let upper =
@@ -24,5 +32,5 @@ pub fn acceptable_computation_error(x: u128, y: u128, precision: u128) -> Result
 }
 
 pub fn default_acceptable_computation_error(x: u128, y: u128) -> Result<(), FixedU128> {
-	acceptable_computation_error(x, y, DEFAULT_ACCEPTABLE_DEVIATION)
+	acceptable_computation_error(x, y, DEFAULT_PRECISION, DEFAULT_EPSILON)
 }

--- a/frame/composable-tests-helpers/src/test/proptest.rs
+++ b/frame/composable-tests-helpers/src/test/proptest.rs
@@ -52,7 +52,7 @@ macro_rules! prop_assert_noop {
 macro_rules! prop_assert_acceptable_computation_error {
 	($x:expr, $y:expr, $precision:expr, $epsilon:expr) => {{
 		match composable_tests_helpers::test::helper::acceptable_computation_error(
-			$x, $y, $precision, $epsilon
+			$x, $y, $precision, $epsilon,
 		) {
 			Ok(()) => {},
 			Err(q) => {

--- a/frame/composable-tests-helpers/src/test/proptest.rs
+++ b/frame/composable-tests-helpers/src/test/proptest.rs
@@ -50,9 +50,9 @@ macro_rules! prop_assert_noop {
 /// Accept a `dust` deviation.
 #[macro_export]
 macro_rules! prop_assert_acceptable_computation_error {
-	($x:expr, $y:expr, $precision:expr) => {{
+	($x:expr, $y:expr, $precision:expr, $epsilon:expr) => {{
 		match composable_tests_helpers::test::helper::acceptable_computation_error(
-			$x, $y, $precision,
+			$x, $y, $precision, $epsilon
 		) {
 			Ok(()) => {},
 			Err(q) => {
@@ -64,7 +64,8 @@ macro_rules! prop_assert_acceptable_computation_error {
 		prop_assert_acceptable_computation_error!(
 			$x,
 			$y,
-			composable_tests_helpers::test::helper::DEFAULT_ACCEPTABLE_DEVIATION
+			composable_tests_helpers::test::helper::DEFAULT_PRECISION,
+			composable_tests_helpers::test::helper::DEFAULT_EPSILON
 		);
 	}};
 }

--- a/frame/curve-amm/src/tests.rs
+++ b/frame/curve-amm/src/tests.rs
@@ -83,10 +83,11 @@ fn test() {
 		));
 
 		let precision = 100;
+		let epsilon = 1;
 		// 1 unit of usdc == 1 unit of usdt
 		let ratio = <StableSwap as CurveAmm>::get_exchange_value(pool_id, USDC, unit)
 			.expect("impossible; qed;");
-		assert_ok!(acceptable_computation_error(ratio, unit, precision));
+		assert_ok!(acceptable_computation_error(ratio, unit, precision, epsilon));
 
 		let swap_usdc = 100_u128 * unit;
 		assert_ok!(Tokens::mint_into(USDC, &BOB, swap_usdc));
@@ -101,7 +102,7 @@ fn test() {
 
 		let bob_usdc = Tokens::balance(USDC, &BOB);
 
-		assert_ok!(acceptable_computation_error(bob_usdc.into(), swap_usdc.into(), precision));
+		assert_ok!(acceptable_computation_error(bob_usdc.into(), swap_usdc.into(), precision, epsilon));
 
 		let lp = Tokens::balance(pool.lp_token, &ALICE);
 		assert_ok!(<StableSwap as CurveAmm>::remove_liquidity(&ALICE, pool_id, lp, 0, 0));
@@ -253,6 +254,7 @@ fn remove_lp_failure() {
 fn lp_fee() {
 	new_test_ext().execute_with(|| {
 		let precision = 100;
+    let epsilon = 1;
 		let unit = 1_000_000_000_000_u128;
 		let initial_usdt = 1_000_000_000_000_u128 * unit;
 		let initial_usdc = 1_000_000_000_000_u128 * unit;
@@ -269,7 +271,8 @@ fn lp_fee() {
 		assert_ok!(acceptable_computation_error(
 			usdc_balance,
 			bob_usdt - lp_fee.mul_ceil(bob_usdt),
-			precision
+			precision,
+      epsilon
 		));
 	});
 }
@@ -280,6 +283,7 @@ fn lp_fee() {
 fn protocol_fee() {
 	new_test_ext().execute_with(|| {
 		let precision = 100;
+    let epsilon = 1;
 		let unit = 1_000_000_000_000_u128;
 		let initial_usdt = 1_000_000_000_000_u128 * unit;
 		let initial_usdc = 1_000_000_000_000_u128 * unit;
@@ -296,14 +300,16 @@ fn protocol_fee() {
 		assert_ok!(acceptable_computation_error(
 			usdc_balance,
 			bob_usdt - lp_fee.mul_floor(bob_usdt),
-			precision
+			precision,
+      epsilon
 		));
 		// from lp_fee 1 % (as per protocol_fee) goes to pool owner (ALICE)
 		let alice_usdc_bal = Tokens::balance(USDC, &ALICE);
 		assert_ok!(acceptable_computation_error(
 			alice_usdc_bal,
 			protocol_fee.mul_floor(lp_fee.mul_floor(bob_usdt)),
-			precision
+			precision,
+      epsilon
 		));
 	});
 }

--- a/frame/curve-amm/src/tests.rs
+++ b/frame/curve-amm/src/tests.rs
@@ -102,7 +102,12 @@ fn test() {
 
 		let bob_usdc = Tokens::balance(USDC, &BOB);
 
-		assert_ok!(acceptable_computation_error(bob_usdc.into(), swap_usdc.into(), precision, epsilon));
+		assert_ok!(acceptable_computation_error(
+			bob_usdc.into(),
+			swap_usdc.into(),
+			precision,
+			epsilon
+		));
 
 		let lp = Tokens::balance(pool.lp_token, &ALICE);
 		assert_ok!(<StableSwap as CurveAmm>::remove_liquidity(&ALICE, pool_id, lp, 0, 0));
@@ -254,7 +259,7 @@ fn remove_lp_failure() {
 fn lp_fee() {
 	new_test_ext().execute_with(|| {
 		let precision = 100;
-    let epsilon = 1;
+		let epsilon = 1;
 		let unit = 1_000_000_000_000_u128;
 		let initial_usdt = 1_000_000_000_000_u128 * unit;
 		let initial_usdc = 1_000_000_000_000_u128 * unit;
@@ -272,7 +277,7 @@ fn lp_fee() {
 			usdc_balance,
 			bob_usdt - lp_fee.mul_ceil(bob_usdt),
 			precision,
-      epsilon
+			epsilon
 		));
 	});
 }
@@ -283,7 +288,7 @@ fn lp_fee() {
 fn protocol_fee() {
 	new_test_ext().execute_with(|| {
 		let precision = 100;
-    let epsilon = 1;
+		let epsilon = 1;
 		let unit = 1_000_000_000_000_u128;
 		let initial_usdt = 1_000_000_000_000_u128 * unit;
 		let initial_usdc = 1_000_000_000_000_u128 * unit;
@@ -301,7 +306,7 @@ fn protocol_fee() {
 			usdc_balance,
 			bob_usdt - lp_fee.mul_floor(bob_usdt),
 			precision,
-      epsilon
+			epsilon
 		));
 		// from lp_fee 1 % (as per protocol_fee) goes to pool owner (ALICE)
 		let alice_usdc_bal = Tokens::balance(USDC, &ALICE);
@@ -309,7 +314,7 @@ fn protocol_fee() {
 			alice_usdc_bal,
 			protocol_fee.mul_floor(lp_fee.mul_floor(bob_usdt)),
 			precision,
-      epsilon
+			epsilon
 		));
 	});
 }

--- a/frame/dex-router/src/tests.rs
+++ b/frame/dex-router/src/tests.rs
@@ -184,7 +184,9 @@ fn exchange_tests() {
 			println!("exchange value {:?}", dy);
 		}
 		let expected_value = 3000 * unit;
-		assert_ok!(acceptable_computation_error(dy, expected_value, 100));
+		let precision = 100;
+		let epsilon = 1;
+		assert_ok!(acceptable_computation_error(dy, expected_value, precision, epsilon));
 	});
 }
 
@@ -210,6 +212,8 @@ fn buy_test() {
 		assert_ok!(dy);
 		let dy = dy.unwrap();
 		let expected_value = 3000 * unit;
-		assert_ok!(acceptable_computation_error(dy, expected_value, 100));
+		let precision = 100;
+		let epsilon = 1;
+		assert_ok!(acceptable_computation_error(dy, expected_value, precision, epsilon));
 	});
 }

--- a/frame/uniswap-v2/src/tests.rs
+++ b/frame/uniswap-v2/src/tests.rs
@@ -88,7 +88,7 @@ fn test() {
 		<Uni as CurveAmm>::buy(&BOB, pool_id, BTC, swap_btc, false).expect("impossible; qed;");
 
 		let precision = 100;
-    let epsilon = 5;
+		let epsilon = 5;
 		let bob_btc = Tokens::balance(BTC, &BOB);
 		assert_ok!(acceptable_computation_error(bob_btc, swap_btc, precision, epsilon));
 

--- a/frame/uniswap-v2/src/tests.rs
+++ b/frame/uniswap-v2/src/tests.rs
@@ -88,8 +88,9 @@ fn test() {
 		<Uni as CurveAmm>::buy(&BOB, pool_id, BTC, swap_btc, false).expect("impossible; qed;");
 
 		let precision = 100;
+    let epsilon = 5;
 		let bob_btc = Tokens::balance(BTC, &BOB);
-		assert_ok!(acceptable_computation_error(bob_btc, swap_btc, precision));
+		assert_ok!(acceptable_computation_error(bob_btc, swap_btc, precision, epsilon));
 
 		let new_pool_invariant = current_pool_product();
 		assert_ok!(default_acceptable_computation_error(

--- a/frame/vault/src/tests.rs
+++ b/frame/vault/src/tests.rs
@@ -730,7 +730,9 @@ proptest! {
 					prop_assert_acceptable_computation_error!(new_native_tokens, half_initial_native_tokens + diff);
 				} else {
 					// Our balance should be equivalent
-				  prop_assert_acceptable_computation_error!(new_native_tokens, half_initial_native_tokens);
+          let precision = 1000;
+          let epsilon = 5;
+				  prop_assert_acceptable_computation_error!(new_native_tokens, half_initial_native_tokens, precision, epsilon);
 				}
 			}
 

--- a/frame/vault/src/tests.rs
+++ b/frame/vault/src/tests.rs
@@ -730,8 +730,8 @@ proptest! {
 					prop_assert_acceptable_computation_error!(new_native_tokens, half_initial_native_tokens + diff);
 				} else {
 					// Our balance should be equivalent
-          let precision = 1000;
-          let epsilon = 5;
+		  let precision = 1000;
+		  let epsilon = 5;
 				  prop_assert_acceptable_computation_error!(new_native_tokens, half_initial_native_tokens, precision, epsilon);
 				}
 			}

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -801,7 +801,7 @@ impl assets::Config for Runtime {
 parameter_types! {
 	  pub const CrowdloanRewardsId: PalletId = PalletId(*b"pal_crow");
 	  pub const InitialPayment: Perbill = Perbill::from_percent(50);
-	  pub const VestingStep: BlockNumber = 1 * MINUTES;
+	  pub const VestingStep: BlockNumber = MINUTES;
 	  pub const Prefix: &'static [u8] = b"picasso-";
 }
 


### PR DESCRIPTION
The issue with proptest is that because of the fact that we generate random
values, we might have some issue because of division. The issue rely on the fact
that for instane, integer division might result in less/more value than expected (odd number
for instance). We can circumvent thoses cases (pretty rare but still making the
CI fail) by lowering the precision of the expected value for some tests.