### PR TITLE
Linked mdbook and cargo docs in repo readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
 
 Picasso is our custom built Kusama parachain, based on the substrate framework.
 
+## Documentation
+
+To learn more about our ecosystem, vision, and product specifics - visit our 
+[mdbook](https://dali.devnets.composablefinance.ninja).
+
+You can also find our cargo docs [here](https://dali.devnets.composablefinance.ninja/doc).
+
 ## Install
 
 For linux, FreeBSD, OpenBSD and macOS:


### PR DESCRIPTION
## Issue
N/A

## Description
Links to the mdbook and our cargo docs can now be found in a new "Documentation" section of the README.

## Checklist

- ~I have updated the cargo docs to reflect changes made by this PR~
- ~I have updated the `book/` to reflect changes made by this PR~