### PR TITLE
[cu-23v2y3n] Event publishing refactoring

### DIFF
--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -445,7 +445,7 @@ pub mod pallet {
 					LiquidityBootstrapping::<T>::do_create_pool(validated_pool_config)?
 				},
 			};
-			Self::deposit_event(Event::PoolCreated { owner: who.clone(), pool_id });
+			Self::deposit_event(Event::<T>::PoolCreated { owner: who.clone(), pool_id });
 			Ok(pool_id)
 		}
 

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -545,7 +545,7 @@ pub mod pallet {
 					min_mint_amount,
 					keep_alive,
 				)?,
-				PoolConfiguration::LiquidityBootstrapping(liquidity_bootstrapping_pool_info) => {
+				PoolConfiguration::LiquidityBootstrapping(liquidity_bootstrapping_pool_info) =>
 					LiquidityBootstrapping::<T>::add_liquidity(
 						who,
 						liquidity_bootstrapping_pool_info,
@@ -554,9 +554,7 @@ pub mod pallet {
 						quote_amount,
 						min_mint_amount,
 						keep_alive,
-					)?;
-					T::Balance::zero()
-				},
+					)?,
 			};
 			Self::deposit_event(Event::<T>::LiquidityAdded {
 				who: who.clone(),

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -123,7 +123,7 @@ pub mod pallet {
 		<T as Config>::AssetId,
 		<T as frame_system::Config>::BlockNumber,
 	>;
-	// TODO refactor event publishing with cu-23v2y3n
+
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
@@ -202,8 +202,6 @@ pub mod pallet {
 		InvalidPair,
 		InvalidFees,
 		AmpFactorMustBeGreaterThanZero,
-
-		// ConstantProduct Specific: Possibly rename
 		MissingAmount,
 	}
 
@@ -427,37 +425,28 @@ pub mod pallet {
 			who: &T::AccountId,
 			init_config: PoolInitConfigurationOf<T>,
 		) -> Result<T::PoolId, DispatchError> {
-			match init_config {
+			let pool_id = match init_config {
 				PoolInitConfiguration::StableSwap {
 					pair,
 					amplification_coefficient,
 					fee,
 					protocol_fee,
-				} => {
-					let pool_id = StableSwap::<T>::do_create_pool(
-						&who,
-						pair,
-						amplification_coefficient,
-						fee,
-						protocol_fee,
-					)?;
-					Self::deposit_event(Event::PoolCreated { owner: who.clone(), pool_id });
-
-					Ok(pool_id)
-				},
-				PoolInitConfiguration::ConstantProduct { pair, fee, owner_fee } => {
-					let pool_id = Uniswap::<T>::do_create_pool(&who, pair, fee, owner_fee)?;
-					Self::deposit_event(Event::PoolCreated { owner: who.clone(), pool_id });
-					Ok(pool_id)
-				},
+				} => StableSwap::<T>::do_create_pool(
+					&who,
+					pair,
+					amplification_coefficient,
+					fee,
+					protocol_fee,
+				)?,
+				PoolInitConfiguration::ConstantProduct { pair, fee, owner_fee } =>
+					Uniswap::<T>::do_create_pool(&who, pair, fee, owner_fee)?,
 				PoolInitConfiguration::LiquidityBootstrapping(pool_config) => {
 					let validated_pool_config = Validated::new(pool_config)?;
-					let pool_id =
-						LiquidityBootstrapping::<T>::do_create_pool(validated_pool_config)?;
-					Self::deposit_event(Event::PoolCreated { owner: who.clone(), pool_id });
-					Ok(pool_id)
+					LiquidityBootstrapping::<T>::do_create_pool(validated_pool_config)?
 				},
-			}
+			};
+			Self::deposit_event(Event::PoolCreated { owner: who.clone(), pool_id });
+			Ok(pool_id)
 		}
 
 		pub(crate) fn get_pool(
@@ -536,9 +525,9 @@ pub mod pallet {
 		) -> Result<(), DispatchError> {
 			let pool = Self::get_pool(pool_id)?;
 			let pool_account = Self::account_id(&pool_id);
-			match pool {
-				PoolConfiguration::StableSwap(stable_swap_pool_info) => {
-					let mint_amount = StableSwap::<T>::add_liquidity(
+			let minted_lp = match pool {
+				PoolConfiguration::StableSwap(stable_swap_pool_info) =>
+					StableSwap::<T>::add_liquidity(
 						who,
 						stable_swap_pool_info,
 						pool_account,
@@ -546,33 +535,16 @@ pub mod pallet {
 						quote_amount,
 						min_mint_amount,
 						keep_alive,
-					)?;
-					Self::deposit_event(Event::<T>::LiquidityAdded {
-						who: who.clone(),
-						pool_id,
-						base_amount,
-						quote_amount,
-						minted_lp: mint_amount,
-					});
-				},
-				ConstantProduct(constant_product_pool_info) => {
-					let mint_amount = Uniswap::<T>::add_liquidity(
-						who,
-						constant_product_pool_info,
-						pool_account,
-						base_amount,
-						quote_amount,
-						min_mint_amount,
-						keep_alive,
-					)?;
-					Self::deposit_event(Event::<T>::LiquidityAdded {
-						who: who.clone(),
-						pool_id,
-						base_amount,
-						quote_amount,
-						minted_lp: mint_amount,
-					});
-				},
+					)?,
+				ConstantProduct(constant_product_pool_info) => Uniswap::<T>::add_liquidity(
+					who,
+					constant_product_pool_info,
+					pool_account,
+					base_amount,
+					quote_amount,
+					min_mint_amount,
+					keep_alive,
+				)?,
 				PoolConfiguration::LiquidityBootstrapping(liquidity_bootstrapping_pool_info) => {
 					LiquidityBootstrapping::<T>::add_liquidity(
 						who,
@@ -583,16 +555,16 @@ pub mod pallet {
 						min_mint_amount,
 						keep_alive,
 					)?;
-					Self::deposit_event(Event::<T>::LiquidityAdded {
-						who: who.clone(),
-						pool_id,
-						base_amount,
-						quote_amount,
-						minted_lp: T::Balance::zero(),
-					});
+					T::Balance::zero()
 				},
-			}
-			// TODO refactor event publishing with cu-23v2y3n
+			};
+			Self::deposit_event(Event::<T>::LiquidityAdded {
+				who: who.clone(),
+				pool_id,
+				base_amount,
+				quote_amount,
+				minted_lp,
+			});
 			Ok(())
 		}
 
@@ -670,7 +642,7 @@ pub mod pallet {
 		) -> Result<Self::Balance, DispatchError> {
 			let pool = Self::get_pool(pool_id)?;
 			let pool_account = Self::account_id(&pool_id);
-			match pool {
+			let (base_amount, fees) = match pool {
 				PoolConfiguration::StableSwap(pool) => {
 					// /!\ NOTE(hussein-aitlahcen): after this check, do not use pool.pair as the
 					// provided pair might have been swapped
@@ -699,17 +671,7 @@ pub mod pallet {
 						base_amount_excluding_fees,
 						false,
 					)?;
-					Self::deposit_event(Event::<T>::Swapped {
-						pool_id,
-						who: who.clone(),
-						base_asset: pair.base,
-						quote_asset: pair.quote,
-						base_amount: base_amount_excluding_fees,
-						quote_amount,
-						fee: lp_fees.safe_add(&protocol_fees)?,
-					});
-
-					Ok(base_amount_excluding_fees)
+					(base_amount_excluding_fees, lp_fees.safe_add(&protocol_fees)?)
 				},
 				ConstantProduct(constant_product_pool_info) => {
 					let (base_amount, quote_amount_excluding_fees, lp_fees, owner_fees) =
@@ -742,18 +704,7 @@ pub mod pallet {
 						false,
 					)?;
 					T::Assets::transfer(pair.base, &pool_account, who, base_amount, false)?;
-
-					Self::deposit_event(Event::<T>::Swapped {
-						pool_id,
-						who: who.clone(),
-						base_asset: pair.base,
-						quote_asset: pair.quote,
-						base_amount,
-						quote_amount: quote_amount_excluding_fees,
-						fee: total_fees,
-					});
-
-					Ok(base_amount)
+					(base_amount, total_fees)
 				},
 				PoolConfiguration::LiquidityBootstrapping(liquidity_bootstrapping_pool_info) => {
 					let current_block = frame_system::Pallet::<T>::current_block_number();
@@ -771,20 +722,19 @@ pub mod pallet {
 					T::Assets::transfer(pair.quote, who, &pool_account, quote_amount, keep_alive)?;
 					// NOTE(hussein-aitlance): no need to keep alive the pool account
 					T::Assets::transfer(pair.base, &pool_account, who, base_amount, false)?;
-					Self::deposit_event(Event::<T>::Swapped {
-						pool_id,
-						who: who.clone(),
-						base_asset: pair.base,
-						quote_asset: pair.quote,
-						base_amount,
-						quote_amount,
-						fee: fees,
-					});
-					Ok(base_amount)
+					(base_amount, fees)
 				},
-			}
-
-			// TODO refactor event publishing with cu-23v2y3n
+			};
+			Self::deposit_event(Event::<T>::Swapped {
+				pool_id,
+				who: who.clone(),
+				base_asset: pair.base,
+				quote_asset: pair.quote,
+				base_amount,
+				quote_amount,
+				fee: fees,
+			});
+			Ok(base_amount)
 		}
 
 		#[transactional]

--- a/frame/pablo/src/liquidity_bootstrapping.rs
+++ b/frame/pablo/src/liquidity_bootstrapping.rs
@@ -163,7 +163,7 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		quote_amount: T::Balance,
 		_: T::Balance,
 		keep_alive: bool,
-	) -> Result<(), DispatchError> {
+	) -> Result<T::Balance, DispatchError> {
 		let current_block = frame_system::Pallet::<T>::current_block_number();
 		Self::ensure_sale_state(&pool, current_block, SaleState::NotStarted)?;
 
@@ -175,7 +175,7 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		T::Assets::transfer(pool.pair.base, who, &pool_account, base_amount, keep_alive)?;
 		T::Assets::transfer(pool.pair.quote, who, &pool_account, quote_amount, keep_alive)?;
 
-		Ok(())
+		Ok(T::Balance::zero())
 	}
 
 	#[transactional]

--- a/frame/pablo/src/liquidity_bootstrapping_tests.rs
+++ b/frame/pablo/src/liquidity_bootstrapping_tests.rs
@@ -1,5 +1,8 @@
+#[cfg(test)]
 use crate::{
+	common_test_functions::*,
 	liquidity_bootstrapping::PoolIsValid,
+	mock,
 	mock::{Pablo, *},
 	Error, PoolInitConfiguration,
 };
@@ -130,10 +133,14 @@ mod create {
 	#[test]
 	fn arbitrary_user_can_create() {
 		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
 			assert_ok!(Pablo::create(
 				Origin::signed(ALICE),
 				PoolInitConfiguration::LiquidityBootstrapping(valid_pool().value())
 			),);
+			assert_has_event::<Test, _>(
+				|e| matches!(e.event, mock::Event::Pablo(crate::Event::PoolCreated { pool_id, .. }) if pool_id == 0)
+			);
 		});
 	}
 

--- a/frame/pablo/src/mock.rs
+++ b/frame/pablo/src/mock.rs
@@ -1,3 +1,5 @@
+#![cfg(test)]
+
 use crate as pablo;
 use frame_support::{parameter_types, traits::Everything, PalletId};
 use frame_system as system;


### PR DESCRIPTION
- Reusing the event publishing code for all three dexes
- Removing TODOs
- Verify some of the events published

I tried to write tests for event publishing before making this change, but I think we need to make a change to the AMM interface to expose things like calculated fees to verify the events