### PR TITLE
docs(benchmarking): update links, remove empty lines, use monospace and other style fixes

### DIFF
--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,4 +1,3 @@
-
 # How to add benchmarking for a pallet
 
 In order to set the correct Weights(the execution time of function/transaction fee) on our functions, we need to test our functions so we can
@@ -7,42 +6,40 @@ This is where benchmarking comes in, a way to dry-run our functions without affe
 
 There are 3 major parts we need in order to implement benchmarking:
 
-*  Create a weight file
-
-*  Write benchmark tests
-
-*  Add the benchmark to the runtime
-
+* Create a weight file
+* Write benchmark tests
+* Add the benchmark to the runtime
 
 Let's try adding benchmarking to the scheduler pallet to picasso's runtime.
 
-
 ## Configuring Weights
+
 All of substrate's own pallets weights.rs files can be automatically generated using the WeightInfo trait.
 
 Read more here:
+
 https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking#auto-generated-weightinfo-implementation
 
+Find the pallets weight file, add it to the weights folder and include it in the `mod.rs` file.
 
-Find the pallets weight file, add it to the weights folder and
-include it in the mod.rs file.
-```bash
+```shell
 $ ls runtime/picasso/src/weights/
 frame_system.rs
 indices.rs
 membership.rs
 mod.rs
 ```
+
 In our case, we want to add the scheduler pallets weight file, which
 we can easily find in the [pallets repository](https://github.com/paritytech/substrate/tree/master/frame/scheduler).
 
-Let's download the weights.rs file and place it into our weights folder and name it after the pallet:
-```
-$ curl "https://raw.githubusercontent.com/paritytech/substrate/v3.0.0/frame/scheduler/src/weights.rs" -o composable/runtime/picasso/src/weights/scheduler.rs
+Let's download the `weights.rs` file and place it into our `weights` folder and name it after the pallet:
+
+```shell
+curl "https://raw.githubusercontent.com/paritytech/substrate/v3.0.0/frame/scheduler/src/weights.rs" -o composable/runtime/picasso/src/weights/scheduler.rs
 ```
 
-
-Lets make the file more lightweight by change WeightInfo into a struct instead of the default trait and rename SubstrateWeight to WeightInfo:
+Lets make the file more lightweight by change `WeightInfo` into a struct instead of the default trait and rename `SubstrateWeight` to `WeightInfo`:
 
 ```rust
 47 pub trait WeightInfo {               // remove
@@ -107,19 +104,19 @@ impl<T: frame_system::Config> scheduler::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
 }
-
 ```
 
-Append our new weight file to mod.rs
-```bash
+Append our new weight file to `mod.rs`
+
+```shell
 echo "pub mod scheduler;" >> mod.rs
 ```
-and now we can simply call our weight file with:
-*weights::scheduler*
 
-And use our WeightInfo functionality in the code base by defining a variable just like this:
+and now we can simply call our weight file with: *weights::scheduler*
+
+And use our `WeightInfo` functionality in the code base by defining a variable just like this:
+
 ```rust
