### PR TITLE
CU-2953d54 

### DIFF
--- a/frame/lending/src/mocks/mod.rs
+++ b/frame/lending/src/mocks/mod.rs
@@ -267,6 +267,7 @@ impl pallet_oracle::Config for Runtime {
 	type MaxPrePrices = MinU32;
 	type WeightInfo = ();
 	type LocalAssets = Decimals;
+	type TreasuryAccount = RootAccount;
 }
 
 impl DeFiComposableConfig for Runtime {

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -614,8 +614,9 @@ pub mod pallet {
 					),
 				Error::<T>::NotEnoughStake
 			);
-
 			let asset_info = Self::asset_info(asset_id).ok_or(Error::<T>::InvalidAssetId)?;
+			ensure!(author_stake >= asset_info.slash, Error::<T>::NotEnoughStake);
+
 			PrePrices::<T>::try_mutate(asset_id, |current_prices| -> Result<(), DispatchError> {
 				// There can convert current_prices.len() to u32 safely
 				// because current_prices.len() limited by u32

--- a/frame/oracle/src/lib.rs
+++ b/frame/oracle/src/lib.rs
@@ -695,10 +695,10 @@ pub mod pallet {
 				let min_accuracy = asset_info.threshold;
 				if accuracy < min_accuracy {
 					let slash_amount = asset_info.slash;
-					let amount_staked = Self::oracle_stake(answer.who.clone())
+					let new_amount_staked = Self::oracle_stake(answer.who.clone())
 						.unwrap_or_else(|| 0_u32.into())
 						.saturating_sub(slash_amount);
-					OracleStake::<T>::insert(&answer.who, amount_staked);
+					OracleStake::<T>::insert(&answer.who, new_amount_staked);
 					let result = T::Currency::repatriate_reserved(
 						&answer.who,
 						&T::TreasuryAccount::get(),

--- a/frame/oracle/src/mock.rs
+++ b/frame/oracle/src/mock.rs
@@ -9,11 +9,9 @@ use frame_support::{
 use frame_system as system;
 use frame_system::EnsureSignedBy;
 use sp_core::{sr25519, sr25519::Signature, H256};
-use sp_keystore::{testing::KeyStore, SyncCryptoStore};
 use sp_runtime::{
 	testing::{Header, TestXt},
 	traits::{BlakeTwo256, Extrinsic as ExtrinsicT, IdentifyAccount, IdentityLookup, Verify},
-	RuntimeAppPublic,
 };
 use system::EnsureRoot;
 
@@ -132,6 +130,9 @@ where
 
 pub type AssetId = u128;
 pub type PriceValue = u128;
+parameter_types! {
+ pub const TreasuryAccountId : AccountId= sr25519::Public([10u8; 32]);
+}
 impl pallet_oracle::Config for Test {
 	type Event = Event;
 	type AuthorityId = crypto::BathurstStId;
@@ -149,6 +150,7 @@ impl pallet_oracle::Config for Test {
 	type MaxPrePrices = MaxPrePrices;
 	type WeightInfo = ();
 	type LocalAssets = ();
+	type TreasuryAccount = TreasuryAccountId;
 }
 
 // Build genesis storage according to the mock runtime.
@@ -160,6 +162,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 			(get_root_account(), 100),
 			(get_account_4(), 100),
 			(get_account_5(), 100),
+			(get_treasury_account(), 100),
 		],
 	};
 	genesis.assimilate_storage(&mut t).unwrap();
@@ -184,4 +187,8 @@ pub fn get_account_4() -> AccountId {
 
 pub fn get_account_5() -> AccountId {
 	sr25519::Public([5u8; 32])
+}
+
+pub fn get_treasury_account() -> AccountId {
+	sr25519::Public([10u8; 32])
 }

--- a/frame/oracle/src/tests.rs
+++ b/frame/oracle/src/tests.rs
@@ -975,7 +975,7 @@ fn test_payout_slash() {
 }
 
 #[test]
-fn halborn_test_escape_slashing() {
+fn halborn_test_bypass_slashing() {
 	new_test_ext().execute_with(|| {
 		const ASSET_ID: u128 = 0;
 		const MIN_ANSWERS: u32 = 3;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -464,6 +464,7 @@ impl oracle::Config for Runtime {
 	type MaxPrePrices = MaxPrePrices;
 	type WeightInfo = weights::oracle::WeightInfo<Runtime>;
 	type LocalAssets = CurrencyFactory;
+	type TreasuryAccount = TreasuryAccount;
 }
 
 // Parachain stuff.


### PR DESCRIPTION
In handle_payout() use T::Currency::repatriate_reserved() to transfer slashed amount to Treasury account.
Update tests accordingly and new test reported by Halborn in audit report.

## Issue
https://app.clickup.com/t/2953d54

## Description
Minor cleanup for unused variables and imports.

## Checklist

~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~
~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~