### PR TITLE
Emit LiquidityAdded event with correct value for base_amount and quote_amount.

### DIFF
--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -715,7 +715,7 @@ pub mod pallet {
 		) -> Result<(), DispatchError> {
 			let pool = Self::get_pool(pool_id)?;
 			let pool_account = Self::account_id(&pool_id);
-			let minted_lp = match pool {
+			let (added_base_amount, added_quote_amount, minted_lp) = match pool {
 				PoolConfiguration::StableSwap(info) => StableSwap::<T>::add_liquidity(
 					who,
 					info,
@@ -749,8 +749,8 @@ pub mod pallet {
 			Self::deposit_event(Event::<T>::LiquidityAdded {
 				who: who.clone(),
 				pool_id,
-				base_amount,
-				quote_amount,
+				base_amount: added_base_amount,
+				quote_amount: added_quote_amount,
 				minted_lp,
 			});
 			Ok(())

--- a/frame/pablo/src/liquidity_bootstrapping.rs
+++ b/frame/pablo/src/liquidity_bootstrapping.rs
@@ -166,7 +166,7 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		quote_amount: T::Balance,
 		_: T::Balance,
 		keep_alive: bool,
-	) -> Result<T::Balance, DispatchError> {
+	) -> Result<(T::Balance, T::Balance, T::Balance), DispatchError> {
 		let current_block = frame_system::Pallet::<T>::current_block_number();
 		Self::ensure_sale_state(&pool, current_block, SaleState::NotStarted)?;
 
@@ -178,7 +178,7 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		T::Assets::transfer(pool.pair.base, who, &pool_account, base_amount, keep_alive)?;
 		T::Assets::transfer(pool.pair.quote, who, &pool_account, quote_amount, keep_alive)?;
 
-		Ok(T::Balance::zero())
+		Ok((base_amount, quote_amount, T::Balance::zero()))
 	}
 
 	#[transactional]

--- a/frame/pablo/src/stable_swap.rs
+++ b/frame/pablo/src/stable_swap.rs
@@ -136,7 +136,7 @@ impl<T: Config> StableSwap<T> {
 		quote_amount: T::Balance,
 		min_mint_amount: T::Balance,
 		keep_alive: bool,
-	) -> Result<T::Balance, DispatchError> {
+	) -> Result<(T::Balance, T::Balance, T::Balance), DispatchError> {
 		let zero = T::Balance::zero();
 		ensure!(base_amount > zero, Error::<T>::AssetAmountMustBePositiveNumber);
 		ensure!(quote_amount > zero, Error::<T>::AssetAmountMustBePositiveNumber);
@@ -215,7 +215,7 @@ impl<T: Config> StableSwap<T> {
 			keep_alive,
 		)?;
 		T::Assets::mint_into(pool.lp_token, who, mint_amount)?;
-		Ok(mint_amount)
+		Ok((base_amount, quote_amount, mint_amount))
 	}
 
 	pub fn remove_liquidity(

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -85,7 +85,7 @@ impl<T: Config> Uniswap<T> {
 		quote_amount: T::Balance,
 		min_mint_amount: T::Balance,
 		keep_alive: bool,
-	) -> Result<T::Balance, DispatchError> {
+	) -> Result<(T::Balance, T::Balance, T::Balance), DispatchError> {
 		ensure!(base_amount > T::Balance::zero(), Error::<T>::InvalidAmount);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, &pool_account));
 		let pool_quote_aum =
@@ -108,7 +108,7 @@ impl<T: Config> Uniswap<T> {
 		T::Assets::transfer(pool.pair.base, who, &pool_account, base_amount, keep_alive)?;
 		T::Assets::transfer(pool.pair.quote, who, &pool_account, quote_amount, keep_alive)?;
 		T::Assets::mint_into(pool.lp_token, who, lp_token_to_mint)?;
-		Ok(lp_token_to_mint)
+		Ok((base_amount, quote_amount, lp_token_to_mint))
 	}
 
 	#[transactional]

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -194,6 +194,47 @@ fn add_remove_lp() {
 	});
 }
 
+#[test]
+fn test_add_liquidity_with_disproportionate_amount() {
+	new_test_ext().execute_with(|| {
+		let unit = 1_000_000_000_000_u128;
+		let initial_usdc = 2500_u128 * unit;
+		let initial_usdt = 2500_u128 * unit;
+		let pool = create_pool(
+			USDC,
+			USDT,
+			initial_usdc,
+			initial_usdt,
+			Permill::from_percent(1),
+			Permill::zero(),
+		);
+
+		let base_amount = 30_u128 * unit;
+		let quote_amount = 1_00_u128 * unit;
+		assert_ok!(Tokens::mint_into(USDC, &ALICE, base_amount));
+		assert_ok!(Tokens::mint_into(USDT, &ALICE, quote_amount));
+
+		// Add the liquidity, user tries to provide more quote_amount compare to
+        // pool's ratio
+		assert_ok!(<Pablo as Amm>::add_liquidity(
+			&ALICE,
+			pool,
+			base_amount,
+			quote_amount,
+			0,
+			false
+		));
+	assert_last_event::<Test, _>(|e| {
+		matches!(e.event,
+            mock::Event::Pablo(crate::Event::LiquidityAdded { who, pool_id, base_amount, quote_amount, .. })
+            if who == ALICE
+            && pool_id == pool
+            && base_amount == 30_u128 * unit
+            && quote_amount == 30_u128 * unit)
+	});
+	});
+}
+
 // test add liquidity with min_mint_amount
 #[test]
 fn add_lp_with_min_mint_amount() {


### PR DESCRIPTION


## Issue
NA

## Description
QA testing found mismatch between amount deposited to pool and value shown in LiquidityAdded event. Specially this matters for Uniswap pools.

## Checklist

- [X] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [X] I have updated the `book/` to reflect changes made by this PR _(if applicable)_