### PR TITLE
Refactored `EcdsaSignature` into `composable_support::types`

### DIFF
--- a/frame/composable-support/src/types/mod.rs
+++ b/frame/composable-support/src/types/mod.rs
@@ -44,3 +44,19 @@ impl<'de> frame_support::Deserialize<'de> for EthereumAddress {
 		Ok(r)
 	}
 }
+
+/// Struct representing an Elliptic Curve Signature
+#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo)]
+pub struct EcdsaSignature(pub [u8; 65]);
+
+impl PartialEq for EcdsaSignature {
+	fn eq(&self, other: &Self) -> bool {
+		self.0[..] == other.0[..]
+	}
+}
+
+impl sp_std::fmt::Debug for EcdsaSignature {
+	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
+		write!(f, "EcdsaSignature({:?})", &self.0[..])
+	}
+}

--- a/frame/crowdloan-rewards/src/benchmarking.rs
+++ b/frame/crowdloan-rewards/src/benchmarking.rs
@@ -2,7 +2,8 @@ use super::*;
 
 use crate::Pallet as CrowdloanReward;
 
-use crate::models::{EcdsaSignature, EthereumAddress, Proof, RemoteAccount};
+use composable_support::types::{EcdsaSignature, EthereumAddress}
+use crate::models::{Proof, RemoteAccount};
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 use sp_core::{ed25519, keccak_256, Pair};

--- a/frame/crowdloan-rewards/src/lib.rs
+++ b/frame/crowdloan-rewards/src/lib.rs
@@ -64,10 +64,10 @@ pub mod weights;
 
 #[frame_support::pallet]
 pub mod pallet {
-	use super::models::{EcdsaSignature, Proof, RemoteAccount, Reward};
+	use super::models::{Proof, RemoteAccount, Reward};
 	use crate::weights::WeightInfo;
 	use codec::{Codec, FullCodec};
-	use composable_support::types::EthereumAddress;
+	use composable_support::types::{EcdsaSignature, EthereumAddress};
 	use composable_traits::math::SafeAdd;
 	use frame_support::{
 		dispatch::PostDispatchInfo,

--- a/frame/crowdloan-rewards/src/mocks.rs
+++ b/frame/crowdloan-rewards/src/mocks.rs
@@ -1,9 +1,9 @@
 use crate::{
 	self as pallet_crowdloan_rewards,
-	models::{EcdsaSignature, Proof, RemoteAccount},
+	models::{Proof, RemoteAccount},
 };
 use codec::Encode;
-use composable_support::types::EthereumAddress;
+use composable_support::types::{EcdsaSignature, EthereumAddress};
 use frame_support::{
 	construct_runtime, dispatch::DispatchResultWithPostInfo, parameter_types, traits::Everything,
 	PalletId,

--- a/frame/crowdloan-rewards/src/models.rs
+++ b/frame/crowdloan-rewards/src/models.rs
@@ -1,5 +1,5 @@
 use codec::{Decode, Encode, MaxEncodedLen};
-use composable_support::types::EthereumAddress;
+use composable_support::types::{EcdsaSignature, EthereumAddress};
 use scale_info::TypeInfo;
 use sp_runtime::{MultiSignature, RuntimeDebug};
 
@@ -21,19 +21,4 @@ pub enum Proof<AccountId> {
 pub enum RemoteAccount<AccountId> {
 	RelayChain(AccountId),
 	Ethereum(EthereumAddress),
-}
-
-#[derive(Encode, Decode, Clone, MaxEncodedLen, TypeInfo)]
-pub struct EcdsaSignature(pub [u8; 65]);
-
-impl PartialEq for EcdsaSignature {
-	fn eq(&self, other: &Self) -> bool {
-		self.0[..] == other.0[..]
-	}
-}
-
-impl sp_std::fmt::Debug for EcdsaSignature {
-	fn fmt(&self, f: &mut sp_std::fmt::Formatter<'_>) -> sp_std::fmt::Result {
-		write!(f, "EcdsaSignature({:?})", &self.0[..])
-	}
 }

--- a/frame/crowdloan-rewards/src/tests.rs
+++ b/frame/crowdloan-rewards/src/tests.rs
@@ -5,11 +5,11 @@ use crate::{
 		CrowdloanRewards, EthKey, ExtBuilder, Moment, Origin, System, Test, Timestamp, ALICE,
 		INITIAL_PAYMENT, PROOF_PREFIX, VESTING_STEP,
 	},
-	models::{EcdsaSignature, Proof, RemoteAccount},
+	models::{Proof, RemoteAccount},
 	Error, RemoteAccountOf, RewardAmountOf, VestingPeriodOf,
 };
 use codec::Encode;
-use composable_support::types::EthereumAddress;
+use composable_support::types::{EcdsaSignature, EthereumAddress};
 use frame_support::{assert_noop, assert_ok, traits::Currency};
 use hex_literal::hex;
 use sp_core::{ed25519, storage::StateVersion, Pair};


### PR DESCRIPTION
## Issue
N/A

## Description
Refactored `pallet_crowdloan_rewards::models::EcdsaSignature` into `composable_support::types`
This type will be used by the Airdrop pallet in the future.

## Checklist

- [X] I have updated the cargo docs to reflect changes made by this PR
- ~I have updated the `book/` to reflect changes made by this PR~