### PR TITLE
CU-2bbgg1k - Configurable constant product

### DIFF
--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -233,6 +233,10 @@ pub struct ConstantProductPoolInfo<AccountId, AssetId> {
 	pub lp_token: AssetId,
 	/// Amount of the fee pool charges for the exchange
 	pub fee_config: FeeConfig,
+	/// The weight of the base asset. Must hold `1 = base_weight + quote_weight`
+	pub base_weight: Permill,
+	/// The weight of the quote asset. Must hold `1 = base_weight + quote_weight`
+	pub quote_weight: Permill,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq)]

--- a/frame/dex-router/src/benchmarking.rs
+++ b/frame/dex-router/src/benchmarking.rs
@@ -72,6 +72,7 @@ where
 		owner: owner.clone(),
 		pair: CurrencyPair::new(pica, ksm),
 		fee_config: FeeConfig::zero(),
+		base_weight: Permill::from_percent(50),
 	};
 	let pica_ksm = pallet_pablo::Pallet::<T>::do_create_pool(pica_ksm_config).unwrap();
 	// 100 pica == 1 ksm
@@ -97,6 +98,7 @@ where
 		owner: owner.clone(),
 		pair: CurrencyPair::new(ksm, eth),
 		fee_config: FeeConfig::zero(),
+		base_weight: Permill::from_percent(50),
 	};
 	let ksm_eth = pallet_pablo::Pallet::<T>::do_create_pool(ksm_eth_config).unwrap();
 	// 10 ksm == 1 eth
@@ -123,6 +125,7 @@ where
 		owner: owner.clone(),
 		pair: CurrencyPair::new(eth, usdc),
 		fee_config: FeeConfig::zero(),
+		base_weight: Permill::from_percent(50),
 	};
 	let eth_usdc = pallet_pablo::Pallet::<T>::do_create_pool(eth_usdc_config).unwrap();
 	// 1 eth = 200 usdc

--- a/frame/dex-router/src/benchmarking.rs
+++ b/frame/dex-router/src/benchmarking.rs
@@ -7,6 +7,7 @@ use composable_traits::{
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
 use frame_support::traits::fungibles::Mutate;
 use frame_system::RawOrigin;
+use sp_runtime::Permill;
 use sp_std::{vec, vec::Vec};
 
 fn create_single_node_pool<T>() -> (

--- a/frame/dex-router/src/tests.rs
+++ b/frame/dex-router/src/tests.rs
@@ -71,6 +71,7 @@ fn create_constant_product_amm_pool(
 			owner_fee_rate: admin_fee,
 			protocol_fee_rate: Permill::zero(),
 		},
+		base_weight: Permill::from_percent(50),
 	};
 	// Create Pablo pool
 	let p = Pablo::do_create_pool(init_config);

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -113,6 +113,7 @@ pub mod pallet {
 			owner: AccountId,
 			pair: CurrencyPair<AssetId>,
 			fee_config: FeeConfig,
+			base_weight: Permill,
 		},
 		LiquidityBootstrapping(LiquidityBootstrappingPoolInfo<AccountId, AssetId, BlockNumber>),
 	}
@@ -231,6 +232,7 @@ pub mod pallet {
 		AmpFactorMustBeGreaterThanZero,
 		MissingAmount,
 		NoLpTokenForLbp,
+		WeightsMustBeNonZero,
 	}
 
 	#[pallet::config]
@@ -554,11 +556,24 @@ pub mod pallet {
 					fee_config: fee,
 				} => (
 					owner.clone(),
-					StableSwap::<T>::do_create_pool(&owner, pair, amplification_coefficient, fee)?,
+					StableSwap::<T>::do_create_pool(
+						&owner,
+						pair,
+						amplification_coefficient,
+						fee,
+					)?,
 					pair,
 				),
