### PR TITLE
Rework vesting origin & audit fixes

### DIFF
--- a/frame/bonded-finance/src/benchmarks.rs
+++ b/frame/bonded-finance/src/benchmarks.rs
@@ -5,16 +5,14 @@ use crate::Pallet as BondedFinance;
 use crate::{AssetIdOf, BalanceOf, BlockNumberOf, BondOfferOf, Call, Config, Pallet};
 use codec::Decode;
 use composable_support::validation::Validated;
-use composable_traits::{
-	bonded_finance::{BondDuration, BondOffer, BondOfferReward},
-};
+use composable_traits::bonded_finance::{BondDuration, BondOffer, BondOfferReward};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::{
 	dispatch::UnfilteredDispatchable,
 	traits::{fungible::Mutate as _, fungibles::Mutate as _},
 };
-use sp_runtime::traits::One;
 use frame_system::RawOrigin;
+use sp_runtime::traits::One;
 
 const MIN_VESTED_TRANSFER: u128 = 1000 * 1_000_000_000_000;
 const BALANCE: u128 = 1_000_000 * 1_000_000_000_000;

--- a/frame/bonded-finance/src/benchmarks.rs
+++ b/frame/bonded-finance/src/benchmarks.rs
@@ -7,13 +7,13 @@ use codec::Decode;
 use composable_support::validation::Validated;
 use composable_traits::{
 	bonded_finance::{BondDuration, BondOffer, BondOfferReward},
-	math::WrappingNext,
 };
-use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller, Zero};
+use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::{
 	dispatch::UnfilteredDispatchable,
 	traits::{fungible::Mutate as _, fungibles::Mutate as _},
 };
+use sp_runtime::traits::One;
 use frame_system::RawOrigin;
 
 const MIN_VESTED_TRANSFER: u128 = 1000 * 1_000_000_000_000;