-
 impl scheduler::Config for Runtime {
 	type Event = Event;
 	type Origin = Origin;
@@ -132,18 +129,17 @@ impl scheduler::Config for Runtime {
 }
 ```
 
-
-
 ## Adding benchmarking to the runtime
+
 So now when we can easily include and use our weight file, we can move forward and add it to our runtime.
 In order to add a pallets benchmarking functions to a runtime we first
 need to go into the directory folder:
 
-```bash
+```shell
 cd runtime/picasso/
 ```
 
-Enable the pallet's benchmarking features in Cargo.toml:
+Enable the pallet's benchmarking features in `Cargo.toml`:
 
 ```toml
 ...
@@ -160,9 +156,9 @@ runtime-benchmarks = [
 ```
 
 In our runtime we need to tell the benchmark library to execute our benchmarks, so we can easily use it.
-This is done with the [dispatch_benchmark](https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/frame/benchmarking/src/utils.rs#L93) function. All benchmarks
+This is done with the [`dispatch_benchmark`](https://github.com/paritytech/substrate/blob/polkadot-v0.9.8/frame/benchmarking/src/utils.rs#L93) function. All benchmarks
 we want to enable needs to be added to the Vec list we are creating in this function.
-So simply add it with the [add_benchmark](https://docs.rs/frame-benchmarking/3.0.0/frame_benchmarking/macro.add_benchmark.html) macro function:
+So simply add it with the [`add_benchmark`](https://docs.rs/frame-benchmarking/3.0.0/frame_benchmarking/macro.add_benchmark.html) macro function:
 
 ```rust
 // ...
@@ -170,7 +166,7 @@ add_benchmark!(params, batches, balances, Balances);
 // ...
 ```
 
-or [define_benchmarks](https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs#L1834-L1869) macro (it's available starting with `polkadot-v0.9.18` branch):
+or [`define_benchmarks`](https://github.com/paritytech/substrate/blob/ededa465214e308d18f12d90515bb49c974c0d7d/frame/benchmarking/src/lib.rs#L1845) macro (it's available starting with `polkadot-v0.9.16` branch):
 
 ```rust
 define_benchmarks!(
@@ -180,17 +176,16 @@ define_benchmarks!(
 );
 ```
 
-Read more about the benchmarking library here:
-https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs#L1325
-https://crates.io/crates/frame-benchmarking
+Read more about the benchmarking library here: https://docs.rs/crate/frame-benchmarking
 
 Extra:
-If we are running the latest version of the frame-benchmarking dependency we can also add our pallet to the [benchmark_metadata](https://github.com/paritytech/substrate/blob/polkadot-v0.9.18/frame/benchmarking/src/utils.rs#L150) function.
 
-
+If we are running the latest version of the frame-benchmarking dependency we can also add our pallet to the [`benchmark_metadata`](https://github.com/paritytech/substrate/blob/19162e43be45817b44c7d48e50d03f074f60fbf4/frame/benchmarking/src/utils.rs#L201) function.
 
 ## Compile and run
+
 Now when we have everything we need, we want to build it:
+
 ```shell
 cargo make build-benchmarks
 ```
@@ -198,20 +193,18 @@ cargo make build-benchmarks
 ## Run the benchmarks
 
 ```shell
-$ ./target/release/composable benchmark --chain=picasso-dev --execution=wasm --wasm-execution=compiled --pallet=scheduler --extrinsic='*' --steps=10 --repeat=5 --raw --output=./runtime/picasso/src/weights
-
+./target/release/composable benchmark --chain=picasso-dev --execution=wasm --wasm-execution=compiled --pallet=scheduler --extrinsic='*' --steps=10 --repeat=5 --raw --output=./runtime/picasso/src/weights
 ```
 
 Tips:
-In the script folder you can find the benchmarks.sh, use that to easily
-run benchmarks on all pallets synchronously.
 
+In the script folder you can find the [`benchmark.sh`](https://github.com/ComposableFi/composable/blob/56e2c1746b845a3556631b5bcebcf7a1773f1f42/scripts/benchmark.sh), use that to easily run benchmarks on all pallets synchronously.
 
+### Read more
 
-### Read more:
-https://github.com/shawntabrizi/substrate-benchmark-genesis
-https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs
-https://www.shawntabrizi.com/substrate-graph-benchmarks/docs/#/
-https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking
-https://crates.io/crates/frame-benchmarking
-https://github.com/paritytech/substrate/tree/polkadot-v0.9.8/frame/benchmarking
+* https://github.com/shawntabrizi/substrate-benchmark-genesis
+* https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs
+* https://www.shawntabrizi.com/substrate-graph-benchmarks/docs/#/
+* https://substrate.dev/docs/en/knowledgebase/runtime/benchmarking
+* https://crates.io/crates/frame-benchmarking
+* https://github.com/paritytech/substrate/tree/polkadot-v0.9.8/frame/benchmarking


### PR DESCRIPTION
## Description

Beautified `benchmarking.md` doc and updated links.

P.S. It can be rejected if it does not match guidelines (which one?).