-				PoolInitConfiguration::ConstantProduct { owner, pair, fee_config: fee } =>
-					(owner.clone(), Uniswap::<T>::do_create_pool(&owner, pair, fee)?, pair),
+				PoolInitConfiguration::ConstantProduct {
+					owner,
+					pair,
+					fee,
+					base_weight,
+				} => (
+					owner.clone(),
+					Uniswap::<T>::do_create_pool(&owner, pair, fee, owner_fee, base_weight)?,
+					pair,
+				),
 				PoolInitConfiguration::LiquidityBootstrapping(pool_config) => {
 					let validated_pool_config = Validated::new(pool_config.clone())?;
 					(

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -233,6 +233,7 @@ pub mod pallet {
 		MissingAmount,
 		NoLpTokenForLbp,
 		WeightsMustBeNonZero,
+		WeightsMustSumToOne,
 	}
 
 	#[pallet::config]
@@ -556,24 +557,15 @@ pub mod pallet {
 					fee_config: fee,
 				} => (
 					owner.clone(),
-					StableSwap::<T>::do_create_pool(
-						&owner,
+					StableSwap::<T>::do_create_pool(&owner, pair, amplification_coefficient, fee)?,
+					pair,
+				),
+				PoolInitConfiguration::ConstantProduct { owner, pair, fee_config, base_weight } =>
+					(
+						owner.clone(),
+						Uniswap::<T>::do_create_pool(&owner, pair, fee_config, base_weight)?,
 						pair,
-						amplification_coefficient,
-						fee,
-					)?,
-					pair,
-				),
-				PoolInitConfiguration::ConstantProduct {
-					owner,
-					pair,
-					fee,
-					base_weight,
-				} => (
-					owner.clone(),
-					Uniswap::<T>::do_create_pool(&owner, pair, fee, owner_fee, base_weight)?,
-					pair,
-				),
+					),
 				PoolInitConfiguration::LiquidityBootstrapping(pool_config) => {
 					let validated_pool_config = Validated::new(pool_config.clone())?;
 					(

--- a/frame/pablo/src/liquidity_bootstrapping.rs
+++ b/frame/pablo/src/liquidity_bootstrapping.rs
@@ -15,7 +15,6 @@ use composable_traits::{
 use frame_support::{
 	pallet_prelude::*,
 	traits::fungibles::{Inspect, Transfer},
-	transactional,
 };
 use frame_system::pallet_prelude::BlockNumberFor;
 use sp_runtime::traits::{BlockNumberProvider, Convert, One, Zero};
@@ -157,7 +156,6 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		Ok(base_amount)
 	}
 
-	#[transactional]
 	pub(crate) fn add_liquidity(
 		who: &T::AccountId,
 		pool: LiquidityBootstrappingPoolInfoOf<T>,
@@ -181,7 +179,6 @@ impl<T: Config> LiquidityBootstrapping<T> {
 		Ok((base_amount, quote_amount, T::Balance::zero()))
 	}
 
-	#[transactional]
 	pub(crate) fn remove_liquidity(
 		who: &T::AccountId,
 		pool_id: T::PoolId,

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -11,7 +11,6 @@ use composable_traits::{
 use frame_support::{
 	pallet_prelude::*,
 	traits::fungibles::{Inspect, Mutate, Transfer},
-	transactional,
 };
 use sp_runtime::{
 	traits::{Convert, One, Zero},
@@ -22,7 +21,6 @@ use sp_runtime::{
 pub(crate) struct Uniswap<T>(PhantomData<T>);
 
 impl<T: Config> Uniswap<T> {
-	#[transactional]
 	pub(crate) fn do_create_pool(
 		who: &T::AccountId,
 		pair: CurrencyPair<T::AssetId>,
@@ -112,7 +110,6 @@ impl<T: Config> Uniswap<T> {
 		Ok((base_amount, quote_amount, lp_token_to_mint))
 	}
 
-	#[transactional]
 	pub(crate) fn remove_liquidity(
 		who: &T::AccountId,
 		pool: ConstantProductPoolInfo<T::AccountId, T::AssetId>,

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -25,12 +25,15 @@ impl<T: Config> Uniswap<T> {
 		who: &T::AccountId,
 		pair: CurrencyPair<T::AssetId>,
 		fee_config: FeeConfig,
+		base_weight: Permill,
 	) -> Result<T::PoolId, DispatchError> {
-		// NOTE(hussein-aitlahcen): do we allow such pair?
+		ensure!(base_weight < Permill::one(), Error::<T>::WeightsMustBeNonZero);
 		ensure!(pair.base != pair.quote, Error::<T>::InvalidPair);
 		ensure!(fee_config.fee_rate < Permill::one(), Error::<T>::InvalidFees);
 
 		let lp_token = T::CurrencyFactory::create(RangeId::LP_TOKENS, T::Balance::default())?;
+
+		let quote_weight = Permill::one().safe_sub(&base_weight)?;
 
 		// Add new pool
 		let pool_id =
@@ -43,6 +46,8 @@ impl<T: Config> Uniswap<T> {
 						pair,
 						lp_token,
 						fee_config,
+						base_weight,
+						quote_weight,
 					}),
 				);
 				*pool_count = pool_id.safe_add(&T::PoolId::one())?;
@@ -60,7 +65,6 @@ impl<T: Config> Uniswap<T> {
 	) -> Result<T::Balance, DispatchError> {
 		ensure!(pool.pair.contains(asset_id), Error::<T>::InvalidAsset);
 		let amount = T::Convert::convert(amount);
-		let half_weight = Permill::from_percent(50);
 		let pool_base_aum = T::Convert::convert(T::Assets::balance(pool.pair.base, pool_account));
 		let pool_quote_aum = T::Convert::convert(T::Assets::balance(pool.pair.quote, pool_account));
 		ensure!(
@@ -68,14 +72,25 @@ impl<T: Config> Uniswap<T> {
 			Error::<T>::NotEnoughLiquidity
 		);
 		let exchange_amount = if asset_id == pool.pair.quote {
-			compute_out_given_in(half_weight, half_weight, pool_quote_aum, pool_base_aum, amount)
+			compute_out_given_in(
+				pool.quote_weight,
+				pool.base_weight,
+				pool_quote_aum,
+				pool_base_aum,
+				amount,
+			)
 		} else {
-			compute_in_given_out(half_weight, half_weight, pool_quote_aum, pool_base_aum, amount)
+			compute_in_given_out(
+				pool.quote_weight,
+				pool.base_weight,
+				pool_quote_aum,
+				pool_base_aum,
+				amount,
+			)
 		}?;
 		Ok(T::Convert::convert(exchange_amount))
 	}
 
-	#[transactional]
 	pub(crate) fn add_liquidity(
 		who: &T::AccountId,
 		pool: ConstantProductPoolInfo<T::AccountId, T::AssetId>,
@@ -166,10 +181,9 @@ impl<T: Config> Uniswap<T> {
 		// Charging fees "on the way in"
 		// https://balancer.gitbook.io/balancer/core-concepts/protocol/index#out-given-in
 		let quote_amount_excluding_lp_fee = T::Convert::convert(quote_amount.safe_sub(&fee.fee)?);
-		let half_weight = Permill::from_percent(50);
 		let base_amount = compute_out_given_in(
-			half_weight,
-			half_weight,
+			pool.quote_weight,
+			pool.base_weight,
 			pool_quote_aum,
 			pool_base_aum,
 			quote_amount_excluding_lp_fee,

--- a/frame/pablo/src/uniswap.rs
+++ b/frame/pablo/src/uniswap.rs
@@ -27,7 +27,9 @@ impl<T: Config> Uniswap<T> {
 		fee_config: FeeConfig,
 		base_weight: Permill,
 	) -> Result<T::PoolId, DispatchError> {
-		ensure!(base_weight < Permill::one(), Error::<T>::WeightsMustBeNonZero);
+		// TODO(hussein-aitlahcen): refactor all those checks using Validated
+		ensure!(base_weight != Permill::zero(), Error::<T>::WeightsMustBeNonZero);
+		ensure!(base_weight < Permill::one(), Error::<T>::WeightsMustSumToOne);
 		ensure!(pair.base != pair.quote, Error::<T>::InvalidPair);
 		ensure!(fee_config.fee_rate < Permill::one(), Error::<T>::InvalidFees);
 

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -42,6 +42,7 @@ fn create_pool(
 			owner_fee_rate: protocol_fee,
 			protocol_fee_rate: Permill::zero(),
 		},
+		base_weight: Permill::from_percent(50),
 	};
 	System::set_block_number(1);
 	let actual_pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
@@ -84,6 +85,7 @@ fn test() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee_config: FeeConfig::zero(),
+			base_weight: Permill::from_percent(50),
 		};
 		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
 
@@ -175,6 +177,7 @@ fn add_remove_lp() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee_config: FeeConfig::zero(),
+			base_weight: Permill::from_percent(50),
 		};
 		let unit = 1_000_000_000_000_u128;
 		let initial_btc = 1_00_u128 * unit;
@@ -244,6 +247,7 @@ fn add_lp_with_min_mint_amount() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee_config: FeeConfig::zero(),
+			base_weight: Permill::from_percent(50),
 		};
 		let unit = 1_000_000_000_000_u128;
 		let initial_btc = 1_00_u128 * unit;
@@ -277,6 +281,7 @@ fn remove_lp_failure() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee_config: FeeConfig::zero(),
+			base_weight: Permill::from_percent(50),
 		};
 		let unit = 1_000_000_000_000_u128;
 		let initial_btc = 1_00_u128 * unit;
@@ -301,6 +306,7 @@ fn exchange_failure() {
 			owner: ALICE,
 			pair: CurrencyPair::new(BTC, USDT),
 			fee_config: FeeConfig::zero(),
+			base_weight: Permill::from_percent(50),
 		};
 		let exchange_base_amount = 100 * unit;
 		common_exchange_failure(pool_init_config, initial_usdt, initial_btc, exchange_base_amount)
@@ -389,6 +395,7 @@ fn avoid_exchange_without_liquidity() {
 				owner_fee_rate: owner_fee,
 				protocol_fee_rate: Permill::zero(),
 			},
+			base_weight: Permill::from_percent(50),
 		};
 		System::set_block_number(1);
 		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
@@ -415,6 +422,7 @@ fn cannot_swap_between_wrong_pairs() {
 				owner_fee_rate: owner_fee,
 				protocol_fee_rate: Permill::zero(),
 			},
+			base_weight: Permill::from_percent(50),
 		};
 		System::set_block_number(1);
 		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");
@@ -460,6 +468,7 @@ fn cannot_get_exchange_value_for_wrong_asset() {
 				owner_fee_rate: owner_fee,
 				protocol_fee_rate: Permill::zero(),
 			},
+			base_weight: Permill::from_percent(50),
 		};
 		System::set_block_number(1);
 		let pool_id = Pablo::do_create_pool(pool_init_config).expect("pool creation failed");

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -499,70 +499,70 @@ proptest! {
 	fn buy_sell_proptest(
 		btc_value in 1..u32::MAX,
 	) {
-	new_test_ext().execute_with(|| {
-		let unit = 1_000_000_000_000_u128;
-		let initial_btc = 1_000_000_000_000_u128 * unit;
-		let btc_price = 45_000_u128;
-		let initial_usdt = initial_btc * btc_price;
-		let btc_value = btc_value as u128 * unit;
-		let usdt_value = btc_value * btc_price;
-		let pool_id = create_pool(
-			BTC,
-			USDT,
-			initial_btc,
-			initial_usdt,
-			Permill::zero(),
-			Permill::zero(),
-		);
-		prop_assert_ok!(Tokens::mint_into(USDT, &BOB, usdt_value));
-		prop_assert_ok!(Pablo::sell(Origin::signed(BOB), pool_id, USDT, usdt_value, 0_u128, false));
-		let bob_btc = Tokens::balance(BTC, &BOB);
-		// mint extra BTC equal to slippage so that original amount of USDT can be buy back
-		prop_assert_ok!(Tokens::mint_into(BTC, &BOB, btc_value - bob_btc));
-		prop_assert_ok!(Pablo::buy(Origin::signed(BOB), pool_id, USDT, usdt_value, 0_u128, false));
-		let bob_usdt = Tokens::balance(USDT, &BOB);
-		let slippage = usdt_value -  bob_usdt;
-		let slippage_percentage = slippage as f64 * 100.0_f64 / usdt_value as f64;
-		prop_assert!(slippage_percentage < 1.0_f64);
-		Ok(())
-	})?;
+	  new_test_ext().execute_with(|| {
+		  let unit = 1_000_000_000_000_u128;
+		  let initial_btc = 1_000_000_000_000_u128 * unit;
+		  let btc_price = 45_000_u128;
+		  let initial_usdt = initial_btc * btc_price;
+		  let btc_value = btc_value as u128 * unit;
+		  let usdt_value = btc_value * btc_price;
+		  let pool_id = create_pool(
+			  BTC,
+			  USDT,
+			  initial_btc,
+			  initial_usdt,
+			  Permill::zero(),
+			  Permill::zero(),
+		  );
+		  prop_assert_ok!(Tokens::mint_into(USDT, &BOB, usdt_value));
+		  prop_assert_ok!(Pablo::sell(Origin::signed(BOB), pool_id, USDT, usdt_value, 0_u128, false));
+		  let bob_btc = Tokens::balance(BTC, &BOB);
+		  // mint extra BTC equal to slippage so that original amount of USDT can be buy back
+		  prop_assert_ok!(Tokens::mint_into(BTC, &BOB, btc_value - bob_btc));
+		  prop_assert_ok!(Pablo::buy(Origin::signed(BOB), pool_id, USDT, usdt_value, 0_u128, false));
+		  let bob_usdt = Tokens::balance(USDT, &BOB);
+		  let slippage = usdt_value -  bob_usdt;
+		  let slippage_percentage = slippage as f64 * 100.0_f64 / usdt_value as f64;
+		  prop_assert!(slippage_percentage < 1.0_f64);
+		  Ok(())
+	  })?;
 	}
 
 	#[test]
 	fn add_remove_liquidity_proptest(
 		btc_value in 1..u32::MAX,
 	) {
-	new_test_ext().execute_with(|| {
-		let unit = 1_000_000_000_000_u128;
-		let initial_btc = 1_000_000_000_000_u128 * unit;
-		let btc_price = 45_000_u128;
-		let initial_usdt = initial_btc * btc_price;
-		let btc_value = btc_value as u128 * unit;
-		let usdt_value = btc_value * btc_price;
-		let pool_id = create_pool(
-			BTC,
-			USDT,
-			initial_btc,
-			initial_usdt,
-			Permill::zero(),
-			Permill::zero(),
-		);
-		let pool = get_pool(pool_id);
-		prop_assert_ok!(Tokens::mint_into(USDT, &BOB, usdt_value));
-		prop_assert_ok!(Tokens::mint_into(BTC, &BOB, btc_value));
-		prop_assert_ok!(Pablo::add_liquidity(Origin::signed(BOB), pool_id, btc_value, usdt_value, 0, false));
-		let term1 = initial_usdt.integer_sqrt_checked().expect("integer_sqrt failed");
-		let term2 = initial_btc.integer_sqrt_checked().expect("integer_sqrt failed");
-		let expected_lp_tokens = safe_multiply_by_rational(term1, btc_value, term2).expect("multiply_by_rational failed");
-		let lp_token = Tokens::balance(pool.lp_token, &BOB);
-		prop_assert_ok!(default_acceptable_computation_error(expected_lp_tokens, lp_token));
-		prop_assert_ok!(Pablo::remove_liquidity(Origin::signed(BOB), pool_id, lp_token, 0, 0));
-		let btc_value_redeemed = Tokens::balance(BTC, &BOB);
-		let usdt_value_redeemed = Tokens::balance(USDT, &BOB);
-		prop_assert_ok!(default_acceptable_computation_error(btc_value_redeemed, btc_value));
-		prop_assert_ok!(default_acceptable_computation_error(usdt_value_redeemed, usdt_value));
-		Ok(())
-	})?;
+	  new_test_ext().execute_with(|| {
+		  let unit = 1_000_000_000_000_u128;
+		  let initial_btc = 1_000_000_000_000_u128 * unit;
+		  let btc_price = 45_000_u128;
+		  let initial_usdt = initial_btc * btc_price;
+		  let btc_value = btc_value as u128 * unit;
+		  let usdt_value = btc_value * btc_price;
+		  let pool_id = create_pool(
+			  BTC,
+			  USDT,
+			  initial_btc,
+			  initial_usdt,
+			  Permill::zero(),
+			  Permill::zero(),
+		  );
+		  let pool = get_pool(pool_id);
+		  prop_assert_ok!(Tokens::mint_into(USDT, &BOB, usdt_value));
+		  prop_assert_ok!(Tokens::mint_into(BTC, &BOB, btc_value));
+		  prop_assert_ok!(Pablo::add_liquidity(Origin::signed(BOB), pool_id, btc_value, usdt_value, 0, false));
+		  let term1 = initial_usdt.integer_sqrt_checked().expect("integer_sqrt failed");
+		  let term2 = initial_btc.integer_sqrt_checked().expect("integer_sqrt failed");
+		  let expected_lp_tokens = safe_multiply_by_rational(term1, btc_value, term2).expect("multiply_by_rational failed");
+		  let lp_token = Tokens::balance(pool.lp_token, &BOB);
+		  prop_assert_ok!(default_acceptable_computation_error(expected_lp_tokens, lp_token));
+		  prop_assert_ok!(Pablo::remove_liquidity(Origin::signed(BOB), pool_id, lp_token, 0, 0));
+		  let btc_value_redeemed = Tokens::balance(BTC, &BOB);
+		  let usdt_value_redeemed = Tokens::balance(USDT, &BOB);
+		  prop_assert_ok!(default_acceptable_computation_error(btc_value_redeemed, btc_value));
+		  prop_assert_ok!(default_acceptable_computation_error(usdt_value_redeemed, usdt_value));
+		  Ok(())
+	  })?;
 	}
 
 	#[test]


### PR DESCRIPTION
## Issue
[Clickup issue](https://app.clickup.com/t/2bbgg1k)

## Description
Allow users to configure constant product pool weights. Prior to this PR, constant product pool were hardcoded with 50/50 weights. This PR allow arbitrary weights for base/quote assets. With the following property:
$$\sum_{i=1}^n{w_i}=1$$

As we have $n=2$, the implementation is expecting $w_1$ with $w_1 != 1$ to be provided and compute the according $w_2=1-w_1$.

Note: just wanted to try mathjax

## Checklist

- [x] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [x] I have updated the `book/` to reflect changes made by this PR _(if applicable)_