@@ -100,7 +100,7 @@ benchmarks! {
 		let bond_offer = bond_offer::<T>(bond_asset, reward_asset);
 		let nb_of_bonds = bond_offer.nb_of_bonds;
 		call_offer::<T>(bond_offer, &caller);
-		let offer_id = T::BondOfferId::zero().next();
+		let offer_id = T::BondOfferId::one();
 	}: _(RawOrigin::Signed(caller), offer_id, nb_of_bonds, false)
 
 	cancel {
@@ -110,7 +110,7 @@ benchmarks! {
 		let bond_offer = bond_offer::<T>(bond_asset, reward_asset);
 		let nb_of_bonds = bond_offer.nb_of_bonds;
 		call_offer::<T>(bond_offer, &caller);
-		let offer_id = T::BondOfferId::zero().next();
+		let offer_id = T::BondOfferId::one();
 		call_bond::<T>(&caller, nb_of_bonds, offer_id);
 	}: _(RawOrigin::Signed(caller), offer_id)
 }

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -72,7 +72,7 @@ pub mod pallet {
 	use composable_support::validation::Validated;
 	use composable_traits::{
 		bonded_finance::{BondDuration, BondOffer, BondedFinance, ValidBondOffer},
-		math::{SafeAdd},
+		math::SafeAdd,
 		vesting::{VestedTransfer, VestingSchedule, VestingWindow::BlockNumberBased},
 	};
 	use frame_support::{
@@ -87,7 +87,7 @@ pub mod pallet {
 	use scale_info::TypeInfo;
 	use sp_runtime::{
 		helpers_128bit::multiply_by_rational,
-		traits::{AccountIdConversion, BlockNumberProvider, Convert, Zero, One},
+		traits::{AccountIdConversion, BlockNumberProvider, Convert, One, Zero},
 		ArithmeticError,
 	};
 	use sp_std::fmt::Debug;
@@ -156,8 +156,8 @@ pub mod pallet {
 			+ Eq
 			+ Debug
 			+ Zero
-      + SafeAdd
-      + One
+			+ SafeAdd
+			+ One
 			+ FullCodec
 			+ MaxEncodedLen
 			+ TypeInfo;
@@ -312,10 +312,12 @@ pub mod pallet {
 			offer: BondOfferOf<T>,
 			keep_alive: bool,
 		) -> Result<T::BondOfferId, DispatchError> {
-			let offer_id = BondOfferCount::<T>::try_mutate(|offer_id| -> Result<T::BondOfferId, DispatchError> {
-				*offer_id = offer_id.safe_add(&T::BondOfferId::one())?;
-				Ok(*offer_id)
-			})?;
+			let offer_id = BondOfferCount::<T>::try_mutate(
+				|offer_id| -> Result<T::BondOfferId, DispatchError> {
+					*offer_id = offer_id.safe_add(&T::BondOfferId::one())?;
+					Ok(*offer_id)
+				},
+			)?;
 			let offer_account = Self::account_id(offer_id);
 			T::NativeCurrency::transfer(from, &offer_account, T::Stake::get(), keep_alive)?;
 			T::Currency::transfer(
@@ -406,7 +408,8 @@ pub mod pallet {
 						}
 						// NOTE(hussein-aitlahcen): can't overflow as checked to be <=
 						// offer.nb_of_bonds prior to this
-						// Same goes for reward_share as nb_of_bonds * bond_price <= total_price is checked by the `Validate` instance of `BondOffer`
+						// Same goes for reward_share as nb_of_bonds * bond_price <= total_price is
+						// checked by the `Validate` instance of `BondOffer`
 						(*offer).nb_of_bonds -= nb_of_bonds;
 						(*offer).reward.amount -= reward_share;
 						let new_bond_event = || {

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -403,9 +403,9 @@ pub mod pallet {
 								// that the protocol is now owning the funds.
 							},
 						}
-						// NOTE(hussein-aitlahcen): can't overflow as checked to be <
+						// NOTE(hussein-aitlahcen): can't overflow as checked to be <=
 						// offer.nb_of_bonds prior to this
-						// Same goes for reward_share as nb_of_bonds * bond_price <= total_price
+						// Same goes for reward_share as nb_of_bonds * bond_price <= total_price is checked by the `Validate` instance of `BondOffer`
 						(*offer).nb_of_bonds -= nb_of_bonds;
 						(*offer).reward.amount -= reward_share;
 						let new_bond_event = || {

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -114,7 +114,7 @@ pub mod pallet {
 	pub enum Error<T> {
 		NotInitialized,
 		AlreadyInitialized,
-		InvalidInitializationBlock,
+		BackToTheFuture,
 		RewardsNotFunded,
 		InvalidProof,
 		InvalidClaim,
@@ -304,7 +304,7 @@ pub mod pallet {
 		pub(crate) fn do_initialize(at: MomentOf<T>) -> DispatchResult {
 			ensure!(!VestingTimeStart::<T>::exists(), Error::<T>::AlreadyInitialized);
 			let now = T::Time::now();
-			ensure!(at >= now, Error::<T>::InvalidInitializationBlock);
+			ensure!(at >= now, Error::<T>::BackToTheFuture);
 			VestingTimeStart::<T>::set(Some(at));
 			Self::deposit_event(Event::Initialized);
 			Ok(())

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -168,7 +168,7 @@ fn test_initialize_at_ko() {
 		Timestamp::set_timestamp(100);
 		assert_noop!(
 			CrowdloanRewards::initialize_at(Origin::root(), 99),
-			Error::<Test>::InvalidInitializationBlock
+			Error::<Test>::BackToTheFuture
 		);
 	});
 }

--- a/frame/vesting/src/benchmarks.rs
+++ b/frame/vesting/src/benchmarks.rs
@@ -90,8 +90,8 @@ benchmarks! {
 
 	vested_transfer {
 		let asset_id = asset::<T>();
-		let caller: T::AccountId = zero_account::<T>();
-		fund_account::<T>(&caller, asset_id.clone(), FUNDING.into());
+		let from: T::AccountId = zero_account::<T>();
+		fund_account::<T>(&from, asset_id.clone(), FUNDING.into());
 		let dest = T::Lookup::unlookup(create_account::<T>("dest", 1));
 		let per_period = T::MinVestedTransfer::get();
 		let schedule = vesting_schedule::<T>(
@@ -100,7 +100,7 @@ benchmarks! {
 			PERIOD_COUNT,
 			per_period.into()
 		);
-	}: _(RawOrigin::Signed(caller), dest, asset_id, schedule)
+	}: _(RawOrigin::Root, T::Lookup::unlookup(from), dest, asset_id, schedule)
 
 	update_vesting_schedules {
 		let s in 0 .. T::MaxVestingSchedules::get();

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -246,13 +246,13 @@ pub mod module {
 		#[pallet::weight(<T as Config>::WeightInfo::vested_transfer())]
 		pub fn vested_transfer(
 			origin: OriginFor<T>,
-      from: <T::Lookup as StaticLookup>::Source,
+			from: <T::Lookup as StaticLookup>::Source,
 			beneficiary: <T::Lookup as StaticLookup>::Source,
 			asset: AssetIdOf<T>,
 			schedule: VestingScheduleOf<T>,
 		) -> DispatchResult {
-      T::VestedTransferOrigin::ensure_origin(origin)?;
-      let from = T::Lookup::lookup(from)?;
+			T::VestedTransferOrigin::ensure_origin(origin)?;
+			let from = T::Lookup::lookup(from)?;
 			let to = T::Lookup::lookup(beneficiary)?;
 			<Self as VestedTransfer>::vested_transfer(asset, &from, &to, schedule.clone())?;
 

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -108,7 +108,7 @@ pub mod module {
 		type MinVestedTransfer: Get<BalanceOf<Self>>;
 
 		/// Required origin for vested transfer.
-		type VestedTransferOrigin: EnsureOrigin<Self::Origin, Success = Self::AccountId>;
+		type VestedTransferOrigin: EnsureOrigin<Self::Origin>;
 
 		/// Weight information for extrinsics in this module.
 		type WeightInfo: WeightInfo;
@@ -246,12 +246,14 @@ pub mod module {
 		#[pallet::weight(<T as Config>::WeightInfo::vested_transfer())]
 		pub fn vested_transfer(
 			origin: OriginFor<T>,
-			dest: <T::Lookup as StaticLookup>::Source,
+      from: <T::Lookup as StaticLookup>::Source,
+			beneficiary: <T::Lookup as StaticLookup>::Source,
 			asset: AssetIdOf<T>,
 			schedule: VestingScheduleOf<T>,
 		) -> DispatchResult {
-			let from = T::VestedTransferOrigin::ensure_origin(origin)?;
-			let to = T::Lookup::lookup(dest)?;
+      T::VestedTransferOrigin::ensure_origin(origin)?;
+      let from = T::Lookup::lookup(from)?;
+			let to = T::Lookup::lookup(beneficiary)?;
 			<Self as VestedTransfer>::vested_transfer(asset, &from, &to, schedule.clone())?;
 
 			Self::deposit_event(Event::VestingScheduleAdded { from, to, asset, schedule });

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{EnsureOrigin, Everything},
 };
-use frame_system::{RawOrigin, EnsureRoot};
+use frame_system::{EnsureRoot, RawOrigin};
 use orml_traits::parameter_type_with_key;
 use scale_info::TypeInfo;
 use sp_core::H256;

--- a/frame/vesting/src/mock.rs
+++ b/frame/vesting/src/mock.rs
@@ -8,7 +8,7 @@ use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{EnsureOrigin, Everything},
 };
-use frame_system::RawOrigin;
+use frame_system::{RawOrigin, EnsureRoot};
 use orml_traits::parameter_type_with_key;
 use scale_info::TypeInfo;
 use sp_core::H256;
@@ -153,7 +153,7 @@ impl Config for Runtime {
 	type Event = Event;
 	type Currency = Tokens;
 	type MinVestedTransfer = MinVestedTransfer;
-	type VestedTransferOrigin = EnsureAliceOrBob;
+	type VestedTransferOrigin = EnsureRoot<AccountId>;
 	type WeightInfo = ();
 	type MaxVestingSchedules = MaxVestingSchedule;
 	type Moment = Moment;

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -116,7 +116,7 @@ fn vested_transfer_works() {
 			per_period: 100_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -144,7 +144,7 @@ fn vested_transfer_for_moment_based_schedule_works() {
 			per_period: 100_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -169,7 +169,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -185,7 +185,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 7_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -198,7 +198,7 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 7_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -221,7 +221,7 @@ fn cannot_use_fund_if_not_claimed() {
 			per_period: 50_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -233,7 +233,7 @@ fn cannot_use_fund_if_not_claimed() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
+			Origin::root(),
 			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
@@ -256,10 +256,7 @@ fn vested_transfer_fails_if_zero_period_count() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(
-        Origin::root(),
-			  ALICE
-, BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), ALICE, BOB, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::ZeroVestingPeriodCount
 		);
 	});
@@ -274,10 +271,7 @@ fn vested_transfer_fails_if_zero_period() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(
-        Origin::root(),
-			  ALICE
-, BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), ALICE, BOB, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
@@ -328,8 +322,8 @@ fn vested_transfer_fails_if_overflow() {
 		};
 		assert_noop!(
 			Vesting::vested_transfer(
-        Origin::root(),
-        ALICE,
+				Origin::root(),
+				ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				another_schedule,
@@ -344,8 +338,8 @@ fn vested_transfer_fails_if_overflow() {
 		};
 		assert_noop!(
 			Vesting::vested_transfer(
-        Origin::root(),
-        ALICE,
+				Origin::root(),
+				ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				moment_based_schedule,
@@ -364,7 +358,13 @@ fn vested_transfer_fails_if_bad_origin() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(CHARLIE), CHARLIE, BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(
+				Origin::signed(CHARLIE),
+				CHARLIE,
+				BOB,
+				MockCurrencyId::BTC,
+				schedule,
+			),
 			BadOrigin
 		);
 	});
@@ -379,8 +379,8 @@ fn claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -418,8 +418,8 @@ fn claim_for_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -454,8 +454,8 @@ fn claim_for_works_moment_based() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -489,8 +489,8 @@ fn update_vesting_schedules_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -502,8 +502,8 @@ fn update_vesting_schedules_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_based_schedule,
@@ -585,8 +585,8 @@ fn multiple_vesting_schedule_claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
@@ -598,8 +598,8 @@ fn multiple_vesting_schedule_claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-        ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule2.clone(),
@@ -636,30 +636,30 @@ fn exceeding_maximum_schedules_should_fail() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
 		));
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
 		));
 		assert_ok!(Vesting::vested_transfer(
-      Origin::root(),
-      ALICE,
+			Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_schedule,
 		));
 		assert_noop!(
 			Vesting::vested_transfer(
-        Origin::root(),
-        ALICE,
+				Origin::root(),
+				ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				schedule.clone(),

--- a/frame/vesting/src/tests.rs
+++ b/frame/vesting/src/tests.rs
@@ -116,7 +116,8 @@ fn vested_transfer_works() {
 			per_period: 100_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
@@ -143,7 +144,8 @@ fn vested_transfer_for_moment_based_schedule_works() {
 			per_period: 100_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
@@ -167,7 +169,8 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -182,7 +185,8 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 7_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			another_schedule,
@@ -194,7 +198,8 @@ fn add_new_vesting_schedule_merges_with_current_locked_balance_and_until() {
 			per_period: 7_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_based_schedule,
@@ -216,7 +221,8 @@ fn cannot_use_fund_if_not_claimed() {
 			per_period: 50_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -227,7 +233,8 @@ fn cannot_use_fund_if_not_claimed() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+			ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_based_schedule,
@@ -249,7 +256,10 @@ fn vested_transfer_fails_if_zero_period_count() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(
+        Origin::root(),
+			  ALICE
+, BOB, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::ZeroVestingPeriodCount
 		);
 	});
@@ -264,7 +274,10 @@ fn vested_transfer_fails_if_zero_period() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(
+        Origin::root(),
+			  ALICE
+, BOB, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 
@@ -274,7 +287,7 @@ fn vested_transfer_fails_if_zero_period() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), ALICE, BOB, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::ZeroVestingPeriod
 		);
 	});
@@ -289,7 +302,7 @@ fn vested_transfer_fails_if_transfer_err() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), BOB, ALICE, MockCurrencyId::BTC, schedule,),
 			orml_tokens::Error::<Runtime>::BalanceTooLow,
 		);
 	});
@@ -304,7 +317,7 @@ fn vested_transfer_fails_if_overflow() {
 			per_period: u64::MAX,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(ALICE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), ALICE, BOB, MockCurrencyId::BTC, schedule,),
 			ArithmeticError::Overflow,
 		);
 
@@ -315,7 +328,8 @@ fn vested_transfer_fails_if_overflow() {
 		};
 		assert_noop!(
 			Vesting::vested_transfer(
-				Origin::signed(ALICE),
+        Origin::root(),
+        ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				another_schedule,
@@ -330,7 +344,8 @@ fn vested_transfer_fails_if_overflow() {
 		};
 		assert_noop!(
 			Vesting::vested_transfer(
-				Origin::signed(ALICE),
+        Origin::root(),
+        ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				moment_based_schedule,
@@ -349,7 +364,7 @@ fn vested_transfer_fails_if_bad_origin() {
 			per_period: 100_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(CHARLIE), BOB, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::signed(CHARLIE), CHARLIE, BOB, MockCurrencyId::BTC, schedule,),
 			BadOrigin
 		);
 	});
@@ -364,7 +379,8 @@ fn claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -402,7 +418,8 @@ fn claim_for_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -437,7 +454,8 @@ fn claim_for_works_moment_based() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -471,7 +489,8 @@ fn update_vesting_schedules_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule,
@@ -483,7 +502,8 @@ fn update_vesting_schedules_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_based_schedule,
@@ -550,7 +570,7 @@ fn vested_transfer_check_for_min() {
 			per_period: 3_u64,
 		};
 		assert_noop!(
-			Vesting::vested_transfer(Origin::signed(BOB), ALICE, MockCurrencyId::BTC, schedule,),
+			Vesting::vested_transfer(Origin::root(), BOB, ALICE, MockCurrencyId::BTC, schedule,),
 			Error::<Runtime>::AmountLow
 		);
 	});
@@ -565,7 +585,8 @@ fn multiple_vesting_schedule_claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
@@ -577,7 +598,8 @@ fn multiple_vesting_schedule_claim_works() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+        ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule2.clone(),
@@ -614,26 +636,30 @@ fn exceeding_maximum_schedules_should_fail() {
 			per_period: 10_u64,
 		};
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
 		));
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			schedule.clone(),
 		));
 		assert_ok!(Vesting::vested_transfer(
-			Origin::signed(ALICE),
+      Origin::root(),
+      ALICE,
 			BOB,
 			MockCurrencyId::BTC,
 			moment_schedule,
 		));
 		assert_noop!(
 			Vesting::vested_transfer(
-				Origin::signed(ALICE),
+        Origin::root(),
+        ALICE,
 				BOB,
 				MockCurrencyId::BTC,
 				schedule.clone(),

--- a/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
+++ b/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
@@ -292,7 +292,7 @@ fn transfer_to_sibling() {
 		assert_ok!(Tokens::deposit(
 			CurrencyId::KSM,
 			&this_native_reserve_account(),
-			100 * CurrencyId::KSM.unit::<Balance>(),
+			100 * CurrencyId::unit::<Balance>(),
 		));
 		Tokens::free_balance(CurrencyId::KSM, &this_native_reserve_account())
 	});
@@ -771,25 +771,25 @@ fn unspent_xcm_fee_is_returned_correctly() {
 		assert_ok!(kusama_runtime::Balances::transfer(
 			kusama_runtime::Origin::signed(ALICE.into()),
 			MultiAddress::Id(some_account.clone()),
-			1_000 * CurrencyId::KSM.unit::<Balance>()
+			1_000 * CurrencyId::unit::<Balance>()
 		));
 		assert_ok!(kusama_runtime::Balances::transfer(
 			kusama_runtime::Origin::signed(ALICE.into()),
 			MultiAddress::Id(parachain_account.clone()),
-			1_000 * CurrencyId::KSM.unit::<Balance>()
+			1_000 * CurrencyId::unit::<Balance>()
 		));
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&AccountId::from(ALICE)),
-			2 * CurrencyId::KSM.unit::<Balance>()
+			2 * CurrencyId::unit::<Balance>()
 		);
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&some_account),
-			1_000 * CurrencyId::KSM.unit::<Balance>()
+			1_000 * CurrencyId::unit::<Balance>()
 		);
 		assert_eq!(kusama_runtime::Balances::free_balance(&AccountId::from(BOB)), 0);
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&parachain_account.clone()),
-			1_010 * CurrencyId::KSM.unit::<Balance>()
+			1_010 * CurrencyId::unit::<Balance>()
 		);
 	});
 
