### PR TITLE
test(Runtime Integration Tests): Fixed number to big issue within Mosaic Tests.

### DIFF
--- a/integration-tests/runtime-tests/test/tests/mosaic/mosaicTests.ts
+++ b/integration-tests/runtime-tests/test/tests/mosaic/mosaicTests.ts
@@ -5,10 +5,10 @@ import {KeyringPair} from "@polkadot/keyring/types";
 import { mintAssetsToWallet } from '@composable/utils/mintingHelper';
 import {
     CommonMosaicRemoteAssetId,
-    OrmlTokensAccountData,
     PalletMosaicDecayBudgetPenaltyDecayer,
     PalletMosaicNetworkInfo
 } from "@composable/types/interfaces";
+import BN from "bn.js";
 
 /**
  * Mosaic Pallet Tests
@@ -273,7 +273,7 @@ describe('tx.mosaic Tests', function () {
                 receiverWallet,
                 assetId);
             const afterTokens = await api.query.tokens.accounts(userWallet.address, assetId);
-            expect(initialTokens.free.toNumber()).to.be.equal((afterTokens.free.toNumber())-transferAmount);
+            expect(new BN(initialTokens.free).eq(new BN(afterTokens.free).sub(new BN(transferAmount)))).to.be.true;
         });
 
         it('User should be able to reclaim the stale funds not accepted by the relayer and locked in outgoing transactions pool', async function(){
@@ -286,7 +286,7 @@ describe('tx.mosaic Tests', function () {
             const {data: [result]} = await TxMosaicTests.testClaimStaleFunds(startRelayerWallet, assetId);
             const afterTokens = await api.query.tokens.accounts(wallet.address, assetId);
             //verify that the reclaimed tokens are transferred into user balance.
-            expect(initialTokens.free.toNumber()).to.be.equal((afterTokens.free.toNumber())-transferAmount);
+            expect(new BN(initialTokens.free).eq(new BN(afterTokens.free).sub(new BN(transferAmount)))).to.be.true;
         });
     });
 });


### PR DESCRIPTION
Greetings this a very small PR to fix a bug within the Mosaic Integration tests.

## Issue
2 of the Mosaic tests were failing due to a number being to big for JavaScript's max integer limit.
Fixed by using BN.js instead of the native JS Integer system.

(Also removed one unused import)

Before:
![image](https://user-images.githubusercontent.com/96540347/164471938-0dc6dde4-d91e-4d71-afc3-a6a4aaed378e.png)
