### PR TITLE
CU-1wtyb38 currency improvements proposals

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,3 +2,4 @@
 
 ED - [existential deposit](../rfcs/0002-rent-deposit.md)
 AUM - [assets under managment](https://www.investopedia.com/terms/a/aum.asp)
+LP - liquidity provider (token)

--- a/frame/assets-registry/README.md
+++ b/frame/assets-registry/README.md
@@ -2,6 +2,8 @@
 
 # Overview
 
+
+
 - helps to hide complexity of creating mappings of local ids to and from HydraDX, with proper authorities and voting
 - should support any asset to be added
 - support to transfer assets to HydraDX (forward mapping)
@@ -16,3 +18,12 @@
 ## vNEXT
 
 - support any assets to be added new via voting processes
+
+
+//! Pallet for allowing to map assets from this and other parachain.
+//!
+//! It works as next:
+//! 1. Each mapping is bidirectional.
+//! 2. Assets map added as candidate and waits for approval.
+//! 3. After approval map return mapped value.
+//! 4. Map of native token to this chain(here) is added unconditionally.

--- a/frame/assets-registry/README.md
+++ b/frame/assets-registry/README.md
@@ -1,29 +1,22 @@
-
-
 # Overview
 
+Allows to map remote assets to local and back(bidirectional). Mapping can be created only by privilidged origin.
 
+Used for cross chain message transfers and payments.
 
-- helps to hide complexity of creating mappings of local ids to and from HydraDX, with proper authorities and voting
-- should support any asset to be added
-- support to transfer assets to HydraDX (forward mapping)
-- support to transfer assets back from HydraDX to Composable (back mapping)
-- supports not only HydraDX
+## Basics
 
-## v1
+Each remote pallet must have local identifiers. This pallet calls [CurrencyFactory](../currecy-factory/README.md) to get that done.
 
-- support small set of well know assets added manually on both registries
-- manually asking HydraDX to add mapping
+Remote assets may have different than local decimals, so remote asset may be configured to have proper decimals.
 
-## vNEXT
+## Weights and fees
 
-- support any assets to be added new via voting processes
+If assets can be used to pay for execution of messages, it can be set with:
 
+- Minimal fee in asset amount on target chain. So messages which will pay less than this fee will not be sent
+- Allowing to pay fee for exectution on this chain, by mapping asset amount to native. In case apprvoed [DEX route](../dex-router/README.md) has approprotiate pool, it used to override registry value.
 
-//! Pallet for allowing to map assets from this and other parachain.
-//!
-//! It works as next:
-//! 1. Each mapping is bidirectional.
-//! 2. Assets map added as candidate and waits for approval.
-//! 3. After approval map return mapped value.
-//! 4. Map of native token to this chain(here) is added unconditionally.
+## Well known tokens
+
+Like relay native, are baked into codebase directly.

--- a/frame/assets-registry/README.md
+++ b/frame/assets-registry/README.md
@@ -6,7 +6,7 @@ Used for cross chain message transfers and payments.
 
 ## Basics
 
-Each remote pallet must have local identifiers. This pallet calls [CurrencyFactory](../currecy-factory/README.md) to get that done.
+Each remote asset must have local identifier. This pallet calls [CurrencyFactory](../currecy-factory/README.md) to get that done.
 
 Remote assets may have different than local decimals, so remote asset may be configured to have proper decimals.
 
@@ -15,7 +15,7 @@ Remote assets may have different than local decimals, so remote asset may be con
 If assets can be used to pay for execution of messages, it can be set with:
 
 - Minimal fee in asset amount on target chain. So messages which will pay less than this fee will not be sent
-- Allowing to pay fee for exectution on this chain, by mapping asset amount to native. In case apprvoed [DEX route](../dex-router/README.md) has approprotiate pool, it used to override registry value.
+- Allowing to pay fee for execution on this chain, by mapping asset amount to native. In case approved [DEX route](../dex-router/README.md) has appropriate pool, it used to override registry value.
 
 ## Well known tokens
 

--- a/frame/assets-registry/src/lib.rs
+++ b/frame/assets-registry/src/lib.rs
@@ -1,11 +1,3 @@
-//! Pallet for allowing to map assets from this and other parachain.
-//!
-//! It works as next:
-//! 1. Each mapping is bidirectional.
-//! 2. Assets map added as candidate and waits for approval.
-//! 3. After approval map return mapped value.
-//! 4. Map of native token to this chain(here) is added unconditionally.
-
 #![cfg_attr(
 	not(test),
 	warn(
@@ -19,6 +11,7 @@
 )] // allow in tests
 #![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![doc = include_str!("../README.md")]
 
 pub use pallet::*;
 