@@ -797,13 +797,13 @@ fn unspent_xcm_fee_is_returned_correctly() {
 		// Construct a transfer XCM call with returning the deposit
 		let transfer_call = crate::relaychain::balances_transfer_keep_alive::<Runtime>(
 			AccountId::from(BOB),
-			CurrencyId::PICA.unit(),
+			CurrencyId::unit(),
 		);
 		let batch_call = crate::relaychain::utility_as_derivative_call::<Runtime>(transfer_call, 0);
 		let weight = 10_000_000_000; // Fee to transfer into the hold register
 		let asset = MultiAsset {
 			id: Concrete(MultiLocation::here()),
-			fun: Fungibility::Fungible(CurrencyId::PICA.unit()),
+			fun: Fungibility::Fungible(CurrencyId::unit()),
 		};
 		let xcm_msg = Xcm(vec![
 			WithdrawAsset(asset.clone().into()),
@@ -823,18 +823,18 @@ fn unspent_xcm_fee_is_returned_correctly() {
 		// 1 dollar is transferred to BOB
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&some_account),
-			1000 * CurrencyId::KSM.unit::<Balance>()
+			1000 * CurrencyId::unit::<Balance>()
 		);
 		// ISSUE: ported from Acala, not clear how BOB at all got s amount as we never transfer that
 		// there is no transfer of KSM at all
 		// assert_eq!(
 		// 	kusama_runtime::Balances::free_balance(&AccountId::from(BOB)),
-		// 	CurrencyId::KSM.unit::<Balance>()
+		// 	CurrencyId::unit::<Balance>()
 		// );
 		// 1 dollar is given to Hold Register for XCM call and never returned.
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&parachain_account.clone()),
-			1_009 * CurrencyId::KSM.unit::<Balance>()
+			1_009 * CurrencyId::unit::<Balance>()
 		);
 	});
 
