### PR TITLE
[cu-28fuhh3][Pablo][subssquid] Add the assetIds to PoolCreated event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ runtime-benchmarks = ["composable-node/runtime-benchmarks"]
 std = ["composable-node/std"]
 
 [workspace]
-exclude = ["frame/transaction-fee","utils/extrinsics-docs-scraper"]
+exclude = ["frame/transaction-fee", "utils/extrinsics-docs-scraper"]
 members = [
   "frame/*",
   "integration-tests/local-integration-tests",

--- a/frame/currency-factory/Cargo.toml
+++ b/frame/currency-factory/Cargo.toml
@@ -36,9 +36,9 @@ composable-traits = { path = "../composable-traits", default-features = false }
 
 [dev-dependencies]
 composable-tests-helpers = { version = "0.0.1", path = "../composable-tests-helpers" }
+frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 pallet-balances = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 proptest = "1.0.0"
-frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 
 [features]
 default = ["std"]

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -159,7 +159,7 @@ pub mod pallet {
 			/// Owner of the pool.
 			owner: T::AccountId,
 			// Pool assets
-			assets: CurrencyPair<AssetIdOf<T>>
+			assets: CurrencyPair<AssetIdOf<T>>,
 		},
 		/// The sale ended, the funds repatriated and the pool deleted.
 		PoolDeleted {
@@ -566,20 +566,23 @@ pub mod pallet {
 						fee,
 						owner_fee,
 					)?,
-					pair
+					pair,
 				),
-				PoolInitConfiguration::ConstantProduct { owner, pair, fee, owner_fee } =>
-					(owner.clone(), Uniswap::<T>::do_create_pool(&owner, pair, fee, owner_fee)?, pair),
+				PoolInitConfiguration::ConstantProduct { owner, pair, fee, owner_fee } => (
+					owner.clone(),
+					Uniswap::<T>::do_create_pool(&owner, pair, fee, owner_fee)?,
+					pair,
+				),
 				PoolInitConfiguration::LiquidityBootstrapping(pool_config) => {
 					let validated_pool_config = Validated::new(pool_config.clone())?;
 					(
 						pool_config.owner,
 						LiquidityBootstrapping::<T>::do_create_pool(validated_pool_config)?,
-						pool_config.pair
+						pool_config.pair,
 					)
 				},
 			};
-			Self::deposit_event(Event::<T>::PoolCreated { owner, pool_id, assets: pair});
+			Self::deposit_event(Event::<T>::PoolCreated { owner, pool_id, assets: pair });
 			Ok(pool_id)
 		}
 


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/265d6yn

## Description
To allow the subsquid indexer to have the necessary data for the pool the base and quote assets need to be published with the `PoolCreated` event.

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_