### PR TITLE
Clamp devnet disk usage with automatic GC

### DIFF
--- a/nix/devnet-gce.nix
+++ b/nix/devnet-gce.nix
@@ -40,6 +40,10 @@ in {
           ];
         };
       };
+      nix = {
+        gc.automatic = true;
+        autoOptimiseStore = true;
+      };
       networking.firewall.allowedTCPPorts = [ 80 443 ];
       systemd.services.composable-devnet = {
         wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
- since doc deployment, releasing the devnet introduce a +3gb to the store, eventually resulting in no space left.
- previous versions can be freed by the GC, which can be automatic (if enabled), resulting in clamped maximum residency of disk usage.