--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
 	not(test),
-	warn(
+	deny(
 		clippy::disallowed_methods,
 		clippy::disallowed_types,
 		clippy::indexing_slicing,
@@ -10,7 +10,7 @@
 	)
 )] // allow in tests#![warn(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
+#![deny(
 	bad_style,
 	bare_trait_objects,
 	const_err,

--- a/frame/currency-factory/README.md
+++ b/frame/currency-factory/README.md
@@ -1,0 +1,41 @@
+# Overview
+
+Currency pallet allows to create new sovereign(local consensu) currencies(assets).
+
+Each currecsy falls into one of next categories:
+
+- new currency issued by governance
+- currency produced as consequnces of execution of protocol and depends on some base currency(ies), usually named LP
+- currency mapping remote location of asset to local identifiers, foregin currency
+  
+## Basics
+
+Currency must be identified, so factory allows to produce new identifiers.
+
+Currency to be usefull must have amounts.  Amounts must be stored on accounts. Accounts must pay ED to prevent spam.
+So each currency must have ED defined.
+
+In rare edge cases, ED could be zero, but in this case amount is locked into protocol and users cannot freely transfer amounts. In some cases such amounts could be stored in storage without issuing new currency.
+
+All local currencies are normalized to 12 decimals.
+
+## Metadata
+
+In some cases goverance may add metadata to make currency recognizable, such as:
+
+- name
+- symbol
+
+## Foreign integration
+
+[AssetsRegistry](../assets-registry/README.md) use this pallet to make integrating other decimals and out of consesus locations. 
+
+Each foreging currency MUST have entry in AssetsRegistry too.
+
+## Well known currencies
+
+Are optimized and baked into codebase directly.
+
+## Approved goverance currencies
+
+Allows goveranance to approve or revoke currencies to pariticpate in democracy.

--- a/frame/currency-factory/README.md
+++ b/frame/currency-factory/README.md
@@ -1,18 +1,18 @@
 # Overview
 
-Currency pallet allows to create new sovereign(local consensu) currencies(assets).
+Currency pallet allows to create new sovereign(local consensus) currencies(assets).
 
-Each currecsy falls into one of next categories:
+Each currency falls into one of next categories:
 
 - new currency issued by governance
-- currency produced as consequnces of execution of protocol and depends on some base currency(ies), usually named LP
-- currency mapping remote location of asset to local identifiers, foregin currency
+- currency produced as consequences of execution of protocol and depends on some base currency(ies), usually named LP
+- currency mapping remote location of asset to local identifiers, foreign currency
   
 ## Basics
 
 Currency must be identified, so factory allows to produce new identifiers.
 
-Currency to be usefull must have amounts.  Amounts must be stored on accounts. Accounts must pay ED to prevent spam.
+Currency to be useful must have amounts. Amounts must be stored on accounts. Accounts must pay ED to prevent spam.
 So each currency must have ED defined.
 
 In rare edge cases, ED could be zero, but in this case amount is locked into protocol and users cannot freely transfer amounts. In some cases such amounts could be stored in storage without issuing new currency.
