### PR TITLE
docs(README): Updated README's for `polkadot-launch` & Integration tests.

### DIFF
--- a/integration-tests/runtime-tests/README.md
+++ b/integration-tests/runtime-tests/README.md
@@ -11,31 +11,30 @@ $ npm ci
 
 ## Usage
 
-### To run the fully automated test suite on Docker:
+### Using Docker
+#### To run the fully automated test suite using Docker:
 ```bash
 $ docker-compose up
 ```
 
-### To run the devnet dummy data initializer
-```bash
-$ npm run init
-```
+### Directly using a locally running chain 
 
-### To run the tests:
+#### Running the local chain
+*To run the integration tester directly without docker, make sure to have a local Picasso Node running.*
+
+[Local Node Run Instructions](../../scripts/polkadot-launch/README.md)
+
+As soon as your chain is running, just follow the instructions below to get started.
+
+#### To run the tests:
 ```bash
 $ npm run test
 ```
 
-### To run the type generator:
+#### To regenerate types:
 ```bash
 $ npm run gen
 ```
-
-### If you want to check for dependency updates:
-```bash
-$ npm run check_dep_updates
-```
-
 
 
 ## Contributing
@@ -46,11 +45,23 @@ Please make sure to update tests as appropriate.
 
 ### Notes for developers
 
+
+#### Updating Dependencies
+```bash
+$ npm run check_dep_updates
+```
+
+### To automatically update all dependencies to their newest versions
+```bash
+$ npx ncu -u
+$ npm install
+```
+
+#### Timeouts
 On any tests waiting for a transaction result, you need to change the timeout setting.
 
 Else the test will timeout before any results, causing a headache and wondering where the error lies. (Story fictitious)
 
-e.g.
 ```typescript
 describe('Imaginary Test', function () {
   // Timeout set to 2 minutes

--- a/scripts/polkadot-launch/README.md
+++ b/scripts/polkadot-launch/README.md
@@ -16,8 +16,8 @@ Need to do to run 4 relay chain nodes and 1 Composable's collator:
 
 	```bash
 	mkdir -p ../../../polkadot/target/release
-	curl https://github.com/paritytech/polkadot/releases/download/v0.9.17/polkadot -Lo ../../../polkadot/target/release/polkadot
-	../../../polkadot/target/release/polkadot -- version
+	curl https://github.com/paritytech/polkadot/releases/download/v0.9.17-rc4/polkadot -Lo ../../../polkadot/target/release/polkadot
+	../../../polkadot/target/release/polkadot --version
     ```
 
 3. build this project
@@ -54,8 +54,8 @@ Need to do to run 4 relay chain nodes, 2 Composable's collators and 2 Basilisk's
 
 	```bash
 	mkdir -p ../../../polkadot/target/release
-	curl https://github.com/paritytech/polkadot/releases/download/v0.9.17/polkadot -Lo ../../../polkadot/target/release/polkadot
-	../../../polkadot/target/release/polkadot -- version
+	curl https://github.com/paritytech/polkadot/releases/download/v0.9.17-rc4/polkadot -Lo ../../../polkadot/target/release/polkadot
+	../../../polkadot/target/release/polkadot --version
     ```
 
 3. download a Basilisk's collator


### PR DESCRIPTION
## Issue & Description
The link to download the Polkadot binary in the `polkadot-launch/README.md` file was leading to a `404` for quite some time.
After the third time being confused why things don't work, I finally managed to update this. :smile: 

Another issue was a typo: `-- version`

And updated the README of the Integration tests, to make it easier for new people to get into.

And i removed the run instructions for the dummy data generator from the Integration tests, since it wasn't used and will be removed anyway. And made things generally a bit more readable and sense-fully structured.