@@ -842,12 +842,12 @@ fn unspent_xcm_fee_is_returned_correctly() {
 		// Construct a transfer using the RelaychainCallBuilder
 		let transfer_call = crate::relaychain::balances_transfer_keep_alive::<Runtime>(
 			AccountId::from(BOB),
-			CurrencyId::PICA.unit(),
+			CurrencyId::unit(),
 		);
 		let batch_call = crate::relaychain::utility_as_derivative_call::<Runtime>(transfer_call, 0);
 		let finalized_call = crate::relaychain::finalize_call_into_xcm_message::<Runtime>(
 			batch_call,
-			CurrencyId::PICA.unit(),
+			CurrencyId::unit(),
 			10_000_000_000,
 		);
 
@@ -859,18 +859,18 @@ fn unspent_xcm_fee_is_returned_correctly() {
 		// 1 dollar is transferred to BOB
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&some_account),
-			1_000 * CurrencyId::KSM.unit::<Balance>()
+			1_000 * CurrencyId::unit::<Balance>()
 		);
 		// ISSUE: ported from Acala, not clear how BOB at all got s amount as we never transfer that
 		// there is no transfer of KSM at all
 		// assert_eq!(
 		// 	kusama_runtime::Balances::free_balance(&AccountId::from(BOB)),
-		// 	2 * CurrencyId::KSM.unit::<Balance>()
+		// 	2 * CurrencyId::unit::<Balance>()
 		// );
 		// Unspent fund from the 1 dollar XCM fee is returned to the sovereign account.
 		assert_eq!(
 			kusama_runtime::Balances::free_balance(&parachain_account.clone()),
-			1_000 * CurrencyId::KSM.unit::<Balance>() + 8_999_626_666_690
+			1_000 * CurrencyId::unit::<Balance>() + 8_999_626_666_690
 		);
 	});
 }
