### PR TITLE
[Bugfix] Don't allow exchange without Liquidity

### DIFF
--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -143,7 +143,7 @@ pub trait SimpleExchange {
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default, PartialEq, Eq, RuntimeDebug)]
 pub struct ConstantProductPoolInfo<AccountId, AssetId> {
 	/// Owner of pool
-	pub owner: Accoun tId,
+	pub owner: AccountId,
 	/// Swappable assets
 	pub pair: CurrencyPair<AssetId>,
 	/// AssetId of LP token

--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -266,7 +266,7 @@ pub trait DexRouter<AccountId, AssetId, PoolId, Balance, MaxHops> {
 }
 
 /// Aggregated prices for a given base/quote currency pair in a pool.
-#[derive(Encode, Decode, Default, Clone, PartialEq, TypeInfo)]
+#[derive(RuntimeDebug, Encode, Decode, Default, Clone, PartialEq, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct PriceAggregate<PoolId, AssetId, Balance> {
 	pub pool_id: PoolId,

--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -143,7 +143,7 @@ pub trait SimpleExchange {
 #[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, Default, PartialEq, Eq, RuntimeDebug)]
 pub struct ConstantProductPoolInfo<AccountId, AssetId> {
 	/// Owner of pool
-	pub owner: AccountId,
+	pub owner: Accoun tId,
 	/// Swappable assets
 	pub pair: CurrencyPair<AssetId>,
 	/// AssetId of LP token

--- a/frame/lending/rpc/Cargo.toml
+++ b/frame/lending/rpc/Cargo.toml
@@ -22,8 +22,12 @@ composable-traits = { path = "../../composable-traits" }
 lending-runtime-api = { path = "../runtime-api" }
 
 # SCALE
-codec = { default-features = false, features = [ "derive" ], package = "parity-scale-codec", version = "3.0.0" }
-scale-info = { version = "2.1.1", default-features = false, features = [ "derive" ] }
+codec = { default-features = false, features = [
+  "derive",
+], package = "parity-scale-codec", version = "3.0.0" }
+scale-info = { version = "2.1.1", default-features = false, features = [
+  "derive",
+] }
 
 # rpc
 jsonrpc-core = "18.0.0"

--- a/frame/lending/runtime-api/Cargo.toml
+++ b/frame/lending/runtime-api/Cargo.toml
@@ -10,7 +10,9 @@ version = "0.0.1"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { default-features = false, features = [ "derive" ], package = "parity-scale-codec", version = "3.0.0" }
+codec = { default-features = false, features = [
+  "derive",
+], package = "parity-scale-codec", version = "3.0.0" }
 composable-support = { path = "../../composable-support", default-features = false }
 composable-traits = { path = "../../composable-traits", default-features = false }
 sp-api = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -222,7 +222,7 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T> {
 		PoolNotFound,
-		PoolConfigurationNotSupported,
+		NotEnoughLiquidity,
 		PairMismatch,
 		MustBeOwner,
 		InvalidSaleState,

--- a/frame/pablo/src/stable_swap.rs
+++ b/frame/pablo/src/stable_swap.rs
@@ -79,6 +79,7 @@ impl<T: Config> StableSwap<T> {
 		let pair = if asset_id == pool.pair.base { pool.pair } else { pool.pair.swap() };
 		let pool_base_aum = T::Assets::balance(pair.base, pool_account);
 		let pool_quote_aum = T::Assets::balance(pair.quote, pool_account);
+		ensure!(!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(), Error::<T>::NotEnoughLiquidity);
 		let amp = T::Convert::convert(pool.amplification_coefficient.into());
 		let d = Self::get_invariant(pool_base_aum, pool_quote_aum, amp)?;
 		let new_quote_amount = pool_quote_aum.safe_add(&amount)?;

--- a/frame/pablo/src/stable_swap.rs
+++ b/frame/pablo/src/stable_swap.rs
@@ -79,7 +79,10 @@ impl<T: Config> StableSwap<T> {
 		let pair = if asset_id == pool.pair.base { pool.pair } else { pool.pair.swap() };
 		let pool_base_aum = T::Assets::balance(pair.base, pool_account);
 		let pool_quote_aum = T::Assets::balance(pair.quote, pool_account);
-		ensure!(!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(), Error::<T>::NotEnoughLiquidity);
+		ensure!(
+			!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(),
+			Error::<T>::NotEnoughLiquidity
+		);
 		let amp = T::Convert::convert(pool.amplification_coefficient.into());
 		let d = Self::get_invariant(pool_base_aum, pool_quote_aum, amp)?;
 		let new_quote_amount = pool_quote_aum.safe_add(&amount)?;

--- a/frame/pablo/src/stable_swap_tests.rs
+++ b/frame/pablo/src/stable_swap_tests.rs
@@ -1,10 +1,9 @@
 #[cfg(test)]
 use crate::{
-	Error,
 	common_test_functions::*,
 	mock,
 	mock::{Pablo, *},
-	pallet,
+	pallet, Error,
 	PoolConfiguration::StableSwap,
 	PoolInitConfiguration,
 };
@@ -13,7 +12,10 @@ use composable_tests_helpers::{
 	test::helper::{acceptable_computation_error, default_acceptable_computation_error},
 };
 use composable_traits::{defi::CurrencyPair, dex::Amm};
-use frame_support::{assert_err, assert_noop, assert_ok, traits::fungibles::{Inspect, Mutate}};
+use frame_support::{
+	assert_err, assert_noop, assert_ok,
+	traits::fungibles::{Inspect, Mutate},
+};
 use proptest::prelude::*;
 use sp_runtime::{DispatchError, Permill};
 
@@ -436,20 +438,19 @@ fn avoid_exchange_without_liquidity() {
 			owner_fee,
 		};
 		System::set_block_number(1);
-		let created_pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
+		let created_pool_id =
+			Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
 		let bob_usdt = 1000 * unit;
 		// Mint the tokens
 		assert_ok!(Tokens::mint_into(USDT, &BOB, bob_usdt));
-		assert_err!(Pablo::sell(
-			Origin::signed(BOB),
-			created_pool_id,
-			USDT,
-			bob_usdt,
-			0_u128,
-			false
-		), DispatchError::from(Error::<Test>::NotEnoughLiquidity));
-		assert_err!(pallet::prices_for::<Test>(created_pool_id, USDC, USDT, 1 * unit)
-			, DispatchError::from(Error::<Test>::NotEnoughLiquidity));
+		assert_err!(
+			Pablo::sell(Origin::signed(BOB), created_pool_id, USDT, bob_usdt, 0_u128, false),
+			DispatchError::from(Error::<Test>::NotEnoughLiquidity)
+		);
+		assert_err!(
+			pallet::prices_for::<Test>(created_pool_id, USDC, USDT, 1 * unit),
+			DispatchError::from(Error::<Test>::NotEnoughLiquidity)
+		);
 	});
 }
 

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -68,7 +68,10 @@ impl<T: Config> Uniswap<T> {
 		let half_weight = Permill::from_percent(50);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, pool_account));
 		let pool_quote_aum = T::Convert::convert(T::Assets::balance(pool.pair.quote, pool_account));
-		ensure!(!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(), Error::<T>::NotEnoughLiquidity);
+		ensure!(
+			!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(),
+			Error::<T>::NotEnoughLiquidity
+		);
 		let exchange_amount = if asset_id == pool.pair.quote {
 			compute_out_given_in(half_weight, half_weight, pool_quote_aum, pool_base_aum, amount)
 		} else {

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -68,6 +68,7 @@ impl<T: Config> Uniswap<T> {
 		let half_weight = Permill::from_percent(50);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, pool_account));
 		let pool_quote_aum = T::Convert::convert(T::Assets::balance(pool.pair.quote, pool_account));
+		ensure!(!pool_base_aum.is_zero() && !pool_quote_aum.is_zero(), Error::<T>::NotEnoughLiquidity);
 		let exchange_amount = if asset_id == pool.pair.quote {
 			compute_out_given_in(half_weight, half_weight, pool_quote_aum, pool_base_aum, amount)
 		} else {

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -1,10 +1,9 @@
 #[cfg(test)]
 use crate::{
-	Error,
 	common_test_functions::*,
 	mock,
 	mock::{Pablo, *},
-	pallet,
+	pallet, Error,
 	PoolConfiguration::ConstantProduct,
 	PoolInitConfiguration,
 };
@@ -17,12 +16,15 @@ use composable_traits::{
 	defi::CurrencyPair,
 	dex::{Amm, ConstantProductPoolInfo},
 };
-use frame_support::{assert_err, assert_ok, traits::{
-	fungibles::{Inspect, Mutate},
-	Hooks,
-}};
+use frame_support::{
+	assert_err, assert_ok,
+	traits::{
+		fungibles::{Inspect, Mutate},
+		Hooks,
+	},
+};
 use proptest::prelude::*;
-use sp_runtime::{traits::IntegerSquareRoot, Permill, DispatchError};
+use sp_runtime::{traits::IntegerSquareRoot, DispatchError, Permill};
 
 fn create_pool(
 	base_asset: AssetId,
@@ -385,13 +387,16 @@ fn avoid_exchange_without_liquidity() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee: lp_fee,
-			owner_fee
+			owner_fee,
 		};
 		System::set_block_number(1);
 		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
 		let bob_usdt = 45_000_u128 * unit;
 		let quote_usdt = bob_usdt - lp_fee.mul_floor(bob_usdt);
-		assert_err!(<Pablo as Amm>::get_exchange_value(pool_id, USDT, quote_usdt), DispatchError::from(Error::<Test>::NotEnoughLiquidity));
+		assert_err!(
+			<Pablo as Amm>::get_exchange_value(pool_id, USDT, quote_usdt),
+			DispatchError::from(Error::<Test>::NotEnoughLiquidity)
+		);
 	});
 }
 

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 use crate::{
+	Error,
 	common_test_functions::*,
 	mock,
 	mock::{Pablo, *},
@@ -16,15 +17,12 @@ use composable_traits::{
 	defi::CurrencyPair,
 	dex::{Amm, ConstantProductPoolInfo},
 };
-use frame_support::{
-	assert_ok,
-	traits::{
-		fungibles::{Inspect, Mutate},
-		Hooks,
-	},
-};
+use frame_support::{assert_err, assert_ok, traits::{
+	fungibles::{Inspect, Mutate},
+	Hooks,
+}};
 use proptest::prelude::*;
-use sp_runtime::{traits::IntegerSquareRoot, Permill};
+use sp_runtime::{traits::IntegerSquareRoot, Permill, DispatchError};
 
 fn create_pool(
 	base_asset: AssetId,
@@ -374,6 +372,26 @@ fn fees() {
         }
 		assert_ok!(default_acceptable_computation_error(expected_alice_usdt_bal, alice_usdt_bal));
 
+	});
+}
+
+#[test]
+fn avoid_exchange_without_liquidity() {
+	new_test_ext().execute_with(|| {
+		let unit = 1_000_000_000_000_u128;
+		let lp_fee = Permill::from_float(0.05);
+		let owner_fee = Permill::from_float(0.01);
+		let pool_init_config = PoolInitConfiguration::ConstantProduct {
+			owner: ALICE,
+			pair: CurrencyPair::new(BTC, USDT),
+			fee: lp_fee,
+			owner_fee
+		};
+		System::set_block_number(1);
+		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
+		let bob_usdt = 45_000_u128 * unit;
+		let quote_usdt = bob_usdt - lp_fee.mul_floor(bob_usdt);
+		assert_err!(<Pablo as Amm>::get_exchange_value(pool_id, USDT, quote_usdt), DispatchError::from(Error::<Test>::NotEnoughLiquidity));
 	});
 }
 


### PR DESCRIPTION
## Description
Right now trying to exchange without adding liquidity to the dex causes arithmatic overflow error. This change makes sure not to exchange or throw overflow error when there is no liquidity, instead producing a descriptive error.

