### PR TITLE
[CH] Add commit-msg hook

### DIFF
--- a/frame/clearing-house/.pre-commit-config.yaml
+++ b/frame/clearing-house/.pre-commit-config.yaml
@@ -6,3 +6,9 @@ repos:
     entry: rustfmt --config skip_children=true --check
     language: system
     types: [rust]
+- repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+  rev: v8.0.0
+  hooks:
+  - id: commitlint
+    stages: [commit-msg]
+    additional_dependencies: ['@commitlint/config-conventional']


### PR DESCRIPTION
This adds a commit linter via a `pre-commit` hook at the `commit-msg` stage. Install it with
```zsh
pre-commit install -t commit-msg
```
The [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) commit message standard is used.