### PR TITLE
CU-2p64ar7 - Update custom rpc wrapper representation

### DIFF
--- a/frame/assets/rpc/src/lib.rs
+++ b/frame/assets/rpc/src/lib.rs
@@ -1,8 +1,7 @@
-use core::str::FromStr;
-use core::fmt::Display;
 use assets_runtime_api::AssetsRuntimeApi;
 use codec::Codec;
 use composable_support::rpc_helpers::SafeRpcWrapper;
+use core::{fmt::Display, str::FromStr};
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result as RpcResult};
 use jsonrpc_derive::rpc;
 use sp_api::ProvideRuntimeApi;
@@ -13,8 +12,8 @@ use sp_std::sync::Arc;
 #[rpc]
 pub trait AssetsApi<BlockHash, AssetId, AccountId, Balance>
 where
-  AssetId: FromStr + Display,
-  Balance: FromStr + Display,
+	AssetId: FromStr + Display,
+	Balance: FromStr + Display,
 {
 	#[rpc(name = "assets_balanceOf")]
 	fn balance_of(

--- a/frame/assets/rpc/src/lib.rs
+++ b/frame/assets/rpc/src/lib.rs
@@ -1,6 +1,8 @@
+use core::str::FromStr;
+use core::fmt::Display;
 use assets_runtime_api::AssetsRuntimeApi;
 use codec::Codec;
-use composable_support::rpc_helpers::{SafeRpcWrapper, SafeRpcWrapperType};
+use composable_support::rpc_helpers::SafeRpcWrapper;
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result as RpcResult};
 use jsonrpc_derive::rpc;
 use sp_api::ProvideRuntimeApi;
@@ -11,8 +13,8 @@ use sp_std::sync::Arc;
 #[rpc]
 pub trait AssetsApi<BlockHash, AssetId, AccountId, Balance>
 where
-	AssetId: SafeRpcWrapperType,
-	Balance: SafeRpcWrapperType,
+  AssetId: FromStr + Display,
+  Balance: FromStr + Display,
 {
 	#[rpc(name = "assets_balanceOf")]
 	fn balance_of(
@@ -39,9 +41,9 @@ impl<C, Block, AssetId, AccountId, Balance>
 	for Assets<C, (Block, AssetId, AccountId, Balance)>
 where
 	Block: BlockT,
-	AssetId: Codec + Send + Sync + 'static + SafeRpcWrapperType,
-	AccountId: Codec + Send + Sync + 'static,
-	Balance: Send + Sync + 'static + SafeRpcWrapperType,
+	AssetId: Codec + Send + Sync + 'static + Codec + FromStr + Display,
+	AccountId: Codec + Send + Sync + 'static + Codec + FromStr + Display,
+	Balance: Send + Sync + 'static + Codec + FromStr + Display,
 	C: Send + Sync + 'static,
 	C: ProvideRuntimeApi<Block>,
 	C: HeaderBackend<Block>,

--- a/frame/assets/runtime-api/src/lib.rs
+++ b/frame/assets/runtime-api/src/lib.rs
@@ -13,7 +13,7 @@ sp_api::decl_runtime_apis! {
 	where
 		AccountId: Codec,
 		Balance: Codec,
-    AssetId: Codec,
+	AssetId: Codec,
 	{
 		fn balance_of(asset_id: SafeRpcWrapper<AssetId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */;
 	}

--- a/frame/assets/runtime-api/src/lib.rs
+++ b/frame/assets/runtime-api/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unnecessary_mut_passed)]
 
 use codec::Codec;
-use composable_support::rpc_helpers::{SafeRpcWrapper, SafeRpcWrapperType};
+use composable_support::rpc_helpers::SafeRpcWrapper;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime amalgamator file (the `runtime/src/lib.rs`)
@@ -11,9 +11,9 @@ sp_api::decl_runtime_apis! {
 	// REVIEW(benluelo): Should the AssetId type parameter be removed and then just use CurencyId directly?
 	pub trait AssetsRuntimeApi<AssetId, AccountId, Balance>
 	where
-		AssetId: SafeRpcWrapperType,
 		AccountId: Codec,
-		Balance: SafeRpcWrapperType,
+		Balance: Codec,
+    AssetId: Codec,
 	{
 		fn balance_of(asset_id: SafeRpcWrapper<AssetId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */;
 	}

--- a/frame/composable-support/src/rpc_helpers.rs
+++ b/frame/composable-support/src/rpc_helpers.rs
@@ -2,41 +2,41 @@ use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[derive(
-    scale_info::TypeInfo,
-    Clone,
-    Copy,
-    Debug,
-    Decode,
-    Default,
-    Encode,
-    Eq,
-    MaxEncodedLen,
-    Ord,
-    PartialEq,
-    PartialOrd,
+	scale_info::TypeInfo,
+	Clone,
+	Copy,
+	Debug,
+	Decode,
+	Default,
+	Encode,
+	Eq,
+	MaxEncodedLen,
+	Ord,
+	PartialEq,
+	PartialOrd,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
 pub struct SafeRpcWrapper<T>(
-    #[cfg_attr(feature = "std", serde(bound(serialize = "T: std::fmt::Display")))]
-    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
-    #[cfg_attr(feature = "std", serde(bound(deserialize = "T: std::str::FromStr")))]
-    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
-    pub T,
+	#[cfg_attr(feature = "std", serde(bound(serialize = "T: std::fmt::Display")))]
+	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+	#[cfg_attr(feature = "std", serde(bound(deserialize = "T: std::str::FromStr")))]
+	#[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+	pub T,
 );
 
 #[cfg(feature = "std")]
 fn serialize_as_string<S: Serializer, T: std::fmt::Display>(
-    t: &T,
-    serializer: S,
+	t: &T,
+	serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(&t.to_string())
+	serializer.serialize_str(&t.to_string())
 }
 
 #[cfg(feature = "std")]
 fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(
-    deserializer: D,
+	deserializer: D,
 ) -> Result<T, D::Error> {
-    let s = String::deserialize(deserializer)?;
-    s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
+	let s = String::deserialize(deserializer)?;
+	s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
 }

--- a/frame/composable-support/src/rpc_helpers.rs
+++ b/frame/composable-support/src/rpc_helpers.rs
@@ -1,79 +1,42 @@
-use codec::{Codec, Decode, Encode};
+use codec::{Decode, Encode, MaxEncodedLen};
 #[cfg(feature = "std")]
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-/// https://github.com/interlay/interbtc/blob/a7c0e69ac041176a2531bafb1c4e35cbc2f7e192/crates/oracle/rpc/runtime-api/src/lib.rs#L10
+#[derive(
+    scale_info::TypeInfo,
+    Clone,
+    Copy,
+    Debug,
+    Decode,
+    Default,
+    Encode,
+    Eq,
+    MaxEncodedLen,
+    Ord,
+    PartialEq,
+    PartialOrd,
+)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-#[derive(Debug, PartialEq, Eq, Encode, Decode)]
-pub struct SafeRpcWrapper<T: SafeRpcWrapperType>(
-	#[cfg_attr(feature = "std", serde(serialize_with = "serialize_to_hex"))]
-	#[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_hex"))]
-	pub T,
+#[cfg_attr(feature = "std", serde(rename_all = "camelCase"))]
+pub struct SafeRpcWrapper<T>(
+    #[cfg_attr(feature = "std", serde(bound(serialize = "T: std::fmt::Display")))]
+    #[cfg_attr(feature = "std", serde(serialize_with = "serialize_as_string"))]
+    #[cfg_attr(feature = "std", serde(bound(deserialize = "T: std::str::FromStr")))]
+    #[cfg_attr(feature = "std", serde(deserialize_with = "deserialize_from_string"))]
+    pub T,
 );
 
-pub trait SafeRpcWrapperType
-where
-	Self: sp_std::fmt::LowerHex + FromHexStr + Codec,
-{
-}
-
-impl<T> SafeRpcWrapperType for T where T: sp_std::fmt::LowerHex + FromHexStr + Codec {}
-
-pub trait FromHexStr: sp_std::marker::Sized {
-	type Err: sp_std::fmt::Display;
-
-	fn from_hex_str(src: &str) -> sp_std::result::Result<Self, Self::Err>;
-}
-
-#[derive(Debug)]
-pub enum FromHexStrErr {
-	No0xPrefix,
-	ParseIntError(sp_std::num::ParseIntError),
-}
-
-impl sp_std::fmt::Display for FromHexStrErr {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-		match self {
-			FromHexStrErr::No0xPrefix => f.write_str("No `0x` prefix"),
-			FromHexStrErr::ParseIntError(parse_int_error) =>
-				f.write_fmt(format_args!("{}", parse_int_error)),
-		}
-	}
-}
-
-impl FromHexStr for u128 {
-	type Err = FromHexStrErr;
-
-	fn from_hex_str(src: &str) -> sp_std::result::Result<Self, Self::Err> {
-		match src.strip_prefix("0x") {
-			Some(stripped) =>
-				u128::from_str_radix(stripped, 16).map_err(FromHexStrErr::ParseIntError),
-			None => Err(FromHexStrErr::No0xPrefix),
-		}
-	}
-}
-
 #[cfg(feature = "std")]
-fn serialize_to_hex<S: Serializer, T: SafeRpcWrapperType>(
-	t: &T,
-	serializer: S,
+fn serialize_as_string<S: Serializer, T: std::fmt::Display>(
+    t: &T,
+    serializer: S,
 ) -> Result<S::Ok, S::Error> {
-	serializer.serialize_str(&format!("{:#x}", t))
+    serializer.serialize_str(&t.to_string())
 }
 
 #[cfg(feature = "std")]
-fn deserialize_from_hex<'de, D: Deserializer<'de>, T: SafeRpcWrapperType>(
-	deserializer: D,
+fn deserialize_from_string<'de, D: Deserializer<'de>, T: std::str::FromStr>(
+    deserializer: D,
 ) -> Result<T, D::Error> {
-	use serde::de::Error;
-	let hex_string = String::deserialize(deserializer)?;
-
-	T::from_hex_str(&hex_string).map_err(|err| {
-		D::Error::custom(format!(
-			"Unable to parse as 0x-prefixed hex string: {} (error: {})",
-			hex_string, err
-		))
-	})
+    let s = String::deserialize(deserializer)?;
+    s.parse::<T>().map_err(|_| serde::de::Error::custom("Parse from string failed"))
 }
-
-// TODO: tests?

--- a/frame/crowdloan-rewards/rpc/src/lib.rs
+++ b/frame/crowdloan-rewards/rpc/src/lib.rs
@@ -1,7 +1,6 @@
-use core::str::FromStr;
-use core::fmt::Display;
 use codec::Codec;
 use composable_support::rpc_helpers::SafeRpcWrapper;
+use core::{fmt::Display, str::FromStr};
 use crowdloan_rewards_runtime_api::CrowdloanRewardsRuntimeApi;
 use frame_support::{pallet_prelude::MaybeSerializeDeserialize, Parameter};
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result as RpcResult};
@@ -14,7 +13,7 @@ use sp_std::{marker::PhantomData, sync::Arc};
 #[rpc]
 pub trait CrowdloanRewardsApi<BlockHash, AccountId, Balance>
 where
-  Balance: FromStr + Display,
+	Balance: FromStr + Display,
 {
 	#[rpc(name = "crowdloanRewards_amountAvailableToClaimFor")]
 	fn amount_available_to_claim_for(

--- a/frame/crowdloan-rewards/rpc/src/lib.rs
+++ b/frame/crowdloan-rewards/rpc/src/lib.rs
@@ -1,4 +1,7 @@
-use composable_support::rpc_helpers::{SafeRpcWrapper, SafeRpcWrapperType};
+use core::str::FromStr;
+use core::fmt::Display;
+use codec::Codec;
+use composable_support::rpc_helpers::SafeRpcWrapper;
 use crowdloan_rewards_runtime_api::CrowdloanRewardsRuntimeApi;
 use frame_support::{pallet_prelude::MaybeSerializeDeserialize, Parameter};
 use jsonrpc_core::{Error as RpcError, ErrorCode, Result as RpcResult};
@@ -11,7 +14,7 @@ use sp_std::{marker::PhantomData, sync::Arc};
 #[rpc]
 pub trait CrowdloanRewardsApi<BlockHash, AccountId, Balance>
 where
-	Balance: SafeRpcWrapperType,
+  Balance: FromStr + Display,
 {
 	#[rpc(name = "crowdloanRewards_amountAvailableToClaimFor")]
 	fn amount_available_to_claim_for(
@@ -39,7 +42,7 @@ impl<C, Block, AccountId, Balance> CrowdloanRewardsApi<<Block as BlockT>::Hash, 
 where
 	Block: BlockT,
 	AccountId: Send + Sync + Parameter + MaybeSerializeDeserialize + Ord + 'static,
-	Balance: Send + Sync + 'static + SafeRpcWrapperType,
+	Balance: Send + Sync + 'static + Codec + FromStr + Display,
 	C: Send + Sync + ProvideRuntimeApi<Block> + HeaderBackend<Block> + 'static,
 	C::Api: CrowdloanRewardsRuntimeApi<Block, AccountId, Balance>,
 {

--- a/frame/crowdloan-rewards/runtime-api/src/lib.rs
+++ b/frame/crowdloan-rewards/runtime-api/src/lib.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::unnecessary_mut_passed)]
 
 use codec::Codec;
-use composable_support::rpc_helpers::{SafeRpcWrapper, SafeRpcWrapperType};
+use composable_support::rpc_helpers::SafeRpcWrapper;
 
 // Here we declare the runtime API. It is implemented it the `impl` block in
 // runtime amalgamator file (the `runtime/src/lib.rs`)
@@ -11,7 +11,7 @@ sp_api::decl_runtime_apis! {
 	pub trait CrowdloanRewardsRuntimeApi<AccountId, Balance>
 	where
 		AccountId: Codec,
-		Balance: SafeRpcWrapperType,
+    Balance: Codec
 	{
 		fn amount_available_to_claim_for(account: AccountId) -> SafeRpcWrapper<Balance>;
 	}

--- a/frame/crowdloan-rewards/runtime-api/src/lib.rs
+++ b/frame/crowdloan-rewards/runtime-api/src/lib.rs
@@ -11,7 +11,7 @@ sp_api::decl_runtime_apis! {
 	pub trait CrowdloanRewardsRuntimeApi<AccountId, Balance>
 	where
 		AccountId: Codec,
-    Balance: Codec
+	Balance: Codec
 	{
 		fn amount_available_to_claim_for(account: AccountId) -> SafeRpcWrapper<Balance>;
 	}

--- a/integration-tests/runtime-tests/src/types/interfaces/assets/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/assets/definitions.ts
@@ -5,7 +5,7 @@ export default {
       params: [
         {
           name: "asset",
-          type: "CurrencyId"
+          type: "CustomRpcCurrencyId"
         },
         {
           name: "account",
@@ -17,11 +17,8 @@ export default {
           isOptional: true,
         },
       ],
-      type: "AssetsBalance"
+      type: "CustomRpcBalance"
     },
   },
-  types: {
-    CurrencyId: "u128",
-    AssetsBalance: "u128",
-  },
+  types: {}
 };

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-consts.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-consts.ts
@@ -172,6 +172,10 @@ declare module '@polkadot/api-base/types/consts' {
     dutchAuction: {
       palletId: FrameSupportPalletId & AugmentedConst<ApiType>;
       /**
+       * ED taken to create position. Part of if returned when position is liqudated.
+       **/
+      positionExistentialDeposit: u128 & AugmentedConst<ApiType>;
+      /**
        * Generic const
        **/
       [key: string]: Codec;
@@ -255,6 +259,13 @@ declare module '@polkadot/api-base/types/consts' {
        **/
       [key: string]: Codec;
     };
+    liquidations: {
+      palletId: FrameSupportPalletId & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
     liquidityBootstrapping: {
       /**
        * Maximum initial weight.
@@ -321,6 +332,33 @@ declare module '@polkadot/api-base/types/consts' {
     oracle: {
       maxHistory: u32 & AugmentedConst<ApiType>;
       maxPrePrices: u32 & AugmentedConst<ApiType>;
+      /**
+       * Generic const
+       **/
+      [key: string]: Codec;
+    };
+    pablo: {
+      /**
+       * Maximum initial weight.
+       **/
+      lbpMaxInitialWeight: Permill & AugmentedConst<ApiType>;
+      /**
+       * Maximum duration for a sale.
+       **/
+      lbpMaxSaleDuration: u32 & AugmentedConst<ApiType>;
+      /**
+       * Minimum final weight.
+       **/
+      lbpMinFinalWeight: Permill & AugmentedConst<ApiType>;
+      /**
+       * Minimum duration for a sale.
+       **/
+      lbpMinSaleDuration: u32 & AugmentedConst<ApiType>;
+      palletId: FrameSupportPalletId & AugmentedConst<ApiType>;
+      /**
+       * The interval between TWAP computations.
+       **/
+      twapInterval: u64 & AugmentedConst<ApiType>;
       /**
        * Generic const
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-errors.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-errors.ts
@@ -413,7 +413,14 @@ declare module '@polkadot/api-base/types/errors' {
       OrderParametersIsInvalid: AugmentedError<ApiType>;
       RequestedOrderDoesNotExists: AugmentedError<ApiType>;
       TakeLimitDoesNotSatisfyOrder: AugmentedError<ApiType>;
+      TakeOrderDidNotHappen: AugmentedError<ApiType>;
       TakeParametersIsInvalid: AugmentedError<ApiType>;
+      /**
+       * errors trying to decode and parse XCM input
+       **/
+      XcmCannotDecodeRemoteParametersToLocalRepresentations: AugmentedError<ApiType>;
+      XcmCannotFindLocalIdentifiersAsDecodedFromRemote: AugmentedError<ApiType>;
+      XcmNotFoundConfigurationById: AugmentedError<ApiType>;
       /**
        * Generic error
        **/
@@ -784,6 +791,24 @@ declare module '@polkadot/api-base/types/errors' {
        * Signer has not been set
        **/
       UnsetSigner: AugmentedError<ApiType>;
+      /**
+       * Generic error
+       **/
+      [key: string]: AugmentedError<ApiType>;
+    };
+    pablo: {
+      AmpFactorMustBeGreaterThanZero: AugmentedError<ApiType>;
+      AssetAmountMustBePositiveNumber: AugmentedError<ApiType>;
+      CannotRespectMinimumRequested: AugmentedError<ApiType>;
+      InvalidAmount: AugmentedError<ApiType>;
+      InvalidFees: AugmentedError<ApiType>;
+      InvalidPair: AugmentedError<ApiType>;
+      InvalidSaleState: AugmentedError<ApiType>;
+      MissingAmount: AugmentedError<ApiType>;
+      MustBeOwner: AugmentedError<ApiType>;
+      PairMismatch: AugmentedError<ApiType>;
+      PoolConfigurationNotSupported: AugmentedError<ApiType>;
+      PoolNotFound: AugmentedError<ApiType>;
       /**
        * Generic error
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-events.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-events.ts
@@ -1,7 +1,8 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import type { CommonMosaicRemoteAssetId, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiCurrencyPair, ComposableTraitsLendingUpdateInput, ComposableTraitsVestingVestingSchedule, FrameSupportScheduleLookupError, PalletCrowdloanRewardsModelsRemoteAccount, PalletCurrencyFactoryRangesRange, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDutchAuctionSellOrder, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo } from '@composable/types/interfaces/crowdloanRewards';
+import type { ComposableTraitsDefiCurrencyPairCurrencyId } from '@composable/types/interfaces/common';
+import type { CommonMosaicRemoteAssetId, ComposableSupportEthereumAddress, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsLendingUpdateInput, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVestingVestingSchedule, FrameSupportScheduleLookupError, PalletCrowdloanRewardsModelsRemoteAccount, PalletCurrencyFactoryRangesRange, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDutchAuctionSellOrder, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo } from '@composable/types/interfaces/crowdloanRewards';
 import type { ApiTypes } from '@polkadot/api-base/types';
 import type { Bytes, Null, Option, Result, U8aFixed, Vec, bool, u128, u32, u64, u8 } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
@@ -359,8 +360,13 @@ declare module '@polkadot/api-base/types/events' {
       [key: string]: AugmentedEvent<ApiType>;
     };
     dutchAuction: {
+      CofigurationAdded: AugmentedEvent<ApiType, [u128, ComposableTraitsTimeTimeReleaseFunction]>;
       OrderAdded: AugmentedEvent<ApiType, [u128, PalletDutchAuctionSellOrder]>;
       OrderRemoved: AugmentedEvent<ApiType, [u128]>;
+      /**
+       * raised when part or whole order was taken with mentioned balance
+       **/
+      OrderTaken: AugmentedEvent<ApiType, [u128, u128]>;
       /**
        * Generic event
        **/
@@ -460,7 +466,7 @@ declare module '@polkadot/api-base/types/events' {
       /**
        * Event emitted when new lending market is created.
        **/
-      MarketCreated: AugmentedEvent<ApiType, [u32, u64, AccountId32, ComposableTraitsDefiCurrencyPair]>;
+      MarketCreated: AugmentedEvent<ApiType, [u32, u64, AccountId32, ComposableTraitsDefiCurrencyPairCurrencyId]>;
       MarketUpdated: AugmentedEvent<ApiType, [u32, ComposableTraitsLendingUpdateInput]>;
       /**
        * Event emitted when user repays borrow of beneficiary in given market.
@@ -558,7 +564,7 @@ declare module '@polkadot/api-base/types/events' {
       /**
        * An outgoing tx is created, and locked in the outgoing tx pool.
        **/
-      TransferOut: AugmentedEvent<ApiType, [H256, U8aFixed, u128, u32, CommonMosaicRemoteAssetId, u128]>;
+      TransferOut: AugmentedEvent<ApiType, [H256, ComposableSupportEthereumAddress, u128, u32, CommonMosaicRemoteAssetId, u128]>;
       /**
        * Generic event
        **/
@@ -624,6 +630,32 @@ declare module '@polkadot/api-base/types/events' {
        * Oracle slashed. \[oracle_address, asset_id, amount\]
        **/
       UserSlashed: AugmentedEvent<ApiType, [AccountId32, u128, u128]>;
+      /**
+       * Generic event
+       **/
+      [key: string]: AugmentedEvent<ApiType>;
+    };
+    pablo: {
+      /**
+       * Liquidity added into the pool `T::PoolId`.
+       **/
+      LiquidityAdded: AugmentedEvent<ApiType, [AccountId32, u128, u128, u128, u128]>;
+      /**
+       * Liquidity removed from pool `T::PoolId` by `T::AccountId` in balanced way.
+       **/
+      LiquidityRemoved: AugmentedEvent<ApiType, [AccountId32, u128, u128, u128, u128]>;
+      /**
+       * Pool with specified id `T::PoolId` was created successfully by `T::AccountId`.
+       **/
+      PoolCreated: AugmentedEvent<ApiType, [u128, AccountId32]>;
+      /**
+       * The sale ended, the funds repatriated and the pool deleted.
+       **/
+      PoolDeleted: AugmentedEvent<ApiType, [u128, u128, u128]>;
+      /**
+       * Token exchange happened.
+       **/
+      Swapped: AugmentedEvent<ApiType, [u128, AccountId32, u128, u128, u128, u128, u128]>;
       /**
        * Generic event
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-query.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-query.ts
@@ -1,7 +1,9 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import type { CommonMosaicRemoteAssetId, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDexConstantProductPoolInfo, ComposableTraitsDexStableSwapPoolInfo, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsLendingMarketConfig, ComposableTraitsOraclePrice, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundChannelDetails, CumulusPalletXcmpQueueOutboundChannelDetails, CumulusPalletXcmpQueueQueueConfigData, DaliRuntimeOpaqueSessionKeys, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletAssetsRegistryForeignMetadata, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsModelsReward, PalletCurrencyFactoryRanges, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicAssetInfo, PalletMosaicNetworkInfo, PalletMosaicRelayerStaleRelayer, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOracleWithdraw, PalletPreimageRequestStatus, PalletSchedulerScheduledV3, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public } from '@composable/types/interfaces/crowdloanRewards';
+import type { ComposableTraitsXcmCumulusMethodId } from '@composable/types/interfaces/common';
+import type { CommonMosaicRemoteAssetId, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDexConstantProductPoolInfo, ComposableTraitsDexStableSwapPoolInfo, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsLendingMarketConfig, ComposableTraitsOraclePrice, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundChannelDetails, CumulusPalletXcmpQueueOutboundChannelDetails, CumulusPalletXcmpQueueQueueConfigData, DaliRuntimeOpaqueSessionKeys, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletAssetsRegistryForeignMetadata, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsModelsReward, PalletCurrencyFactoryRanges, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicAssetInfo, PalletMosaicNetworkInfo, PalletMosaicRelayerStaleRelayer, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOracleWithdraw, PalletPreimageRequestStatus, PalletSchedulerScheduledV3, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public } from '@composable/types/interfaces/crowdloanRewards';
+import type { PalletPabloPoolConfiguration, PalletPabloPriceCumulative, PalletPabloTimeWeightedAveragePrice } from '@composable/types/interfaces/pablo';
 import type { ApiTypes } from '@polkadot/api-base/types';
 import type { Data } from '@polkadot/types';
 import type { BTreeMap, Bytes, Null, Option, U8aFixed, Vec, WrapperKeepOpaque, bool, u128, u16, u32, u64 } from '@polkadot/types-codec';
@@ -385,13 +387,27 @@ declare module '@polkadot/api-base/types/storage' {
       [key: string]: QueryableStorageEntry<ApiType>;
     };
     dutchAuction: {
+      /**
+       * set of reusable auction configurations
+       **/
+      configurations: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<ComposableTraitsTimeTimeReleaseFunction>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
+      /**
+       * orders are handled locally, but if these came from remote,
+       * these should be notified approtiately
+       **/
+      localOrderIdToRemote: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<ITuple<[u32, u64]>>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
       ordersIndex: AugmentedQuery<ApiType, () => Observable<u128>, []> & QueryableStorageEntry<ApiType, []>;
+      /**
+       * registered callback location for specific parachain
+       **/
+      parachainXcmCallbackLocation: AugmentedQuery<ApiType, (arg: u32 | AnyNumber | Uint8Array) => Observable<Option<ComposableTraitsXcmCumulusMethodId>>, [u32]> & QueryableStorageEntry<ApiType, [u32]>;
       sellOrders: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<PalletDutchAuctionSellOrder>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
       /**
        * one block storage, users payed N * WEIGHT for this Vec, so will not put bound here (neither
        * HydraDX does)
        **/
       takes: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<Vec<PalletDutchAuctionTakeOrder>>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
+      xcmSellOrders: AugmentedQuery<ApiType, (arg1: u32 | AnyNumber | Uint8Array, arg2: u64 | AnyNumber | Uint8Array) => Observable<Option<u128>>, [u32, u64]> & QueryableStorageEntry<ApiType, [u32, u64]>;
       /**
        * Generic query
        **/
@@ -576,6 +592,16 @@ declare module '@polkadot/api-base/types/storage' {
        * Mapping signing key to controller key
        **/
       signerToController: AugmentedQuery<ApiType, (arg: AccountId32 | string | Uint8Array) => Observable<Option<AccountId32>>, [AccountId32]> & QueryableStorageEntry<ApiType, [AccountId32]>;
+      /**
+       * Generic query
+       **/
+      [key: string]: QueryableStorageEntry<ApiType>;
+    };
+    pablo: {
+      poolCount: AugmentedQuery<ApiType, () => Observable<u128>, []> & QueryableStorageEntry<ApiType, []>;
+      pools: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<PalletPabloPoolConfiguration>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
+      priceCumulativeState: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<PalletPabloPriceCumulative>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
+      twapState: AugmentedQuery<ApiType, (arg: u128 | AnyNumber | Uint8Array) => Observable<Option<PalletPabloTimeWeightedAveragePrice>>, [u128]> & QueryableStorageEntry<ApiType, [u128]>;
       /**
        * Generic query
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-rpc.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-rpc.ts
@@ -1,7 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import type { AssetsBalance, CurrencyId } from '@composable/types/interfaces/assets';
+import type { CustomRpcBalance, CustomRpcCurrencyId } from '@composable/types/interfaces/common';
 import type { AugmentedRpc } from '@polkadot/rpc-core/types';
 import type { Metadata, StorageKey } from '@polkadot/types';
 import type { Bytes, HashMap, Json, Null, Option, Text, U256, U64, Vec, bool, u32, u64 } from '@polkadot/types-codec';
@@ -32,7 +32,7 @@ declare module '@polkadot/rpc-core/types/jsonrpc' {
       /**
        * Balance available for the specified account for the specified asset.
        **/
-      balanceOf: AugmentedRpc<(asset: CurrencyId | AnyNumber | Uint8Array, account: AccountId32 | string | Uint8Array, at?: Hash | string | Uint8Array) => Observable<AssetsBalance>>;
+      balanceOf: AugmentedRpc<(asset: CustomRpcCurrencyId | string, account: AccountId32 | string | Uint8Array, at?: Hash | string | Uint8Array) => Observable<CustomRpcBalance>>;
     };
     author: {
       /**

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-api-tx.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-api-tx.ts
@@ -1,7 +1,9 @@
 // Auto-generated via `yarn polkadot-types-from-chain`, do not edit
 /* eslint-disable */
 
-import type { CommonMosaicRemoteAssetId, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiCurrencyPair, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsLendingCreateInput, ComposableTraitsLendingUpdateInput, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, FrameSupportScheduleMaybeHashed, PalletAssetsRegistryForeignMetadata, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletDemocracyConviction, PalletDemocracyVoteAccountVote, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo, XcmVersionedMultiAsset } from '@composable/types/interfaces/crowdloanRewards';
+import type { ComposableTraitsDefiCurrencyPairCurrencyId, ComposableTraitsDefiSellCurrencyId, ComposableTraitsXcmXcmSellRequest } from '@composable/types/interfaces/common';
+import type { CommonMosaicRemoteAssetId, ComposableSupportEthereumAddress, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiTake, ComposableTraitsLendingCreateInput, ComposableTraitsLendingUpdateInput, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, FrameSupportScheduleMaybeHashed, PalletAssetsRegistryForeignMetadata, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletDemocracyConviction, PalletDemocracyVoteAccountVote, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo, XcmVersionedMultiAsset } from '@composable/types/interfaces/crowdloanRewards';
+import type { PalletPabloPoolInitConfiguration } from '@composable/types/interfaces/pablo';
 import type { ApiTypes } from '@polkadot/api-base/types';
 import type { Data } from '@polkadot/types';
 import type { Bytes, Compact, Option, U8aFixed, Vec, WrapperKeepOpaque, bool, u128, u16, u32, u64, u8 } from '@polkadot/types-codec';
@@ -206,14 +208,15 @@ declare module '@polkadot/api-base/types/submittable' {
     bondedFinance: {
       /**
        * Bond to an offer.
-       * And user should provide the number of contracts she is willing to buy.
-       * On offer completion (a.k.a. no more contract on the offer), the `stake` put by the
-       * creator is refunded.
+       * 
+       * The issuer should provide the number of contracts they are willing to buy.
+       * Once there are no more contracts available on the offer, the `stake` put by the
+       * offer creator is refunded.
        * 
        * The dispatch origin for this call must be _Signed_ and the sender must have the
-       * appropriate funds.
+       * appropriate funds to buy the desired number of contracts.
        * 
-       * Allow the bonder to ask for his account to be kept alive using the `keep_alive`
+       * Allows the issuer to ask for their account to be kept alive using the `keep_alive`
        * parameter.
        * 
        * Emits a `NewBond`.
@@ -221,19 +224,23 @@ declare module '@polkadot/api-base/types/submittable' {
        **/
       bond: AugmentedSubmittable<(offerId: u128 | AnyNumber | Uint8Array, nbOfBonds: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128, bool]>;
       /**
-       * Cancel a running offer. Blocking further bond but not cancelling the
-       * currently vested rewards. The `stake` put by the creator is refunded.
+       * Cancel a running offer.
+       * 
+       * Blocking further bonds but not cancelling the currently vested rewards. The `stake` put
+       * by the offer creator is refunded.
+       * 
        * The dispatch origin for this call must be _Signed_ and the sender must be `AdminOrigin`
        * 
        * Emits a `OfferCancelled`.
        **/
       cancel: AugmentedSubmittable<(offerId: u128 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128]>;
       /**
-       * Create a new offer. So later can `bond` it.
+       * Create a new bond offer. To be `bond` to later.
        * 
        * The dispatch origin for this call must be _Signed_ and the sender must have the
-       * appropriate funds.
-       * Allow the issuer to ask for his account to be kept alive using the `keep_alive`
+       * appropriate funds to stake the offer.
+       * 
+       * Allows the issuer to ask for their account to be kept alive using the `keep_alive`
        * parameter.
        * 
        * Emits a `NewOffer`.
@@ -324,7 +331,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * Emits `PoolCreated` even when successful.
        **/
-      create: AugmentedSubmittable<(pair: ComposableTraitsDefiCurrencyPair | { base?: any; quote?: any } | string | Uint8Array, fee: Permill | AnyNumber | Uint8Array, ownerFee: Permill | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiCurrencyPair, Permill, Permill]>;
+      create: AugmentedSubmittable<(pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, fee: Permill | AnyNumber | Uint8Array, ownerFee: Permill | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiCurrencyPairCurrencyId, Permill, Permill]>;
       /**
        * Remove liquidity from constant_product pool.
        * 
@@ -349,7 +356,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * Emits `Swapped` event when successful.
        **/
-      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPair | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPair, u128, u128, bool]>;
+      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPairCurrencyId, u128, u128, bool]>;
       /**
        * Generic tx
        **/
@@ -966,10 +973,15 @@ declare module '@polkadot/api-base/types/submittable' {
     };
     dutchAuction: {
       /**
+       * Inserts or replaces auction configuration.
+       * Already running auctions are not updated.
+       **/
+      addConfiguration: AugmentedSubmittable<(configurationId: u128 | AnyNumber | Uint8Array, configuration: ComposableTraitsTimeTimeReleaseFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsTimeTimeReleaseFunction]>;
+      /**
        * sell `order` in auction with `configuration`
        * some deposit is taken for storing sell order
        **/
-      ask: AugmentedSubmittable<(order: ComposableTraitsDefiSell | { pair?: any; take?: any } | string | Uint8Array, configuration: ComposableTraitsTimeTimeReleaseFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSell, ComposableTraitsTimeTimeReleaseFunction]>;
+      ask: AugmentedSubmittable<(order: ComposableTraitsDefiSellCurrencyId | { pair?: any; take?: any } | string | Uint8Array, configuration: ComposableTraitsTimeTimeReleaseFunction | { LinearDecrease: any } | { StairstepExponentialDecrease: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSellCurrencyId, ComposableTraitsTimeTimeReleaseFunction]>;
       /**
        * allows to remove `order_id` from storage
        **/
@@ -978,6 +990,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * adds take to list, does not execute take immediately
        **/
       take: AugmentedSubmittable<(orderId: u128 | AnyNumber | Uint8Array, take: ComposableTraitsDefiTake | { amount?: any; limit?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiTake]>;
+      xcmSell: AugmentedSubmittable<(request: ComposableTraitsXcmXcmSellRequest | { orderId?: any; fromTo?: any; order?: any; configuration?: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsXcmXcmSellRequest]>;
       /**
        * Generic tx
        **/
@@ -1442,7 +1455,8 @@ declare module '@polkadot/api-base/types/submittable' {
       [key: string]: SubmittableExtrinsicFunction<ApiType>;
     };
     liquidations: {
-      addLiquidationStrategy: AugmentedSubmittable<(configuraiton: PalletLiquidationsLiquidationStrategyConfiguration | { DutchAuction: any } | { UniswapV2: any } | { XcmDex: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [PalletLiquidationsLiquidationStrategyConfiguration]>;
+      addLiquidationStrategy: AugmentedSubmittable<(configuraiton: PalletLiquidationsLiquidationStrategyConfiguration | { DutchAuction: any } | { Pablo: any } | { Xcm: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [PalletLiquidationsLiquidationStrategyConfiguration]>;
+      sell: AugmentedSubmittable<(order: ComposableTraitsDefiSellCurrencyId | { pair?: any; take?: any } | string | Uint8Array, configuration: Vec<u32> | (u32 | AnyNumber | Uint8Array)[]) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiSellCurrencyId, Vec<u32>]>;
       /**
        * Generic tx
        **/
@@ -1491,7 +1505,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * Emits `Swapped` event when successful.
        **/
-      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPair | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPair, u128, u128, bool]>;
+      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPairCurrencyId, u128, u128, bool]>;
       /**
        * Generic tx
        **/
@@ -1570,7 +1584,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * - Transfers near Balance::max may result in overflows, which are caught and returned as
        * an error.
        **/
-      transferTo: AugmentedSubmittable<(networkId: u32 | AnyNumber | Uint8Array, assetId: u128 | AnyNumber | Uint8Array, address: U8aFixed | string | Uint8Array, amount: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u32, u128, U8aFixed, u128, bool]>;
+      transferTo: AugmentedSubmittable<(networkId: u32 | AnyNumber | Uint8Array, assetId: u128 | AnyNumber | Uint8Array, address: ComposableSupportEthereumAddress | string | Uint8Array, amount: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u32, u128, ComposableSupportEthereumAddress, u128, bool]>;
       /**
        * Update a network asset mapping.
        * 
@@ -1781,6 +1795,51 @@ declare module '@polkadot/api-base/types/submittable' {
        * Emits `PriceSubmitted` event when successful.
        **/
       submitPrice: AugmentedSubmittable<(price: u128 | AnyNumber | Uint8Array, assetId: u128 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128]>;
+      /**
+       * Generic tx
+       **/
+      [key: string]: SubmittableExtrinsicFunction<ApiType>;
+    };
+    pablo: {
+      /**
+       * Add liquidity to the given pool.
+       * 
+       * Emits `LiquidityAdded` event when successful.
+       **/
+      addLiquidity: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, baseAmount: u128 | AnyNumber | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minMintAmount: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128, u128, u128, bool]>;
+      /**
+       * Execute a buy order on pool.
+       * 
+       * Emits `Swapped` event when successful.
+       **/
+      buy: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, assetId: u128 | AnyNumber | Uint8Array, amount: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128, u128, bool]>;
+      /**
+       * Create a new pool.
+       * 
+       * Emits `PoolCreated` event when successful.
+       **/
+      create: AugmentedSubmittable<(pool: PalletPabloPoolInitConfiguration | { StableSwap: any } | { ConstantProduct: any } | { LiquidityBootstrapping: any } | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [PalletPabloPoolInitConfiguration]>;
+      enableTwap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128]>;
+      /**
+       * Remove liquidity from the given pool.
+       * 
+       * Emits `LiquidityRemoved` event when successful.
+       **/
+      removeLiquidity: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, lpAmount: u128 | AnyNumber | Uint8Array, minBaseAmount: u128 | AnyNumber | Uint8Array, minQuoteAmount: u128 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128, u128, u128]>;
+      /**
+       * Execute a sell order on pool.
+       * 
+       * Emits `Swapped` event when successful.
+       **/
+      sell: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, assetId: u128 | AnyNumber | Uint8Array, amount: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, u128, u128, bool]>;
+      /**
+       * Execute a specific swap operation.
+       * 
+       * The `quote_amount` is always the quote asset amount (A/B => B), (B/A => A).
+       * 
+       * Emits `Swapped` event when successful.
+       **/
+      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPairCurrencyId, u128, u128, bool]>;
       /**
        * Generic tx
        **/
@@ -2061,7 +2120,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * Emits `PoolCreated` event when successful.
        **/
-      create: AugmentedSubmittable<(pair: ComposableTraitsDefiCurrencyPair | { base?: any; quote?: any } | string | Uint8Array, amplificationCoefficient: u16 | AnyNumber | Uint8Array, fee: Permill | AnyNumber | Uint8Array, ownerFee: Permill | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiCurrencyPair, u16, Permill, Permill]>;
+      create: AugmentedSubmittable<(pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, amplificationCoefficient: u16 | AnyNumber | Uint8Array, fee: Permill | AnyNumber | Uint8Array, ownerFee: Permill | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [ComposableTraitsDefiCurrencyPairCurrencyId, u16, Permill, Permill]>;
       /**
        * Remove liquidity from stable-swap pool.
        * 
@@ -2081,7 +2140,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * Emits `Swapped` event when successful.
        **/
-      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPair | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPair, u128, u128, bool]>;
+      swap: AugmentedSubmittable<(poolId: u128 | AnyNumber | Uint8Array, pair: ComposableTraitsDefiCurrencyPairCurrencyId | { base?: any; quote?: any } | string | Uint8Array, quoteAmount: u128 | AnyNumber | Uint8Array, minReceive: u128 | AnyNumber | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [u128, ComposableTraitsDefiCurrencyPairCurrencyId, u128, u128, bool]>;
       /**
        * Generic tx
        **/

--- a/integration-tests/runtime-tests/src/types/interfaces/augment-types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/augment-types.ts
@@ -1,8 +1,9 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-import type { AssetsBalance, CurrencyId } from '@composable/types/interfaces/assets';
-import type { CommonMosaicRemoteAssetId, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsAuctionAuctionStepFunction, ComposableTraitsBondedFinanceBondDuration, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsBondedFinanceBondOfferReward, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiCurrencyPair, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsDexConsantProductPoolInfo, ComposableTraitsDexConstantProductPoolInfo, ComposableTraitsDexStableSwapPoolInfo, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsLendingCreateInput, ComposableTraitsLendingMarketConfig, ComposableTraitsLendingUpdateInput, ComposableTraitsOraclePrice, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundChannelDetails, CumulusPalletXcmpQueueInboundStatus, CumulusPalletXcmpQueueOutboundChannelDetails, CumulusPalletXcmpQueueOutboundStatus, CumulusPalletXcmpQueueQueueConfigData, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, FrameSupportScheduleLookupError, FrameSupportScheduleMaybeHashed, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletAssetsRegistryForeignMetadata, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsEcdsaSignature, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsModelsReward, PalletCrowdloanRewardsReward, PalletCurrencyFactoryRanges, PalletCurrencyFactoryRangesRange, PalletDemocracyConviction, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicAssetInfo, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo, PalletMosaicRelayerStaleRelayer, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOraclePrice, PalletOracleWithdraw, PalletPreimageRequestStatus, PalletSchedulerReleases, PalletSchedulerScheduledV2, PalletSchedulerScheduledV3, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotParachainPrimitivesXcmpMessageFormat, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public, XcmVersionedMultiAsset } from '@composable/types/interfaces/crowdloanRewards';
+import type { AssetsBalance, ComposableTraitsDefiCurrencyPairCurrencyId, ComposableTraitsDefiSellCurrencyId, ComposableTraitsXcmCumulusMethodId, ComposableTraitsXcmXcmSellRequest, CurrencyId, CustomRpcBalance, CustomRpcCurrencyId, SafeRpcWrapper } from '@composable/types/interfaces/common';
+import type { CommonMosaicRemoteAssetId, ComposableSupportEthereumAddress, ComposableTraitsAssetsXcmAssetLocation, ComposableTraitsAuctionAuctionStepFunction, ComposableTraitsBondedFinanceBondDuration, ComposableTraitsBondedFinanceBondOffer, ComposableTraitsBondedFinanceBondOfferReward, ComposableTraitsCallFilterCallFilterEntry, ComposableTraitsDefiSell, ComposableTraitsDefiTake, ComposableTraitsDexConsantProductPoolInfo, ComposableTraitsDexConstantProductPoolInfo, ComposableTraitsDexStableSwapPoolInfo, ComposableTraitsGovernanceSignedRawOrigin, ComposableTraitsLendingCreateInput, ComposableTraitsLendingMarketConfig, ComposableTraitsLendingUpdateInput, ComposableTraitsOraclePrice, ComposableTraitsTimeTimeReleaseFunction, ComposableTraitsVaultVaultConfig, ComposableTraitsVestingVestingSchedule, CumulusPalletDmpQueueConfigData, CumulusPalletDmpQueuePageIndexData, CumulusPalletParachainSystemRelayStateSnapshotMessagingStateSnapshot, CumulusPalletXcmpQueueInboundChannelDetails, CumulusPalletXcmpQueueInboundStatus, CumulusPalletXcmpQueueOutboundChannelDetails, CumulusPalletXcmpQueueOutboundStatus, CumulusPalletXcmpQueueQueueConfigData, CumulusPrimitivesParachainInherentParachainInherentData, DaliRuntimeOpaqueSessionKeys, DaliRuntimeOriginCaller, FrameSupportScheduleLookupError, FrameSupportScheduleMaybeHashed, OrmlTokensAccountData, OrmlTokensBalanceLock, PalletAssetsRegistryCandidateStatus, PalletAssetsRegistryForeignMetadata, PalletCollatorSelectionCandidateInfo, PalletCrowdloanRewardsModelsEcdsaSignature, PalletCrowdloanRewardsModelsProof, PalletCrowdloanRewardsModelsRemoteAccount, PalletCrowdloanRewardsModelsReward, PalletCrowdloanRewardsReward, PalletCurrencyFactoryRanges, PalletCurrencyFactoryRangesRange, PalletDemocracyConviction, PalletDemocracyPreimageStatus, PalletDemocracyReferendumInfo, PalletDemocracyReleases, PalletDemocracyVoteAccountVote, PalletDemocracyVoteThreshold, PalletDemocracyVoteVoting, PalletDutchAuctionSellOrder, PalletDutchAuctionTakeOrder, PalletIdentityBitFlags, PalletIdentityIdentityInfo, PalletIdentityJudgement, PalletIdentityRegistrarInfo, PalletIdentityRegistration, PalletLiquidationsLiquidationStrategyConfiguration, PalletLiquidityBootstrappingPool, PalletMosaicAssetInfo, PalletMosaicDecayBudgetPenaltyDecayer, PalletMosaicNetworkInfo, PalletMosaicRelayerStaleRelayer, PalletOracleAssetInfo, PalletOraclePrePrice, PalletOraclePrice, PalletOracleWithdraw, PalletPreimageRequestStatus, PalletSchedulerReleases, PalletSchedulerScheduledV2, PalletSchedulerScheduledV3, PalletTreasuryProposal, PalletVaultModelsStrategyOverview, PalletVaultModelsVaultInfo, PolkadotParachainPrimitivesXcmpMessageFormat, PolkadotPrimitivesV1AbridgedHostConfiguration, PolkadotPrimitivesV1PersistedValidationData, SpConsensusAuraSr25519AppSr25519Public, XcmVersionedMultiAsset } from '@composable/types/interfaces/crowdloanRewards';
+import type { PalletPabloPoolConfiguration, PalletPabloPoolInitConfiguration, PalletPabloPriceCumulative, PalletPabloTimeWeightedAveragePrice } from '@composable/types/interfaces/pablo';
 import type { Data, StorageKey } from '@polkadot/types';
 import type { BitVec, Bool, Bytes, I128, I16, I256, I32, I64, I8, Json, Null, Raw, Text, Type, U128, U16, U256, U32, U64, U8, USize, bool, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types-codec';
 import type { BlockAttestations, IncludedBlocks, MoreAttestations } from '@polkadot/types/interfaces/attestations';
@@ -209,14 +210,16 @@ declare module '@polkadot/types/types/registry' {
     CompactAssignmentsWith24: CompactAssignmentsWith24;
     CompactScore: CompactScore;
     CompactScoreCompact: CompactScoreCompact;
+    ComposableSupportEthereumAddress: ComposableSupportEthereumAddress;
     ComposableTraitsAssetsXcmAssetLocation: ComposableTraitsAssetsXcmAssetLocation;
     ComposableTraitsAuctionAuctionStepFunction: ComposableTraitsAuctionAuctionStepFunction;
     ComposableTraitsBondedFinanceBondDuration: ComposableTraitsBondedFinanceBondDuration;
     ComposableTraitsBondedFinanceBondOffer: ComposableTraitsBondedFinanceBondOffer;
     ComposableTraitsBondedFinanceBondOfferReward: ComposableTraitsBondedFinanceBondOfferReward;
     ComposableTraitsCallFilterCallFilterEntry: ComposableTraitsCallFilterCallFilterEntry;
-    ComposableTraitsDefiCurrencyPair: ComposableTraitsDefiCurrencyPair;
+    ComposableTraitsDefiCurrencyPairCurrencyId: ComposableTraitsDefiCurrencyPairCurrencyId;
     ComposableTraitsDefiSell: ComposableTraitsDefiSell;
+    ComposableTraitsDefiSellCurrencyId: ComposableTraitsDefiSellCurrencyId;
     ComposableTraitsDefiTake: ComposableTraitsDefiTake;
     ComposableTraitsDexConsantProductPoolInfo: ComposableTraitsDexConsantProductPoolInfo;
     ComposableTraitsDexConstantProductPoolInfo: ComposableTraitsDexConstantProductPoolInfo;
@@ -229,6 +232,8 @@ declare module '@polkadot/types/types/registry' {
     ComposableTraitsTimeTimeReleaseFunction: ComposableTraitsTimeTimeReleaseFunction;
     ComposableTraitsVaultVaultConfig: ComposableTraitsVaultVaultConfig;
     ComposableTraitsVestingVestingSchedule: ComposableTraitsVestingVestingSchedule;
+    ComposableTraitsXcmCumulusMethodId: ComposableTraitsXcmCumulusMethodId;
+    ComposableTraitsXcmXcmSellRequest: ComposableTraitsXcmXcmSellRequest;
     ConfigData: ConfigData;
     Consensus: Consensus;
     ConsensusEngineId: ConsensusEngineId;
@@ -315,6 +320,8 @@ declare module '@polkadot/types/types/registry' {
     CumulusPalletXcmpQueueQueueConfigData: CumulusPalletXcmpQueueQueueConfigData;
     CumulusPrimitivesParachainInherentParachainInherentData: CumulusPrimitivesParachainInherentParachainInherentData;
     CurrencyId: CurrencyId;
+    CustomRpcBalance: CustomRpcBalance;
+    CustomRpcCurrencyId: CustomRpcCurrencyId;
     DaliRuntimeOpaqueSessionKeys: DaliRuntimeOpaqueSessionKeys;
     DaliRuntimeOriginCaller: DaliRuntimeOriginCaller;
     Data: Data;
@@ -749,6 +756,10 @@ declare module '@polkadot/types/types/registry' {
     PalletOraclePrePrice: PalletOraclePrePrice;
     PalletOraclePrice: PalletOraclePrice;
     PalletOracleWithdraw: PalletOracleWithdraw;
+    PalletPabloPoolConfiguration: PalletPabloPoolConfiguration;
+    PalletPabloPoolInitConfiguration: PalletPabloPoolInitConfiguration;
+    PalletPabloPriceCumulative: PalletPabloPriceCumulative;
+    PalletPabloTimeWeightedAveragePrice: PalletPabloTimeWeightedAveragePrice;
     PalletPreimageRequestStatus: PalletPreimageRequestStatus;
     PalletSchedulerReleases: PalletSchedulerReleases;
     PalletSchedulerScheduledV2: PalletSchedulerScheduledV2;
@@ -893,6 +904,7 @@ declare module '@polkadot/types/types/registry' {
     RuntimeVersion: RuntimeVersion;
     RuntimeVersionApi: RuntimeVersionApi;
     RuntimeVersionPartial: RuntimeVersionPartial;
+    SafeRpcWrapper: SafeRpcWrapper;
     Schedule: Schedule;
     Scheduled: Scheduled;
     ScheduledTo254: ScheduledTo254;

--- a/integration-tests/runtime-tests/src/types/interfaces/common/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/common/definitions.ts
@@ -1,0 +1,17 @@
+export default {
+  rpc: {},
+  types: {
+    SafeRpcWrapper: "String",
+    CustomRpcCurrencyId: "SafeRpcWrapper",
+    CustomRpcBalance: "SafeRpcWrapper",
+    CurrencyId: "u128",
+    AssetsBalance: "u128",
+    ComposableTraitsDefiSellCurrencyId: "CurrencyId",
+    ComposableTraitsDefiCurrencyPairCurrencyId: {
+      base: "CurrencyId",
+      quote: "CurrencyId"
+    },
+    ComposableTraitsXcmCumulusMethodId: "Null",
+    ComposableTraitsXcmXcmSellRequest: "Null"
+  },
+};

--- a/integration-tests/runtime-tests/src/types/interfaces/common/index.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/common/index.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export type PHANTOM_ASSETS = 'assets';
+export * from './types';

--- a/integration-tests/runtime-tests/src/types/interfaces/common/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/common/types.ts
@@ -1,0 +1,36 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+import type { Null, Struct, Text, u128 } from '@polkadot/types-codec';
+
+/** @name AssetsBalance */
+export interface AssetsBalance extends u128 {}
+
+/** @name ComposableTraitsDefiCurrencyPairCurrencyId */
+export interface ComposableTraitsDefiCurrencyPairCurrencyId extends Struct {
+  readonly base: CurrencyId;
+  readonly quote: CurrencyId;
+}
+
+/** @name ComposableTraitsDefiSellCurrencyId */
+export interface ComposableTraitsDefiSellCurrencyId extends CurrencyId {}
+
+/** @name ComposableTraitsXcmCumulusMethodId */
+export interface ComposableTraitsXcmCumulusMethodId extends Null {}
+
+/** @name ComposableTraitsXcmXcmSellRequest */
+export interface ComposableTraitsXcmXcmSellRequest extends Null {}
+
+/** @name CurrencyId */
+export interface CurrencyId extends u128 {}
+
+/** @name CustomRpcBalance */
+export interface CustomRpcBalance extends SafeRpcWrapper {}
+
+/** @name CustomRpcCurrencyId */
+export interface CustomRpcCurrencyId extends SafeRpcWrapper {}
+
+/** @name SafeRpcWrapper */
+export interface SafeRpcWrapper extends Text {}
+
+export type PHANTOM_COMMON = 'common';

--- a/integration-tests/runtime-tests/src/types/interfaces/crowdloanRewards/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/crowdloanRewards/definitions.ts
@@ -32,7 +32,7 @@ export default {
     SpConsensusAuraSr25519AppSr25519Public: "Null",
     ComposableTraitsBondedFinanceBondOffer: {
       beneficiary: "AccountId32",
-      asset: "u128",
+      asset: "CurrencyId",
       bondPrice: "u128",
       nbOfBonds: "u128",
       maturity: "ComposableTraitsBondedFinanceBondDuration",
@@ -43,7 +43,7 @@ export default {
       Finite: {returnIn: "u32"}
     },
     ComposableTraitsBondedFinanceBondOfferReward: {
-      asset: "u128",
+      asset: "CurrencyId",
       amount: "u128",
       maturity: "u32"
     },
@@ -125,10 +125,6 @@ export default {
     PalletCurrencyFactoryRanges: "Null",
     PalletCurrencyFactoryRangesRange: "Null",
     PalletLiquidationsLiquidationStrategyConfiguration: "Null",
-    ComposableTraitsDefiCurrencyPair: {
-      base: "u128",
-      quote: "u128"
-    },
     CommonMosaicRemoteAssetId: "Null",
     ComposableTraitsDexConsantProductPoolInfo: "Null",
     ComposableTraitsLendingMarketConfig: "Null",
@@ -139,10 +135,7 @@ export default {
     PalletLiquidityBootstrappingPool: "Null",
     ComposableTraitsDexConstantProductPoolInfo: {
       owner: "AccountId32",
-      pair: {
-        base: "u128",
-        quote: "u128"
-      },
+      pair: "ComposableTraitsDefiCurrencyPairCurrencyId",
       lpToken: "u128",
       fee: "Permill",
       ownerFee: "Permill"

--- a/integration-tests/runtime-tests/src/types/interfaces/crowdloanRewards/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/crowdloanRewards/types.ts
@@ -1,6 +1,7 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
+import type { ComposableTraitsDefiCurrencyPairCurrencyId, CurrencyId } from '@composable/types/interfaces/common';
 import type { Enum, Null, Struct, bool, u128, u32 } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
 import type { EthereumAccountId } from '@polkadot/types/interfaces/eth';
@@ -10,6 +11,9 @@ import type { AccountId32, Balance, Permill } from '@polkadot/types/interfaces/r
 
 /** @name CommonMosaicRemoteAssetId */
 export interface CommonMosaicRemoteAssetId extends Null {}
+
+/** @name ComposableSupportEthereumAddress */
+export interface ComposableSupportEthereumAddress extends Null {}
 
 /** @name ComposableTraitsAssetsXcmAssetLocation */
 export interface ComposableTraitsAssetsXcmAssetLocation extends Null {}
@@ -27,7 +31,7 @@ export interface ComposableTraitsBondedFinanceBondDuration extends Struct {
 /** @name ComposableTraitsBondedFinanceBondOffer */
 export interface ComposableTraitsBondedFinanceBondOffer extends Struct {
   readonly beneficiary: AccountId32;
-  readonly asset: u128;
+  readonly asset: CurrencyId;
   readonly bondPrice: u128;
   readonly nbOfBonds: u128;
   readonly maturity: ComposableTraitsBondedFinanceBondDuration;
@@ -37,19 +41,13 @@ export interface ComposableTraitsBondedFinanceBondOffer extends Struct {
 
 /** @name ComposableTraitsBondedFinanceBondOfferReward */
 export interface ComposableTraitsBondedFinanceBondOfferReward extends Struct {
-  readonly asset: u128;
+  readonly asset: CurrencyId;
   readonly amount: u128;
   readonly maturity: u32;
 }
 
 /** @name ComposableTraitsCallFilterCallFilterEntry */
 export interface ComposableTraitsCallFilterCallFilterEntry extends Null {}
-
-/** @name ComposableTraitsDefiCurrencyPair */
-export interface ComposableTraitsDefiCurrencyPair extends Struct {
-  readonly base: u128;
-  readonly quote: u128;
-}
 
 /** @name ComposableTraitsDefiSell */
 export interface ComposableTraitsDefiSell extends Null {}
@@ -63,10 +61,7 @@ export interface ComposableTraitsDexConsantProductPoolInfo extends Null {}
 /** @name ComposableTraitsDexConstantProductPoolInfo */
 export interface ComposableTraitsDexConstantProductPoolInfo extends Struct {
   readonly owner: AccountId32;
-  readonly pair: {
-    readonly base: u128;
-    readonly quote: u128;
-  } & Struct;
+  readonly pair: ComposableTraitsDefiCurrencyPairCurrencyId;
   readonly lpToken: u128;
   readonly fee: Permill;
   readonly ownerFee: Permill;

--- a/integration-tests/runtime-tests/src/types/interfaces/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/definitions.ts
@@ -1,2 +1,5 @@
 export { default as crowdloanRewards } from "./crowdloanRewards/definitions";
 export { default as assets } from "./assets/definitions";
+export { default as lending } from "./lending/definitions";
+export { default as common } from "./common/definitions";
+export { default as pablo } from "./pablo/definitions";

--- a/integration-tests/runtime-tests/src/types/interfaces/lending/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/lending/definitions.ts
@@ -1,0 +1,4 @@
+export default {
+  rpc: {},
+  types: {}
+};

--- a/integration-tests/runtime-tests/src/types/interfaces/lending/index.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/lending/index.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export type PHANTOM_ASSETS = 'assets';
+export * from './types';

--- a/integration-tests/runtime-tests/src/types/interfaces/lending/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/lending/types.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export type PHANTOM_ASSETS = 'assets';
+export type PHANTOM_LENDING = 'lending';

--- a/integration-tests/runtime-tests/src/types/interfaces/pablo/definitions.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/pablo/definitions.ts
@@ -1,0 +1,15 @@
+export default {
+  rpc: {},
+  types: {
+    PalletPabloPoolInitConfiguration: "PalletPabloPoolConfiguration",
+    PalletPabloPoolConfiguration: {
+      _enum: {
+        StableSwap: "Null",
+        ConstantProduct: "Null",
+        LiquidityBootstrapping: "Null"
+      }
+    },
+    PalletPabloPriceCumulative: "Null",
+    PalletPabloTimeWeightedAveragePrice: "Null",
+  },
+};

--- a/integration-tests/runtime-tests/src/types/interfaces/pablo/index.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/pablo/index.ts
@@ -1,4 +1,4 @@
 // Auto-generated via `yarn polkadot-types-from-defs`, do not edit
 /* eslint-disable */
 
-export type PHANTOM_ASSETS = 'assets';
+export * from './types';

--- a/integration-tests/runtime-tests/src/types/interfaces/pablo/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/pablo/types.ts
@@ -1,0 +1,23 @@
+// Auto-generated via `yarn polkadot-types-from-defs`, do not edit
+/* eslint-disable */
+
+import type { Enum, Null } from '@polkadot/types-codec';
+
+/** @name PalletPabloPoolConfiguration */
+export interface PalletPabloPoolConfiguration extends Enum {
+  readonly isStableSwap: boolean;
+  readonly isConstantProduct: boolean;
+  readonly isLiquidityBootstrapping: boolean;
+  readonly type: 'StableSwap' | 'ConstantProduct' | 'LiquidityBootstrapping';
+}
+
+/** @name PalletPabloPoolInitConfiguration */
+export interface PalletPabloPoolInitConfiguration extends PalletPabloPoolConfiguration {}
+
+/** @name PalletPabloPriceCumulative */
+export interface PalletPabloPriceCumulative extends Null {}
+
+/** @name PalletPabloTimeWeightedAveragePrice */
+export interface PalletPabloTimeWeightedAveragePrice extends Null {}
+
+export type PHANTOM_PABLO = 'pablo';

--- a/integration-tests/runtime-tests/src/types/interfaces/types.ts
+++ b/integration-tests/runtime-tests/src/types/interfaces/types.ts
@@ -3,3 +3,6 @@
 
 export * from './crowdloanRewards/types';
 export * from './assets/types';
+export * from './lending/types';
+export * from './common/types';
+export * from './pablo/types';

--- a/integration-tests/runtime-tests/src/utils/testSetup.ts
+++ b/integration-tests/runtime-tests/src/utils/testSetup.ts
@@ -19,25 +19,27 @@ global.testSudoCommands = true;
 
 exports.mochaHooks = {
   async beforeAll() {
-    this.timeout(5*60*1000);
-// Enable and inject BN dependency
-  chai.use(chai_bn(BN));
-  const rpc = Object.keys(definitions).reduce((accumulator, key) => ({ ...accumulator, [key]: definitions[key].rpc }), {});
-  const types = Object.values(definitions).reduce((accumulator, { types }) => ({ ...accumulator, ...types }), {});
+    this.timeout(5 * 60 * 1000);
+    // Enable and inject BN dependency
+    chai.use(chai_bn(BN));
+    const rpc = Object.keys(definitions)
+      .filter(k => Object.keys(definitions[k].rpc).length > 0)
+      .reduce((accumulator, key) => ({ ...accumulator, [key]: definitions[key].rpc }), {});
+    const types = Object.values(definitions).reduce((accumulator, { types }) => ({ ...accumulator, ...types }), {});
 
-  global.endpoint = 'ws://' + (process.env.ENDPOINT ?? '127.0.0.1:9988');
-  const provider = new WsProvider(global.endpoint);
-  console.debug(`Establishing connection to ${global.endpoint}...`);
-  const apiOptions: ApiOptions = {
-    provider, types, rpc
-  };
-  global.api = await ApiPromise.create(apiOptions);
+    global.endpoint = 'ws://' + (process.env.ENDPOINT ?? '127.0.0.1:9988');
+    const provider = new WsProvider(global.endpoint);
+    console.debug(`Establishing connection to ${global.endpoint}...`);
+    const apiOptions: ApiOptions = {
+      provider, types, rpc
+    };
+    global.api = await ApiPromise.create(apiOptions);
 
-  global.web3 = new Web3();
+    global.web3 = new Web3();
 
-  // do something before every test,
-  // then run the next hook in this array
-  global.keyring = new Keyring({ type: 'sr25519' });
+    // do something before every test,
+    // then run the next hook in this array
+    global.keyring = new Keyring({ type: 'sr25519' });
 
     if (global.useTestnetWallets === true) {
       global.walletAlice = global.keyring.addFromUri('//Alice');

--- a/integration-tests/runtime-tests/test/tests/assets/rpcAssetsTests.ts
+++ b/integration-tests/runtime-tests/test/tests/assets/rpcAssetsTests.ts
@@ -1,23 +1,28 @@
-import { CurrencyId } from '@composable/types/interfaces';
-import { AnyNumber } from '@polkadot/types-codec/types';
+import { SafeRpcWrapper } from '@composable/types/interfaces';
 import { expect } from 'chai';
 import testConfiguration from './test_configuration.json';
 
-describe('rpc.assets Tests', function () {
-    if (!testConfiguration.enabledTests.rpc.enabled)
-        return;
-    it('rpc.assets.balanceOf Tests', async function () {
-        if (!testConfiguration.enabledTests.rpc.balanceOf__success)
-            this.skip();
-        const asset_id = api.createType('CurrencyId', '123456789123456789');
-        const publicKey = walletAlice.address;
-        const result = await RpcAssetsTests.rpcAssetsTest(asset_id, publicKey);
-        expect(result).to.be.a["bignumber"].that.equals('0');
-    });
+describe('rpc.assets Tests', function() {
+  if (!testConfiguration.enabledTests.rpc.enabled)
+    return;
+  it('rpc.assets.balanceOf Tests', async function() {
+    if (!testConfiguration.enabledTests.rpc.balanceOf__success)
+        this.skip();
+    const publicKey = walletBob.address;
+    const PICA = api.createType('SafeRpcWrapper', 1) as SafeRpcWrapper;
+    const PICA_amount = await RpcAssetsTests.rpcAssetsTest(PICA, publicKey);
+    expect(parseInt(PICA_amount.toString())).to.not.equals(0);
+    const KSM = api.createType('SafeRpcWrapper', 4) as SafeRpcWrapper;
+    const KSM_amount = await RpcAssetsTests.rpcAssetsTest(KSM, publicKey);
+    expect(parseInt(KSM_amount.toString())).to.be.equals(0);
+    const kUSD = api.createType('SafeRpcWrapper', 129) as SafeRpcWrapper;
+    const kUSD_amount = await RpcAssetsTests.rpcAssetsTest(kUSD, publicKey);
+    expect(parseInt(kUSD_amount.toString())).to.be.equals(0);
+  });
 });
 
 export class RpcAssetsTests {
-    public static async rpcAssetsTest(asset_id: CurrencyId | AnyNumber, publicKey: string | Uint8Array) {
-        return await api.rpc.assets.balanceOf(asset_id, publicKey);
-    }
+  public static async rpcAssetsTest(assetId: SafeRpcWrapper, publicKey: string | Uint8Array) {
+    return await api.rpc.assets.balanceOf(assetId, publicKey);
+  }
 }

--- a/integration-tests/runtime-tests/test/tests/dexTests/constantProductDex/testHandlers/constantProductDexHelper.ts
+++ b/integration-tests/runtime-tests/test/tests/dexTests/constantProductDex/testHandlers/constantProductDexHelper.ts
@@ -15,9 +15,9 @@ quoteAmountTotal = 0;
 mintedLPTokens = 0;
 
 export async function createPool(walletId: KeyringPair, baseAssetId: number, quoteAssetId: number, ownerFee: number){
-  const pair = api.createType('ComposableTraitsDefiCurrencyPair', {
-    base: api.createType('u128', baseAssetId),
-    quote: api.createType('u128', quoteAssetId)
+  const pair = api.createType('ComposableTraitsDefiCurrencyPairCurrencyId', {
+    base: api.createType('CurrencyId', baseAssetId),
+    quote: api.createType('CurrencyId', quoteAssetId)
   });
   const fee = api.createType('Permill', 0);
   const ownerFees = api.createType('Permill', ownerFee);
@@ -119,9 +119,9 @@ export async function swapTokenPairs(wallet: KeyringPair,
   minReceiveAmount: number = 0
   ){
     const poolIdParam = api.createType('u128', poolId);
-    const currencyPair = api.createType('ComposableTraitsDefiCurrencyPair', {
-      base: api.createType('u128', baseAssetId),
-      quote: api.createType('u128',quoteAssetId)
+    const currencyPair = api.createType('ComposableTraitsDefiCurrencyPairCurrencyId', {
+      base: api.createType('CurrencyId', baseAssetId),
+      quote: api.createType('CurrencyId',quoteAssetId)
     });
     const quoteAmountParam = api.createType('u128', quoteAmount);
     const minReceiveParam = api.createType('u128', minReceiveAmount);

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -1193,8 +1193,8 @@ mod benches {
 
 impl_runtime_apis! {
 	impl assets_runtime_api::AssetsRuntimeApi<Block, CurrencyId, AccountId, Balance> for Runtime {
-		fn balance_of(asset_id: SafeRpcWrapper<CurrencyId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */ {
-			SafeRpcWrapper(<Assets as fungibles::Inspect::<AccountId>>::balance(asset_id.0, &account_id))
+		fn balance_of(SafeRpcWrapper(asset_id): SafeRpcWrapper<CurrencyId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */ {
+			SafeRpcWrapper(<Assets as fungibles::Inspect::<AccountId>>::balance(asset_id, &account_id))
 		}
 	}
 

--- a/runtime/picasso/src/lib.rs
+++ b/runtime/picasso/src/lib.rs
@@ -909,8 +909,8 @@ mod benches {
 
 impl_runtime_apis! {
 	impl assets_runtime_api::AssetsRuntimeApi<Block, CurrencyId, AccountId, Balance> for Runtime {
-		fn balance_of(asset_id: SafeRpcWrapper<CurrencyId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */ {
-			SafeRpcWrapper(<Assets as fungibles::Inspect::<AccountId>>::balance(asset_id.0, &account_id))
+		fn balance_of(SafeRpcWrapper(asset_id): SafeRpcWrapper<CurrencyId>, account_id: AccountId) -> SafeRpcWrapper<Balance> /* Balance */ {
+			SafeRpcWrapper(<Assets as fungibles::Inspect::<AccountId>>::balance(asset_id, &account_id))
 		}
 	}
 

--- a/runtime/primitives/src/currency.rs
+++ b/runtime/primitives/src/currency.rs
@@ -2,10 +2,11 @@
 use codec::{CompactAs, Decode, Encode, MaxEncodedLen};
 use composable_traits::currency::Exponent;
 use core::ops::Div;
+use core::str::FromStr;
+use core::fmt::Display;
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
-use composable_support::rpc_helpers::FromHexStr;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_runtime::sp_std::ops::Deref;
@@ -41,6 +42,20 @@ pub trait WellKnownCurrency {
 #[repr(transparent)]
 pub struct CurrencyId(pub u128);
 
+impl FromStr for CurrencyId {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+      u128::from_str(s).map(CurrencyId).map_err(|_| ())
+    }
+}
+
+impl Display for CurrencyId {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		let CurrencyId(id) = self;
+		write!(f, "{}", id)
+	}
+}
+
 impl WellKnownCurrency for CurrencyId {
 	const NATIVE: CurrencyId = CurrencyId::PICA;
 	const RELAY_NATIVE: CurrencyId = CurrencyId::KSM;
@@ -70,20 +85,6 @@ impl CurrencyId {
 	}
 	pub fn milli<T: From<u64> + Div<Output = T>>() -> T {
 		Self::unit::<T>() / T::from(1000_u64)
-	}
-}
-
-impl FromHexStr for CurrencyId {
-	type Err = <u128 as FromHexStr>::Err;
-
-	fn from_hex_str(src: &str) -> core::result::Result<Self, Self::Err> {
-		u128::from_hex_str(src).map(CurrencyId)
-	}
-}
-
-impl core::fmt::LowerHex for CurrencyId {
-	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		core::fmt::LowerHex::fmt(&self.0, f)
 	}
 }
 

--- a/runtime/primitives/src/currency.rs
+++ b/runtime/primitives/src/currency.rs
@@ -1,9 +1,7 @@
 //! CurrencyId implementation
 use codec::{CompactAs, Decode, Encode, MaxEncodedLen};
 use composable_traits::currency::Exponent;
-use core::ops::Div;
-use core::str::FromStr;
-use core::fmt::Display;
+use core::{fmt::Display, ops::Div, str::FromStr};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;
 
@@ -43,10 +41,10 @@ pub trait WellKnownCurrency {
 pub struct CurrencyId(pub u128);
 
 impl FromStr for CurrencyId {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-      u128::from_str(s).map(CurrencyId).map_err(|_| ())
-    }
+	type Err = ();
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		u128::from_str(s).map(CurrencyId).map_err(|_| ())
+	}
 }
 
 impl Display for CurrencyId {


### PR DESCRIPTION
## Issue
Fix the `assets.balanceOf` custom RPC by moving the expected JSON representation from hex string to string (Display).

## Checklist

- [x] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [x] I have updated the `book/` to reflect changes made by this PR _(if applicable)_