### PR TITLE
test(Runtime Integration Tests): Fix test suite only running crowdloa…

### DIFF
--- a/integration-tests/runtime-tests/test/tests/crowdloanRewards/txCrowdloanRewardsTests.ts
+++ b/integration-tests/runtime-tests/test/tests/crowdloanRewards/txCrowdloanRewardsTests.ts
@@ -13,7 +13,7 @@ import {mintAssetsToWallet} from "@composable/utils/mintingHelper";
  *  4. Associate a picassso account (which also claims)
  *  5. Claiming more rewards.
  */
-describe.only('CrowdloanRewards Tests', function() {
+describe('CrowdloanRewards Tests', function() {
   if (!testConfiguration.enabledTests.tx.enabled)
     return;
 


### PR DESCRIPTION
Greetings, very minor fix.

## Issue
Accidentally committed the `.only` part when calling `describe`, which tells mocha to only run this specific test suite.
