### PR TITLE
Fix for CU-2xgnnvt and CU-2xpjf2x.

### DIFF
--- a/frame/composable-tests-helpers/src/test/helper.rs
+++ b/frame/composable-tests-helpers/src/test/helper.rs
@@ -1,4 +1,3 @@
-use composable_support::math::safe::SafeSub;
 use frame_support::{assert_ok, dispatch::DispatchResultWithPostInfo};
 use frame_system::{Config, EventRecord};
 use sp_runtime::{FixedPointNumber, FixedU128};

--- a/frame/composable-traits/src/defi.rs
+++ b/frame/composable-traits/src/defi.rs
@@ -96,9 +96,13 @@ impl<AssetId: PartialEq> PartialEq for CurrencyPair<AssetId> {
 
 impl<AssetId: PartialEq> Eq for CurrencyPair<AssetId> {}
 
-impl<AssetId: Copy> CurrencyPair<AssetId> {
+impl<AssetId: Copy + PartialEq> CurrencyPair<AssetId> {
 	pub fn swap(&self) -> Self {
 		Self { base: self.quote, quote: self.base }
+	}
+
+	pub fn contains(&self, asset_id: AssetId) -> bool {
+		self.base == asset_id || self.quote == asset_id
 	}
 }
 

--- a/frame/currency-factory/src/benchmarking.rs
+++ b/frame/currency-factory/src/benchmarking.rs
@@ -5,7 +5,7 @@ use super::*;
 #[allow(unused_imports)]
 use crate::Pallet as CurrencyFactory;
 use crate::{self as currency_factory};
-use codec::{Decode, Encode};
+use codec::Decode;
 use composable_traits::{
 	assets::BasicAssetMetadata,
 	currency::{CurrencyFactory as DeFiCurrencyFactory, RangeId},

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -227,6 +227,7 @@ pub mod pallet {
 		MustBeOwner,
 		InvalidSaleState,
 		InvalidAmount,
+		InvalidAsset,
 		CannotRespectMinimumRequested,
 		AssetAmountMustBePositiveNumber,
 		InvalidPair,
@@ -835,12 +836,15 @@ pub mod pallet {
 			let pool_account = Self::account_id(&pool_id);
 			let (base_amount, fees, fee_asset_id) = match pool {
 				PoolConfiguration::StableSwap(info) => {
-					// /!\ NOTE(hussein-aitlahcen): after this check, do not use pool.pair as the
-					// provided pair might have been swapped
-					ensure!(pair == info.pair, Error::<T>::PairMismatch);
 					// NOTE: lp_fees includes owner_fees.
 					let (base_amount_excluding_fees, quote_amount, lp_fees, owner_fees) =
-						StableSwap::<T>::do_compute_swap(&info, &pool_account, quote_amount, true)?;
+						StableSwap::<T>::do_compute_swap(
+							&info,
+							&pool_account,
+							pair,
+							quote_amount,
+							true,
+						)?;
 
 					ensure!(
 						base_amount_excluding_fees >= min_receive,

--- a/frame/pablo/src/liquidity_bootstrapping.rs
+++ b/frame/pablo/src/liquidity_bootstrapping.rs
@@ -150,10 +150,7 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
-		ensure!(
-			asset_id == pool.pair.base || asset_id == pool.pair.quote,
-			Error::<T>::InvalidAsset
-		);
+		ensure!(pool.pair.contains(asset_id), Error::<T>::InvalidAsset);
 		let pair = if asset_id == pool.pair.base { pool.pair.swap() } else { pool.pair };
 		let current_block = frame_system::Pallet::<T>::current_block_number();
 		let (_, base_amount) =

--- a/frame/pablo/src/liquidity_bootstrapping.rs
+++ b/frame/pablo/src/liquidity_bootstrapping.rs
@@ -150,6 +150,10 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
+		ensure!(
+			asset_id == pool.pair.base || asset_id == pool.pair.quote,
+			Error::<T>::InvalidAsset
+		);
 		let pair = if asset_id == pool.pair.base { pool.pair.swap() } else { pool.pair };
 		let current_block = frame_system::Pallet::<T>::current_block_number();
 		let (_, base_amount) =

--- a/frame/pablo/src/stable_swap.rs
+++ b/frame/pablo/src/stable_swap.rs
@@ -76,10 +76,7 @@ impl<T: Config> StableSwap<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
-		ensure!(
-			asset_id == pool.pair.base || asset_id == pool.pair.quote,
-			Error::<T>::InvalidAsset
-		);
+		ensure!(pool.pair.contains(asset_id), Error::<T>::InvalidAsset);
 		let pair = if asset_id == pool.pair.base { pool.pair } else { pool.pair.swap() };
 		let pool_base_aum = T::Assets::balance(pair.base, pool_account);
 		let pool_quote_aum = T::Assets::balance(pair.quote, pool_account);

--- a/frame/pablo/src/stable_swap.rs
+++ b/frame/pablo/src/stable_swap.rs
@@ -76,6 +76,10 @@ impl<T: Config> StableSwap<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
+		ensure!(
+			asset_id == pool.pair.base || asset_id == pool.pair.quote,
+			Error::<T>::InvalidAsset
+		);
 		let pair = if asset_id == pool.pair.base { pool.pair } else { pool.pair.swap() };
 		let pool_base_aum = T::Assets::balance(pair.base, pool_account);
 		let pool_quote_aum = T::Assets::balance(pair.quote, pool_account);
@@ -110,11 +114,12 @@ impl<T: Config> StableSwap<T> {
 	pub fn do_compute_swap(
 		pool: &StableSwapPoolInfo<T::AccountId, T::AssetId>,
 		pool_account: &T::AccountId,
+		pair: CurrencyPair<T::AssetId>,
 		quote_amount: T::Balance,
 		apply_fees: bool,
 	) -> Result<(T::Balance, T::Balance, T::Balance, T::Balance), DispatchError> {
-		let base_amount =
-			Self::get_exchange_value(pool, pool_account, pool.pair.base, quote_amount)?;
+		ensure!(pair == pool.pair, Error::<T>::PairMismatch);
+		let base_amount = Self::get_exchange_value(pool, pool_account, pair.base, quote_amount)?;
 		let base_amount_u: u128 = T::Convert::convert(base_amount);
 
 		let (lp_fee, owner_fee) = if apply_fees {

--- a/frame/pablo/src/stable_swap_tests.rs
+++ b/frame/pablo/src/stable_swap_tests.rs
@@ -13,7 +13,7 @@ use composable_tests_helpers::{
 };
 use composable_traits::{defi::CurrencyPair, dex::Amm};
 use frame_support::{
-	assert_err, assert_noop, assert_ok,
+	assert_noop, assert_ok,
 	traits::fungibles::{Inspect, Mutate},
 };
 use proptest::prelude::*;
@@ -443,13 +443,92 @@ fn avoid_exchange_without_liquidity() {
 		let bob_usdt = 1000 * unit;
 		// Mint the tokens
 		assert_ok!(Tokens::mint_into(USDT, &BOB, bob_usdt));
-		assert_err!(
+		assert_noop!(
 			Pablo::sell(Origin::signed(BOB), created_pool_id, USDT, bob_usdt, 0_u128, false),
 			DispatchError::from(Error::<Test>::NotEnoughLiquidity)
 		);
-		assert_err!(
+		assert_noop!(
 			pallet::prices_for::<Test>(created_pool_id, USDC, USDT, 1 * unit),
 			DispatchError::from(Error::<Test>::NotEnoughLiquidity)
+		);
+	});
+}
+
+#[test]
+fn cannot_swap_between_wrong_pairs() {
+	new_test_ext().execute_with(|| {
+		let unit = 1_000_000_000_000_u128;
+		let lp_fee = Permill::from_float(0.05);
+		let owner_fee = Permill::from_float(0.01);
+		let pool_init_config = PoolInitConfiguration::StableSwap {
+			owner: ALICE,
+			pair: CurrencyPair::new(BTC, USDT),
+			amplification_coefficient: 40_000,
+			fee: lp_fee,
+			owner_fee,
+		};
+		System::set_block_number(1);
+		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
+		let base_amount = 100_000_u128 * unit;
+		let quote_amount = 100_000_u128 * unit;
+		assert_ok!(Tokens::mint_into(BTC, &ALICE, base_amount));
+		assert_ok!(Tokens::mint_into(USDT, &ALICE, quote_amount));
+
+		assert_ok!(Tokens::mint_into(BTC, &BOB, base_amount));
+		assert_ok!(Tokens::mint_into(USDC, &BOB, quote_amount));
+		assert_ok!(<Pablo as Amm>::add_liquidity(
+			&ALICE,
+			pool_id,
+			base_amount,
+			quote_amount,
+			0,
+			false
+		));
+		let usdc_amount = 2000_u128 * unit;
+		let bad_pair = CurrencyPair::new(BTC, USDC);
+		assert_noop!(
+			Pablo::swap(Origin::signed(BOB), pool_id, bad_pair, usdc_amount, 0_u128, false),
+			Error::<Test>::PairMismatch
+		);
+		assert_noop!(
+			Pablo::swap(Origin::signed(BOB), pool_id, bad_pair.swap(), usdc_amount, 0_u128, false),
+			Error::<Test>::PairMismatch
+		);
+	});
+}
+
+#[test]
+fn cannot_get_exchange_value_for_wrong_asset() {
+	new_test_ext().execute_with(|| {
+		let unit = 1_000_000_000_000_u128;
+		let lp_fee = Permill::from_float(0.05);
+		let owner_fee = Permill::from_float(0.01);
+		let pool_init_config = PoolInitConfiguration::StableSwap {
+			owner: ALICE,
+			pair: CurrencyPair::new(BTC, USDT),
+			amplification_coefficient: 40_000,
+			fee: lp_fee,
+			owner_fee,
+		};
+		System::set_block_number(1);
+		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
+		let base_amount = 100_000_u128 * unit;
+		let quote_amount = 100_000_u128 * unit;
+		assert_ok!(Tokens::mint_into(BTC, &ALICE, base_amount));
+		assert_ok!(Tokens::mint_into(USDT, &ALICE, quote_amount));
+
+		assert_ok!(<Pablo as Amm>::add_liquidity(
+			&ALICE,
+			pool_id,
+			base_amount,
+			quote_amount,
+			0,
+			false
+		));
+		let usdc_amount = 2000_u128 * unit;
+		assert_noop!(
+			<Pablo as Amm>::get_exchange_value(pool_id, USDC, usdc_amount,),
+			Error::<Test>::InvalidAsset
 		);
 	});
 }

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -64,6 +64,10 @@ impl<T: Config> Uniswap<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
+		ensure!(
+			asset_id == pool.pair.base || asset_id == pool.pair.quote,
+			Error::<T>::InvalidAsset
+		);
 		let amount = T::Convert::convert(amount);
 		let half_weight = Permill::from_percent(50);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, pool_account));
@@ -160,6 +164,7 @@ impl<T: Config> Uniswap<T> {
 		quote_amount: T::Balance,
 		apply_fees: bool,
 	) -> Result<(T::Balance, T::Balance, T::Balance, T::Balance), DispatchError> {
+		ensure!(pair == pool.pair, Error::<T>::PairMismatch);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pair.base, pool_account));
 		let pool_quote_aum = T::Convert::convert(T::Assets::balance(pair.quote, pool_account));
 		let quote_amount = T::Convert::convert(quote_amount);

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -64,10 +64,7 @@ impl<T: Config> Uniswap<T> {
 		asset_id: T::AssetId,
 		amount: T::Balance,
 	) -> Result<T::Balance, DispatchError> {
-		ensure!(
-			asset_id == pool.pair.base || asset_id == pool.pair.quote,
-			Error::<T>::InvalidAsset
-		);
+		ensure!(pool.pair.contains(asset_id), Error::<T>::InvalidAsset);
 		let amount = T::Convert::convert(amount);
 		let half_weight = Permill::from_percent(50);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, pool_account));


### PR DESCRIPTION
Check asset_id before performing exchange().
Update tests accordingly.
Remove some unused imports.

## Issue
https://app.clickup.com/t/2xgnnvt
https://app.clickup.com/t/2xpjf2x

## Checklist

~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~
~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~