### PR TITLE
CU-24g8vet - Refactor VammConfig type bounds

### DIFF
--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -144,7 +144,15 @@ pub mod pallet {
 		type UnixTime: UnixTime;
 
 		/// Virtual Automated Market Maker pallet implementation
-		type Vamm: Vamm<Balance = Self::Balance, Decimal = Self::Decimal>;
+		type Vamm: Vamm<
+			Balance = Self::Balance,
+			Decimal = Self::Decimal,
+			VammConfig = Self::VammConfig,
+		>;
+
+		/// Configuration for creating and initializing a new vAMM instance. To be used as an
+		/// extrinsic input
+		type VammConfig: FullCodec + MaxEncodedLen + TypeInfo + Debug + Clone + PartialEq;
 
 		/// Price feed (in USDT) Oracle pallet implementation
 		type Oracle: Oracle<AssetId = Self::MayBeAssetId, Balance = Self::Balance>;
@@ -236,7 +244,7 @@ pub mod pallet {
 	type AssetIdOf<T> = <T as DeFiComposableConfig>::MayBeAssetId;
 	type MarketIdOf<T> = <T as Config>::MarketId;
 	type DecimalOf<T> = <T as Config>::Decimal;
-	type VammConfigOf<T> = <<T as Config>::Vamm as Vamm>::VammConfig;
+	type VammConfigOf<T> = <T as Config>::VammConfig;
 	type VammIdOf<T> = <<T as Config>::Vamm as Vamm>::VammId;
 	type PositionOf<T> = Position<MarketIdOf<T>, DecimalOf<T>>;
 	type MarketConfigOf<T> = MarketConfig<AssetIdOf<T>, VammConfigOf<T>, DecimalOf<T>>;
@@ -512,7 +520,7 @@ pub mod pallet {
 				let market_id = id.clone();
 				let market = Market {
 					asset_id: config.asset,
-					vamm_id: T::Vamm::create(config.vamm_config.clone())?,
+					vamm_id: T::Vamm::create(&config.vamm_config)?,
 					margin_ratio_initial: config.margin_ratio_initial,
 					margin_ratio_maintenance: config.margin_ratio_maintenance,
 					funding_frequency: config.funding_frequency,

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -122,8 +122,10 @@ pub mod pallet {
 	pub trait Config: DeFiComposableConfig + frame_system::Config {
 		/// Event type emitted by this pallet. Depends on the runtime's definition of an event.
 		type Event: From<Event<Self>> + IsType<<Self as frame_system::Config>::Event>;
+
 		/// Weight information for this pallet's extrinsics
 		type WeightInfo: WeightInfo;
+
 		/// The market ID type for this pallet.
 		type MarketId: CheckedAdd
 			+ One
@@ -134,20 +136,26 @@ pub mod pallet {
 			+ Clone
 			+ PartialEq
 			+ Debug;
+
 		/// Signed decimal fixed point number.
 		type Decimal: FullCodec + MaxEncodedLen + TypeInfo + FixedPointNumber;
+
 		/// Implementation for querying the current Unix timestamp
 		type UnixTime: UnixTime;
+
 		/// Virtual Automated Market Maker pallet implementation
 		type Vamm: Vamm<Balance = Self::Balance, Decimal = Self::Decimal>;
+
 		/// Price feed (in USDT) Oracle pallet implementation
 		type Oracle: Oracle<AssetId = Self::MayBeAssetId, Balance = Self::Balance>;
+
 		/// Pallet implementation of asset transfers.
 		type Assets: Transfer<
 			Self::AccountId,
 			Balance = Self::Balance,
 			AssetId = Self::MayBeAssetId,
 		>;
+
 		/// The id used as the `AccountId` of the clearing house. This should be unique across all
 		/// pallets to avoid name collisions with other pallets and clearing houses.
 		#[pallet::constant]

--- a/frame/clearing-house/src/mock/runtime.rs
+++ b/frame/clearing-house/src/mock/runtime.rs
@@ -234,6 +234,7 @@ impl clearing_house::Config for Runtime {
 	type Decimal = Decimal;
 	type UnixTime = Timestamp;
 	type Vamm = Vamm;
+	type VammConfig = mock_vamm::VammConfig;
 	type Oracle = Oracle;
 	type Assets = Assets;
 	type PalletId = TestPalletId;

--- a/frame/clearing-house/src/tests.rs
+++ b/frame/clearing-house/src/tests.rs
@@ -262,7 +262,7 @@ proptest! {
 	#[test]
 	fn mock_vamm_created_id_reflects_genesis_config(vamm_id in any::<Option<VammId>>()) {
 		ExtBuilder { vamm_id , ..Default::default() }.build().execute_with(|| {
-			let created = <Runtime as Config>::Vamm::create(valid_vamm_config());
+			let created = <Runtime as Config>::Vamm::create(&valid_vamm_config());
 			match vamm_id {
 				Some(id) => assert_ok!(created, id),
 				None => assert_err!(created, mock_vamm::Error::<Runtime>::FailedToCreateVamm),

--- a/frame/composable-traits/src/vamm.rs
+++ b/frame/composable-traits/src/vamm.rs
@@ -1,11 +1,10 @@
 //! # Virtual Automated Market Maker
 //!
 //! Common traits and data structures for vamm implementation.
-use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
+use codec::{FullCodec, MaxEncodedLen};
 use frame_support::pallet_prelude::DispatchError;
 use scale_info::TypeInfo;
 use sp_runtime::FixedPointNumber;
-use sp_std::fmt::Debug;
 
 /// Exposes functionality for creation and management of virtual automated market makers.
 ///
@@ -19,9 +18,8 @@ pub trait Vamm {
 	/// Signed fixed point number implementation
 	type Decimal: FixedPointNumber;
 
-	/// Configuration for creating and initializing a new vAMM instance. May be used in extrinsic
-	/// signatures
-	type VammConfig: FullCodec + MaxEncodedLen + TypeInfo + Debug + Clone + PartialEq;
+	/// Configuration for creating and initializing a new vAMM instance
+	type VammConfig;
 
 	/// The identifier type for each virtual automated market maker.
 	type VammId: FullCodec + MaxEncodedLen + TypeInfo;
@@ -38,7 +36,6 @@ pub trait Vamm {
 }
 
 /// Specify a common encapsulation layer for the [`create`](Vamm::create) function.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, PartialEq)]
 pub struct VammConfig<Balance> {
 	/// The total amount of base assets to be set in vamm's creation.
 	pub base_asset_reserves: Balance,


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/24g8vet

## Description
Avoid propagating trait requirements by the Clearing House to the Vamm
trait's associated types.

Also includes a minor style change in the Clearing House's `Config`.
