### PR TITLE
Make @0xbrainjar2 codeowner of book

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,5 +7,6 @@
 docker/ @haroldsphinx @seunlanlege
 runtime/ @seunlanlege
 node/ @seunlanlege
+book/ @0xbrainjar2
 
 Makefile @haroldsphinx


### PR DESCRIPTION
## Description
Since @0xBrainjar2 needs to review the book contents before they go live, I've made him a mandatory reviewer for edits of the `book/`


## Checklist

~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~
~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~