### PR TITLE
[cu-2pbvg9e] Save pool stats as a time series

### DIFF
--- a/subsquid/db/migrations/1651759469878-PabloInit.js
+++ b/subsquid/db/migrations/1651759469878-PabloInit.js
@@ -1,10 +1,10 @@
-module.exports = class PabloInit1651160130576 {
-  name = 'PabloInit1651160130576'
+module.exports = class PabloInit1651759469878 {
+  name = 'PabloInit1651759469878'
 
   async up(db) {
     await db.query(`CREATE TABLE "pablo_pool_asset" ("id" character varying NOT NULL, "asset_id" numeric NOT NULL, "total_liquidity" numeric NOT NULL, "total_volume" numeric NOT NULL, "block_number" numeric NOT NULL, "calculated_timestamp" numeric NOT NULL, "pool_id" character varying NOT NULL, CONSTRAINT "PK_fc75f8a8a8a0ac8408eef787237" PRIMARY KEY ("id"))`)
     await db.query(`CREATE INDEX "IDX_7fd4cdb45620476d1de745a265" ON "pablo_pool_asset" ("pool_id") `)
-    await db.query(`CREATE TABLE "pablo_pool" ("id" character varying NOT NULL, "pool_id" text NOT NULL, "owner" text NOT NULL, "transaction_count" integer NOT NULL, "total_liquidity" text NOT NULL, "total_volume" text NOT NULL, "quote_asset_id" numeric NOT NULL, "block_number" numeric NOT NULL, "calculated_timestamp" numeric NOT NULL, CONSTRAINT "PK_28d674c3fdadf69d19745e5343a" PRIMARY KEY ("id"))`)
+    await db.query(`CREATE TABLE "pablo_pool" ("id" character varying NOT NULL, "event_id" text NOT NULL, "pool_id" numeric NOT NULL, "owner" text NOT NULL, "transaction_count" integer NOT NULL, "total_liquidity" text NOT NULL, "total_volume" text NOT NULL, "quote_asset_id" numeric NOT NULL, "block_number" numeric NOT NULL, "calculated_timestamp" numeric NOT NULL, CONSTRAINT "PK_28d674c3fdadf69d19745e5343a" PRIMARY KEY ("id"))`)
     await db.query(`CREATE TABLE "pablo_transaction" ("id" character varying NOT NULL, "event_id" text NOT NULL, "who" text NOT NULL, "transaction_type" character varying(16), "base_asset_id" numeric NOT NULL, "base_asset_amount" numeric NOT NULL, "quote_asset_id" numeric NOT NULL, "quote_asset_amount" numeric NOT NULL, "block_number" numeric NOT NULL, "spot_price" text NOT NULL, "received_timestamp" numeric NOT NULL, "pool_id" character varying NOT NULL, CONSTRAINT "PK_8b040ecc6da14a71ef547ae2ae6" PRIMARY KEY ("id"))`)
     await db.query(`CREATE INDEX "IDX_969a927080f5b6c81b79b40cd8" ON "pablo_transaction" ("pool_id") `)
     await db.query(`ALTER TABLE "pablo_pool_asset" ADD CONSTRAINT "FK_7fd4cdb45620476d1de745a2658" FOREIGN KEY ("pool_id") REFERENCES "pablo_pool"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`)

--- a/subsquid/schema.graphql
+++ b/subsquid/schema.graphql
@@ -37,8 +37,10 @@ type PabloTransaction @entity {
 }
 
 type PabloPool @entity {
+  "ID of the last event that was used to derive this entity data"
+  eventId: ID!
   "Pool ID"
-  poolId: ID!
+  poolId: BigInt!
   owner: String!
   transactionCount: Int!
   totalLiquidity: String!

--- a/subsquid/src/dbHelper.ts
+++ b/subsquid/src/dbHelper.ts
@@ -1,4 +1,5 @@
 import {Store} from "@subsquid/substrate-processor";
+import {PabloPool} from "./model";
 
 export async function get<T extends { id: string }>(
     store: Store,
@@ -7,6 +8,16 @@ export async function get<T extends { id: string }>(
 ): Promise<T | undefined> {
     return await store.get<T>(EntityConstructor, {
         where: {id},
+    });
+}
+
+export async function getLatestPoolByPoolId<T extends { id: string }>(
+    store: Store,
+    poolId: bigint
+): Promise<PabloPool | undefined> {
+    return await store.get<PabloPool>(PabloPool, {
+        where: {poolId},
+        order: {calculatedTimestamp: 'DESC'},
     });
 }
 

--- a/subsquid/src/model/generated/pabloPool.model.ts
+++ b/subsquid/src/model/generated/pabloPool.model.ts
@@ -13,10 +13,16 @@ export class PabloPool {
   id!: string
 
   /**
-   * Pool ID
+   * ID of the last event that was used to derive this entity data
    */
   @Column_("text", {nullable: false})
-  poolId!: string
+  eventId!: string
+
+  /**
+   * Pool ID
+   */
+  @Column_("numeric", {transformer: marshal.bigintTransformer, nullable: false})
+  poolId!: bigint
 
   @Column_("text", {nullable: false})
   owner!: string

--- a/subsquid/src/processor.ts
+++ b/subsquid/src/processor.ts
@@ -24,8 +24,10 @@ const processor = new SubstrateProcessor("composable_dali_dev");
 
 processor.setBatchSize(500);
 processor.setDataSource({
-  archive: `http://localhost:4010/v1/graphql`,
-  chain: "wss://dali.devnets.composablefinance.ninja/parachain/alice",
+  archive: `http://localhost:8080/v1/graphql`,
+  // archive: `http://localhost:4010/v1/graphql`,
+  chain: "ws://localhost:9997",
+  // chain: "wss://dali.devnets.composablefinance.ninja/parachain/alice",
 });
 
 processor.addEventHandler('pablo.PoolCreated', async (ctx) => {

--- a/subsquid/test/pabloProcessorTest.ts
+++ b/subsquid/test/pabloProcessorTest.ts
@@ -22,7 +22,8 @@ const UNIT = 1_000_000_000_000;
 
 function assertPool(
     poolArg: PabloPool,
-    poolId: string,
+    id: string,
+    poolId: bigint,
     owner: string,
     blockNumber: bigint,
     transactionCount: number,
@@ -30,9 +31,9 @@ function assertPool(
     totalLiquidity: string,
     totalVolume: string
 ) {
+    expect(poolArg.id).eq(id);
     expect(poolArg.poolId).eq(poolId);
-    expect(poolArg.owner)
-        .eq(owner);
+    expect(poolArg.owner).eq(owner);
     expect(poolArg.blockNumber).eq(blockNumber);
     expect(poolArg.transactionCount).eq(transactionCount);
     expect(poolArg.quoteAssetId).eq(quoteAssetId);
@@ -85,6 +86,7 @@ function createCtx(storeMock: Store, blockHeight: number) {
     let ctx: EventHandlerContext = instance(ctxMock);
     ctx.store = instance(storeMock);
     ctx.block = blockMock;
+    ctx.event = event;
     return ctx;
 }
 
@@ -198,7 +200,8 @@ function createZeroPool() {
     let baseAsset = createZeroAsset('1-1', BigInt(1));
     let quoteAsset = createZeroAsset('1-4', BigInt(4));
     let pabloPool = new PabloPool();
-    pabloPool.poolId = '1';
+    pabloPool.id = randomUUID();
+    pabloPool.poolId = BigInt(1);
     pabloPool.owner = encodeAccount(createAccount());
     pabloPool.quoteAssetId = BigInt(4);
     pabloPool.totalLiquidity = '0.0';
@@ -241,7 +244,8 @@ describe('PoolCreated Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             encodeAccount(owner),
             BigInt(1),
             1,
@@ -252,7 +256,7 @@ describe('PoolCreated Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' + '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(0),
@@ -260,7 +264,7 @@ describe('PoolCreated Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' + '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(0),
@@ -301,7 +305,8 @@ describe('Liquidity Added & Removed Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             pabloPool.owner,
             BigInt(1),
             2,
@@ -312,7 +317,7 @@ describe('Liquidity Added & Removed Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' +  '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(10_000 * UNIT),
@@ -320,7 +325,7 @@ describe('Liquidity Added & Removed Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' +  '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(10_000 * UNIT),
@@ -359,7 +364,8 @@ describe('Liquidity Added & Removed Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             pabloPool.owner,
             BigInt(1),
             3,
@@ -370,7 +376,7 @@ describe('Liquidity Added & Removed Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' +  '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(9_990_000 * UNIT),
@@ -378,7 +384,7 @@ describe('Liquidity Added & Removed Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' + '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(9_990_000 * UNIT),
@@ -420,7 +426,8 @@ describe('PoolDeleted Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             pabloPool.owner,
             BigInt(1),
             3,
@@ -431,7 +438,7 @@ describe('PoolDeleted Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' +  '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(0),
@@ -439,7 +446,7 @@ describe('PoolDeleted Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' + '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(0),
@@ -481,7 +488,8 @@ describe('Swapped Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             pabloPool.owner,
             BigInt(1),
             3,
@@ -492,7 +500,7 @@ describe('Swapped Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' +    '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(9899 * UNIT),
@@ -500,7 +508,7 @@ describe('Swapped Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' +   '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(10_025 * UNIT),
@@ -546,7 +554,8 @@ describe('Swapped Tests', function () {
         const [poolArg] = capture(storeMock.save).first();
         assertPool(
             poolArg as unknown as PabloPool,
-            '1',
+            ctx.event.id,
+            BigInt(1),
             pabloPool.owner,
             BigInt(1),
             3,
@@ -557,7 +566,7 @@ describe('Swapped Tests', function () {
         verify(storeMock.save(anyOfClass(PabloPoolAsset))).twice();
         const [assetOneArg] = capture(storeMock.save).second();
         assertAsset(assetOneArg as unknown as PabloPoolAsset,
-            '1-1',
+            ctx.event.id + '-' +  '1-1',
             BigInt(1),
             BigInt(1),
             BigInt(10_025 * UNIT),
@@ -565,7 +574,7 @@ describe('Swapped Tests', function () {
         );
         const [assetTwoArg] = capture(storeMock.save).byCallIndex(2);
         assertAsset(assetTwoArg as unknown as PabloPoolAsset,
-            '1-4',
+            ctx.event.id + '-' + '1-4',
             BigInt(4),
             BigInt(1),
             BigInt(9987 * UNIT),


### PR DESCRIPTION
## Description
- Save all entities indexed by the event that triggered an update as new entities to keep track of history

## Checklist

- [x] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [x] I have updated the `book/` to reflect changes made by this PR _(if applicable)_