### PR TITLE
test(Runtime Integration Tests): Fixed Oracle tests not finishing

### DIFF
--- a/integration-tests/runtime-tests/test/tests/oracle/txOracleTests.ts
+++ b/integration-tests/runtime-tests/test/tests/oracle/txOracleTests.ts
@@ -44,6 +44,11 @@ describe("tx.oracle Tests", function() {
     signedWallet = devWalletAlice.derive("/oracleSigner");
     controllerWallet = devWalletAlice;
   });
+
+  after("Closing the connection", async function() {
+    await api.disconnect();
+  });
+
   /**
    * oracle.addAssetAndInfo Success Tests
    *


### PR DESCRIPTION
## Issue
The Oracle tests were missing a `after` step to close the API connection and therefore never exited the application.