@@ -21,21 +21,21 @@ All local currencies are normalized to 12 decimals.
 
 ## Metadata
 
-In some cases goverance may add metadata to make currency recognizable, such as:
+In some cases governance may add metadata to make currency recognizable, such as:
 
 - name
 - symbol
 
 ## Foreign integration
 
-[AssetsRegistry](../assets-registry/README.md) use this pallet to make integrating other decimals and out of consesus locations. 
+[AssetsRegistry](../assets-registry/README.md) use this pallet to make integrating other decimals and out of consensus locations. 
 
-Each foreging currency MUST have entry in AssetsRegistry too.
+Each foreign currency MUST have entry in AssetsRegistry too.
 
 ## Well known currencies
 
 Are optimized and baked into codebase directly.
 
-## Approved goverance currencies
+## Approved governance currencies
 
-Allows goveranance to approve or revoke currencies to pariticpate in democracy.
+Allows governance to approve or revoke currencies to participate in democracy.

--- a/frame/currency-factory/src/lib.rs
+++ b/frame/currency-factory/src/lib.rs
@@ -1,8 +1,6 @@
-//! Overview
-//! Allows to add new assets internally. User facing mutating API is provided by other pallets.
 #![cfg_attr(
 	not(test),
-	warn(
+	deny(
 		clippy::disallowed_methods,
 		clippy::disallowed_types,
 		clippy::indexing_slicing,
@@ -11,9 +9,9 @@
 		clippy::panic
 	)
 )] // allow in tests
-#![warn(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
+#![deny(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![warn(
+#![deny(
 	bad_style,
 	bare_trait_objects,
 	const_err,
@@ -33,6 +31,7 @@
 	trivial_numeric_casts,
 	unused_extern_crates
 )]
+#![doc = include_str!("../README.md")]
 
 pub use pallet::*;
 pub use weights::{SubstrateWeight, WeightInfo};

--- a/frame/governance-registry/src/lib.rs
+++ b/frame/governance-registry/src/lib.rs
@@ -1,3 +1,4 @@
+// TODO: move this pallet stuff into currency-factory (check if used on picasso and may need to route from this pallet to factory)
 //! # Governance Registry Pallet
 //!
 //! Is used to add new assets into chain.

--- a/frame/governance-registry/src/lib.rs
+++ b/frame/governance-registry/src/lib.rs
@@ -1,4 +1,5 @@
-// TODO: move this pallet stuff into currency-factory (check if used on picasso and may need to route from this pallet to factory)
+// TODO: move this pallet stuff into currency-factory (check if used on picasso and may need to
+// route from this pallet to factory)
 //! # Governance Registry Pallet
 //!
 //! Is used to add new assets into chain.

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -184,7 +184,13 @@ pub fn multi_existential_deposits(_currency_id: &CurrencyId) -> Balance {
 #[cfg(not(feature = "runtime-benchmarks"))]
 pub fn multi_existential_deposits(currency_id: &CurrencyId) -> Balance {
 	PriceConverter::get_price_inverse(*currency_id, NativeExistentialDeposit::get())
-		.unwrap_or(Balance::MAX) // TODO: here DEX call to pemissioned markets should come
+		// TODO:
+		// 1. ask approved DEX pair for price  (is it enought performacne? or should we allow pay in
+		// ED PICA for other asset account?)
+		// 2. ask CurrencyFactory
+		// 3. use harcoded values
+		// 4. else Balance::MAX
+		.unwrap_or(Balance::MAX)
 }
 
 parameter_type_with_key! {


### PR DESCRIPTION
this is documentation on how pallets should be changed to:
- allow no 12 decimals of USDT
- integrated statemine
- prevent spamming with newly created assets
- reduce one method pallets amounts
- be on par with Acala to handle currencies
- reduce errors during XCMP 
- make assets more flexible and configurable

if we are ok with that, will make PR to make docs run for our assets