@@ -882,25 +882,25 @@ fn trap_assets_larger_than_ed_works() {
 
 	let mut native_treasury_amount = 0;
 	let (ksm_asset_amount, native_asset_amount) =
-		(3 * CurrencyId::KSM.unit::<Balance>(), 2 * CurrencyId::PICA.unit::<Balance>());
+		(3 * CurrencyId::unit::<Balance>(), 2 * CurrencyId::unit::<Balance>());
 	let parent_account: AccountId = ParentIsDefault::<AccountId>::convert(Parent.into()).unwrap();
 	Picasso::execute_with(|| {
 		assert_ok!(Tokens::deposit(
 			CurrencyId::KSM,
 			&parent_account,
-			42 * CurrencyId::KSM.unit::<Balance>()
+			42 * CurrencyId::unit::<Balance>()
 		));
 		let _ =
 			<balances::Pallet<Runtime> as support::traits::Currency<AccountId>>::deposit_creating(
 				&parent_account,
-				123 * CurrencyId::PICA.unit::<Balance>(),
+				123 * CurrencyId::unit::<Balance>(),
 			);
 		// TODO: if we do not top up account initially, than any depositn_creating do not create
 		// anything may be somethign with zero block or like - fix it better way
 		let _ =
 			<balances::Pallet<Runtime> as support::traits::Currency<AccountId>>::deposit_creating(
 				&picasso_runtime::TreasuryAccount::get(),
-				7 * CurrencyId::PICA.unit::<Balance>(),
+				7 * CurrencyId::unit::<Balance>(),
 			);
 
 		native_treasury_amount =
@@ -913,7 +913,7 @@ fn trap_assets_larger_than_ed_works() {
 			WithdrawAsset(assets.clone().into()),
 			BuyExecution {
 				fees: assets,
-				weight_limit: Limited(CurrencyId::KSM.unit::<Balance>() as u64),
+				weight_limit: Limited(CurrencyId::unit::<Balance>() as u64),
 			},
 			WithdrawAsset(((0, GeneralKey(CurrencyId::PICA.encode())), native_asset_amount).into()),
 		];
@@ -926,14 +926,14 @@ fn trap_assets_larger_than_ed_works() {
 
 	Picasso::execute_with(|| {
 		assert_eq!(
-			3 * CurrencyId::KSM.unit::<Balance>(),
+			3 * CurrencyId::unit::<Balance>(),
 			Assets::free_balance(CurrencyId::KSM, &picasso_runtime::TreasuryAccount::get())
 		);
 		log::error!("{:?}", &picasso_runtime::TreasuryAccount::get());
 		assert_eq!(
 			native_asset_amount,
 			picasso_runtime::Balances::free_balance(&picasso_runtime::TreasuryAccount::get()) -
-				7 * CurrencyId::PICA.unit::<Balance>(),
+				7 * CurrencyId::unit::<Balance>(),
 		);
 	});
 }

--- a/runtime/common/src/impls.rs
+++ b/runtime/common/src/impls.rs
@@ -220,8 +220,8 @@ mod tests {
 		/// percentage of proposal that most be bonded by the proposer
 		pub const ProposalBond: Permill = Permill::from_percent(5);
 		// TODO: rationale?
-		pub ProposalBondMinimum: Balance = 5 * CurrencyId::PICA.unit::<Balance>();
-		pub ProposalBondMaximum: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
+		pub ProposalBondMinimum: Balance = 5 * CurrencyId::unit::<Balance>();
+		pub ProposalBondMaximum: Balance = 1000 * CurrencyId::unit::<Balance>();
 		pub const SpendPeriod: BlockNumber = 7 * DAYS;
 		pub const Burn: Permill = Permill::from_percent(0);
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -33,6 +33,8 @@ mod types {
 	// todo move it into more shared directory so it can be shared with
 	// tests, integration, benchmark, (simnode?)
 
+  pub type BondOfferId = u128;
+
 	/// Timestamp implementation.
 	pub type Moment = u64;
 

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -33,7 +33,7 @@ mod types {
 	// todo move it into more shared directory so it can be shared with
 	// tests, integration, benchmark, (simnode?)
 
-  pub type BondOfferId = u128;
+	pub type BondOfferId = u128;
 
 	/// Timestamp implementation.
 	pub type Moment = u64;

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -139,7 +139,7 @@ mod constants {
 
 parameter_types! {
 	/// Existential deposit (ED for short) is minimum amount an account has to hold to stay in state.
-	pub NativeExistentialDeposit: Balance = 100 * CurrencyId::PICA.milli::<Balance>();
+	pub NativeExistentialDeposit: Balance = 100 * CurrencyId::milli::<Balance>();
 }
 
 pub struct PriceConverter;

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -229,8 +229,8 @@ impl timestamp::Config for Runtime {
 
 parameter_types! {
 	/// Minimum amount an account has to hold to stay in state.
-	// minimum account balance is given as 0.1 PICA ~ 100 CurrencyId::PICA.milli()
-	pub ExistentialDeposit: Balance = 100 * CurrencyId::PICA.milli::<Balance>();
+	// minimum account balance is given as 0.1 PICA ~ 100 CurrencyId::milli()
+	pub ExistentialDeposit: Balance = 100 * CurrencyId::milli::<Balance>();
 	/// Max locks that can be placed on an account. Capped for storage
 	/// concerns.
 	pub const MaxLocks: u32 = 50;
@@ -252,7 +252,7 @@ impl balances::Config for Runtime {
 
 parameter_types! {
 	/// 1 milli-pica/byte should be fine
-	pub TransactionByteFee: Balance = CurrencyId::PICA.milli();
+	pub TransactionByteFee: Balance = CurrencyId::milli();
 
 	// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
@@ -273,7 +273,7 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let p = CurrencyId::PICA.milli::<Balance>();
+		let p = CurrencyId::milli::<Balance>();
 		let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 		smallvec::smallvec![WeightToFeeCoefficient {
 			degree: 1,
@@ -301,7 +301,7 @@ impl sudo::Config for Runtime {
 
 parameter_types! {
 	/// Deposit required to get an index.
-	pub IndexDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub IndexDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 }
 
 impl indices::Config for Runtime {
@@ -380,7 +380,7 @@ parameter_types! {
 	pub const StalePrice: BlockNumber = 5;
 
 	/// TODO: discuss with omar/cosmin
-	pub MinStake: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
+	pub MinStake: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub const MaxAnswerBound: u32 = 25;
 	pub const MaxAssetsCount: u32 = 100_000;
 	pub const MaxHistory: u32 = 20;
@@ -514,8 +514,8 @@ parameter_types! {
 	/// percentage of proposal that most be bonded by the proposer
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	// TODO: rationale?
-	pub ProposalBondMinimum: Balance = 5 * CurrencyId::PICA.unit::<Balance>();
-	pub ProposalBondMaximum: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
+	pub ProposalBondMinimum: Balance = 5 * CurrencyId::unit::<Balance>();
+	pub ProposalBondMaximum: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub const SpendPeriod: BlockNumber = 7 * DAYS;
 	pub const Burn: Permill = Permill::from_percent(0);
 
@@ -594,7 +594,7 @@ impl scheduler::Config for Runtime {
 
 parameter_types! {
 	pub const PreimageMaxSize: u32 = 4096 * 1024;
-	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
+	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
 }
 
 impl preimage::Config for Runtime {
@@ -619,11 +619,11 @@ parameter_types! {
 	pub const VotingPeriod: BlockNumber = 5 * DAYS;
 	pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
 
-	pub MinimumDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub MinimumDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 	pub const EnactmentPeriod: BlockNumber = 2 * DAYS;
 	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
 	// TODO: prod value
-	pub PreimageByteDeposit: Balance = CurrencyId::PICA.milli();
+	pub PreimageByteDeposit: Balance = CurrencyId::milli();
 	pub const InstantAllowed: bool = true;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
@@ -707,9 +707,9 @@ impl crowdloan_rewards::Config for Runtime {
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
 	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
-	pub CreationDeposit: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
-	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
-	pub RentPerBlock: Balance = CurrencyId::PICA.milli::<Balance>();
+	pub CreationDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
+	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::unit::<Balance>();
+	pub RentPerBlock: Balance = CurrencyId::milli::<Balance>();
 	pub const VaultMinimumDeposit: Balance = 10_000;
 	pub const VaultMinimumWithdrawal: Balance = 10_000;
 	pub const VaultPalletId: PalletId = PalletId(*b"cubic___");

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -28,7 +28,7 @@ use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
 	CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, MosaicRemoteAssetId,
 	MultiExistentialDeposits, Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS,
-	MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION, BondOfferId,
 };
 use composable_support::rpc_helpers::SafeRpcWrapper;
 use cumulus_primitives_core::ParaId;
@@ -860,8 +860,8 @@ parameter_types! {
 }
 
 impl bonded_finance::Config for Runtime {
-	type AdminOrigin = EnsureRoot<AccountId>;
-	type BondOfferId = u64;
+	type AdminOrigin = EnsureRootOrHalfCouncil;
+	type BondOfferId = BondOfferId;
 	type Convert = sp_runtime::traits::ConvertInto;
 	type Currency = Assets;
 	type Event = Event;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -26,9 +26,9 @@ pub use xcmp::{MaxInstructions, UnitWeightCost};
 
 use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
-	CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, MosaicRemoteAssetId,
+	BondOfferId, CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, MosaicRemoteAssetId,
 	MultiExistentialDeposits, Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS,
-	MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION, BondOfferId,
+	MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use composable_support::rpc_helpers::SafeRpcWrapper;
 use cumulus_primitives_core::ParaId;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -223,12 +223,12 @@ impl aura::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-	pub BasicDeposit: Balance = 8 * CurrencyId::PICA.unit::<Balance>();
-	pub FieldDeposit: Balance = 256 * CurrencyId::PICA.milli::<Balance>();
+	pub BasicDeposit: Balance = 8 * CurrencyId::unit::<Balance>();
+	pub FieldDeposit: Balance = 256 * CurrencyId::milli::<Balance>();
 	pub const MaxAdditionalFields: u32 = 32;
 	pub const MaxRegistrars: u32 = 8;
 	pub const MaxSubAccounts: u32 = 32;
-	pub SubAccountDeposit: Balance = 2 * CurrencyId::PICA.unit::<Balance>();
+	pub SubAccountDeposit: Balance = 2 * CurrencyId::unit::<Balance>();
 }
 
 impl identity::Config for Runtime {
@@ -247,8 +247,8 @@ impl identity::Config for Runtime {
 }
 
 parameter_types! {
-	pub DepositBase: u64 = CurrencyId::PICA.unit();
-	pub DepositFactor: u64 = 32 * CurrencyId::PICA.milli::<u64>();
+	pub DepositBase: u64 = CurrencyId::unit();
+	pub DepositFactor: u64 = 32 * CurrencyId::milli::<u64>();
 	pub const MaxSignatories: u16 = 5;
 }
 
@@ -299,7 +299,7 @@ impl balances::Config for Runtime {
 
 parameter_types! {
 	/// 1 milli-pica/byte should be fine
-	pub TransactionByteFee: Balance = CurrencyId::PICA.milli::<Balance>();
+	pub TransactionByteFee: Balance = CurrencyId::milli::<Balance>();
 
 	// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
@@ -320,7 +320,7 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let p = CurrencyId::PICA.milli::<Balance>();
+		let p = CurrencyId::milli::<Balance>();
 		let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 		smallvec::smallvec![WeightToFeeCoefficient {
 			degree: 1,
@@ -348,7 +348,7 @@ impl sudo::Config for Runtime {
 
 parameter_types! {
 	/// Deposit required to get an index.
-	pub IndexDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub IndexDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 }
 
 impl indices::Config for Runtime {
@@ -427,7 +427,7 @@ parameter_types! {
 	pub const StalePrice: BlockNumber = 5;
 
 	/// TODO: discuss with omar/cosmin
-	pub MinStake: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
+	pub MinStake: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub const MaxAnswerBound: u32 = 25;
 	pub const MaxAssetsCount: u32 = 100_000;
 	pub const MaxHistory: u32 = 20;
@@ -569,8 +569,8 @@ parameter_types! {
 	/// percentage of proposal that most be bonded by the proposer
 	pub const ProposalBond: Permill = Permill::from_percent(5);
 	// TODO: rationale?
-	pub ProposalBondMinimum: Balance = 5 * CurrencyId::PICA.unit::<Balance>();
-	pub ProposalBondMaximum: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
+	pub ProposalBondMinimum: Balance = 5 * CurrencyId::unit::<Balance>();
+	pub ProposalBondMaximum: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub const SpendPeriod: BlockNumber = 7 * DAYS;
 	pub const Burn: Permill = Permill::from_percent(0);
 
@@ -659,11 +659,11 @@ parameter_types! {
 	pub const VotingPeriod: BlockNumber = 5 * DAYS;
 	pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
 
-	pub MinimumDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub MinimumDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 	pub const EnactmentPeriod: BlockNumber = 2 * DAYS;
 	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
 	// TODO: prod value
-	pub PreimageByteDeposit: Balance = CurrencyId::PICA.milli::<Balance>();
+	pub PreimageByteDeposit: Balance = CurrencyId::milli::<Balance>();
 	pub const InstantAllowed: bool = true;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
@@ -708,7 +708,7 @@ impl democracy::Config for Runtime {
 
 parameter_types! {
 	pub const PreimageMaxSize: u32 = 4096 * 1024;
-	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
+	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
 }
 
 impl preimage::Config for Runtime {
@@ -724,9 +724,9 @@ impl preimage::Config for Runtime {
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
 	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
-	pub CreationDeposit: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
-	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::PICA.unit::<Balance>();
-	pub RentPerBlock: Balance = CurrencyId::PICA.milli();
+	pub CreationDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
+	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::unit::<Balance>();
+	pub RentPerBlock: Balance = CurrencyId::milli();
 	pub const VaultMinimumDeposit: Balance = 10_000;
 	pub const VaultMinimumWithdrawal: Balance = 10_000;
 	pub const VaultPalletId: PalletId = PalletId(*b"cubic___");
@@ -839,7 +839,7 @@ impl call_filter::Config for Runtime {
 
 parameter_types! {
 	pub const MaxVestingSchedule: u32 = 2;
-	pub MinVestedTransfer: u64 = 10 * CurrencyId::PICA.unit::<u64>();
+	pub MinVestedTransfer: u64 = 10 * CurrencyId::unit::<u64>();
 }
 
 impl vesting::Config for Runtime {
@@ -855,8 +855,8 @@ impl vesting::Config for Runtime {
 
 parameter_types! {
 	pub const BondedFinanceId: PalletId = PalletId(*b"bondedfi");
-	pub MinReward: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
-	pub Stake: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
+	pub MinReward: Balance = 100 * CurrencyId::unit::<Balance>();
+	pub Stake: Balance = 10 * CurrencyId::unit::<Balance>();
 }
 
 impl bonded_finance::Config for Runtime {

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -24,7 +24,7 @@ mod xcmp;
 use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
 	CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK, NORMAL_DISPATCH_RATIO, SLOT_DURATION, BondOfferId,
 };
 use orml_traits::parameter_type_with_key;
 use primitives::currency::CurrencyId;
@@ -757,8 +757,8 @@ parameter_types! {
 }
 
 impl bonded_finance::Config for Runtime {
-	type AdminOrigin = EnsureRoot<AccountId>;
-	type BondOfferId = u64;
+	type AdminOrigin = EnsureRootOrHalfCouncil;
+	type BondOfferId = BondOfferId;
 	type Convert = sp_runtime::traits::ConvertInto;
 	type Currency = Assets;
 	type Event = Event;

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -24,8 +24,9 @@ mod xcmp;
 
 use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
-	CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, Signature, AVERAGE_ON_INITIALIZE_RATIO,
-	DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK, NORMAL_DISPATCH_RATIO, SLOT_DURATION, BondOfferId,
+	BondOfferId, CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, Signature,
+	AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK,
+	NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use orml_traits::parameter_type_with_key;
 use primitives::currency::CurrencyId;

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -21,6 +21,7 @@ include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
 
 mod weights;
 mod xcmp;
+
 use common::{
 	impls::DealWithFees, AccountId, AccountIndex, Address, Amount, AuraId, Balance, BlockNumber,
 	CouncilInstance, EnsureRootOrHalfCouncil, Hash, Moment, Signature, AVERAGE_ON_INITIALIZE_RATIO,
@@ -235,12 +236,12 @@ impl aura::Config for Runtime {
 impl cumulus_pallet_aura_ext::Config for Runtime {}
 
 parameter_types! {
-	pub BasicDeposit: Balance = 8 * CurrencyId::PICA.unit::<Balance>();
-	pub FieldDeposit: Balance = 256 * CurrencyId::PICA.milli::<Balance>();
+	pub BasicDeposit: Balance = 8 * CurrencyId::unit::<Balance>();
+	pub FieldDeposit: Balance = 256 * CurrencyId::milli::<Balance>();
 	pub const MaxAdditionalFields: u32 = 32;
 	pub const MaxRegistrars: u32 = 8;
 	pub const MaxSubAccounts: u32 = 32;
-	pub SubAccountDeposit: Balance = 2 * CurrencyId::PICA.unit::<Balance>();
+	pub SubAccountDeposit: Balance = 2 * CurrencyId::unit::<Balance>();
 }
 
 impl identity::Config for Runtime {
@@ -259,8 +260,8 @@ impl identity::Config for Runtime {
 }
 
 parameter_types! {
-	pub DepositBase: u64 = CurrencyId::PICA.unit();
-	pub DepositFactor: u64 = 32 * CurrencyId::PICA.milli::<u64>();
+	pub DepositBase: u64 = CurrencyId::unit();
+	pub DepositFactor: u64 = 32 * CurrencyId::milli::<u64>();
 	pub const MaxSignatories: u16 = 5;
 }
 
@@ -291,8 +292,8 @@ impl timestamp::Config for Runtime {
 
 parameter_types! {
 	/// Minimum amount an account has to hold to stay in state.
-	// minimum account balance is given as 0.1 PICA ~ 100 CurrencyId::PICA.milli()
-	pub ExistentialDeposit: Balance = 100 * CurrencyId::PICA.milli::<Balance>();
+	// minimum account balance is given as 0.1 PICA ~ 100 CurrencyId::milli()
+	pub ExistentialDeposit: Balance = 100 * CurrencyId::milli::<Balance>();
 	/// Max locks that can be placed on an account. Capped for storage
 	/// concerns.
 	pub const MaxLocks: u32 = 50;
@@ -314,7 +315,7 @@ impl balances::Config for Runtime {
 
 parameter_types! {
 	/// 1 milli-pica/byte should be fine
-	pub TransactionByteFee: Balance = CurrencyId::PICA.milli();
+	pub TransactionByteFee: Balance = CurrencyId::milli();
 
 	// The portion of the `NORMAL_DISPATCH_RATIO` that we adjust the fees with. Blocks filled less
 	/// than this will decrease the weight and more will increase.
@@ -335,7 +336,7 @@ pub struct WeightToFee;
 impl WeightToFeePolynomial for WeightToFee {
 	type Balance = Balance;
 	fn polynomial() -> WeightToFeeCoefficients<Self::Balance> {
-		let p = CurrencyId::PICA.milli::<Balance>();
+		let p = CurrencyId::milli::<Balance>();
 		let q = 10 * Balance::from(ExtrinsicBaseWeight::get());
 		smallvec::smallvec![WeightToFeeCoefficient {
 			degree: 1,
@@ -363,7 +364,7 @@ impl sudo::Config for Runtime {
 
 parameter_types! {
 	/// Deposit required to get an index.
-	pub IndexDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub IndexDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 }
 
 impl indices::Config for Runtime {
@@ -550,8 +551,8 @@ parameter_types! {
 	pub const TreasuryPalletId: PalletId = PalletId(*b"picatrsy");
 	/// Percentage of proposal that most be bonded by the proposer.
 	pub const ProposalBond: Permill = Permill::from_percent(5);
-	pub ProposalBondMinimum: Balance = 5000 * CurrencyId::PICA.unit::<Balance>();
-	pub ProposalBondMaximum: Balance = 10000 * CurrencyId::PICA.unit::<Balance>();
+	pub ProposalBondMinimum: Balance = 5000 * CurrencyId::unit::<Balance>();
+	pub ProposalBondMaximum: Balance = 10000 * CurrencyId::unit::<Balance>();
 	pub const SpendPeriod: BlockNumber = 7 * DAYS;
 	pub const Burn: Permill = Permill::from_percent(0);
 
@@ -629,7 +630,7 @@ impl scheduler::Config for Runtime {
 
 parameter_types! {
 	pub const PreimageMaxSize: u32 = 4096 * 1024;
-	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
+	pub PreimageBaseDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
 }
 
 impl preimage::Config for Runtime {
@@ -654,14 +655,14 @@ parameter_types! {
 	pub const VotingPeriod: BlockNumber = 5 * DAYS;
 	pub const FastTrackVotingPeriod: BlockNumber = 3 * HOURS;
 
-	pub MinimumDeposit: Balance = 100 * CurrencyId::PICA.unit::<Balance>();
+	pub MinimumDeposit: Balance = 100 * CurrencyId::unit::<Balance>();
 	pub const EnactmentPeriod: BlockNumber = 2 * DAYS;
 	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
 
 	// Note that Kusama uses 10 millis, however KSM is significantly more expensive
 	// https://github.com/paritytech/polkadot/blob/dc784f9b47e4681897cfd477b4f0760330875a87/runtime/kusama/src/lib.rs#L237
 	// so we increase it by a factor 10. This might still be on the low side.
-	pub PreimageByteDeposit: Balance = CurrencyId::PICA.milli::<u128>() * 100_u128;
+	pub PreimageByteDeposit: Balance = CurrencyId::milli::<u128>() * 100_u128;
 	pub const InstantAllowed: bool = true;
 	pub const MaxVotes: u32 = 100;
 	pub const MaxProposals: u32 = 100;
@@ -736,7 +737,7 @@ impl crowdloan_rewards::Config for Runtime {
 
 parameter_types! {
 	  pub const MaxVestingSchedule: u32 = 128;
-	  pub MinVestedTransfer: u64 = CurrencyId::PICA.milli::<u64>();
+	  pub MinVestedTransfer: u64 = CurrencyId::milli::<u64>();
 }
 
 impl vesting::Config for Runtime {
@@ -744,7 +745,7 @@ impl vesting::Config for Runtime {
 	type Event = Event;
 	type MaxVestingSchedules = MaxVestingSchedule;
 	type MinVestedTransfer = MinVestedTransfer;
-	type VestedTransferOrigin = system::EnsureSigned<AccountId>;
+	type VestedTransferOrigin = EnsureRootOrHalfCouncil;
 	type WeightInfo = weights::vesting::WeightInfo<Runtime>;
 	type Moment = Moment;
 	type Time = Timestamp;
@@ -752,8 +753,8 @@ impl vesting::Config for Runtime {
 
 parameter_types! {
 	  pub const BondedFinanceId: PalletId = PalletId(*b"bondedfi");
-	  pub MinReward: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
-	  pub Stake: Balance = 10 * CurrencyId::PICA.unit::<Balance>();
+	  pub MinReward: Balance = 10 * CurrencyId::unit::<Balance>();
+	  pub Stake: Balance = 10 * CurrencyId::unit::<Balance>();
 }
 
 impl bonded_finance::Config for Runtime {

--- a/runtime/primitives/src/currency.rs
+++ b/runtime/primitives/src/currency.rs
@@ -51,14 +51,14 @@ impl CurrencyId {
 	pub const KSM: CurrencyId = CurrencyId(4);
 
 	#[inline(always)]
-	pub fn decimals(&self) -> Exponent {
+	pub const fn decimals() -> Exponent {
 		12
 	}
-	pub fn unit<T: From<u64>>(&self) -> T {
-		T::from(10_u64.pow(self.decimals()))
+	pub fn unit<T: From<u64>>() -> T {
+		T::from(10_u64.pow(Self::decimals()))
 	}
-	pub fn milli<T: From<u64> + Div<Output = T>>(&self) -> T {
-		self.unit::<T>() / T::from(1000_u64)
+	pub fn milli<T: From<u64> + Div<Output = T>>() -> T {
+		Self::unit::<T>() / T::from(1000_u64)
 	}
 }
 


### PR DESCRIPTION
This PR must fix #773 #772 #771 

I also modified the Vesting pallet not to use the `origin` account as source account for the transfer.
This allow us to define the `RootOrHalfCouncil` as `VesterTransferOrigin` in the runtimes.
Cross-pallet call is still permisionless.

This PR also remove the usage of `self` in `CurrencyId` to allow us to represent amounts without confusion (A unit of any currency was previously defined as `CurrencyId.PICA.unit()` while it is now represented as `CurrencyId::unit()` as all currencies are normalized to the same number of decimals within our system.