### PR TITLE
CU-2ct0avn - Refactor staking

### DIFF
--- a/frame/composable-support/src/abstractions/block_fold.rs
+++ b/frame/composable-support/src/abstractions/block_fold.rs
@@ -95,12 +95,14 @@ where
 				let r = iterator.try_fold(
 					(0_u32, current_state),
 					|(processed, state), (key, value)| {
-						let next_state = f(state, key.clone(), value);
 						/* NOTE(hussein-aitlahcen):
-						   The above `iter_from` is expected a previous key, the iterator start AFTER the provided previous key.
-						   This mean we need to actually process the current item before returning his key as `previous_key`, otherwise it would be skipped by the next iteration.
-						   Do not refactor this by moving the above line inside the if.
-						*/
+						The above `iter_from` is expecting a `previous` key, the iterator start AFTER the provided previous key.
+						This mean we need to actually process the current item before returning his key as `previous_key`, otherwise it would be skipped by the next iteration.
+						Conclusion: do not refactor this by moving the below line inside the if.
+						 */
+						let next_state = f(state, key.clone(), value);
+						// NOTE(hussein-aitlahcen): related to previous comment, we need to subtract
+						// one as we always start by processing one element
 						if processed == number_of_elements.saturating_sub(1) {
 							Err((next_state, key))
 						} else {

--- a/frame/lending/Cargo.toml
+++ b/frame/lending/Cargo.toml
@@ -20,9 +20,11 @@ version = "3.0.0"
 
 [dependencies]
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
+frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", features = [
+  "try-runtime",
+], branch = "polkadot-v0.9.18" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
-frame-executive = { default-features = false, git = "https://github.com/paritytech/substrate", features = ["try-runtime"] , branch = "polkadot-v0.9.18" }
 pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.18" }
 pallet-timestamp = { default-features = false, git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.18" }
 sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/substrate", optional = true, branch = "polkadot-v0.9.18" }
@@ -42,10 +44,10 @@ xcm = { git = "https://github.com/paritytech/polkadot", default-features = false
 
 log = { version = "0.4.14", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }
+rand = { version = "0.7.2", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = [
   "derive",
 ] }
-rand = { version = "0.7.2", optional = true }
 
 [dev-dependencies]
 composable-tests-helpers = { path = "../composable-tests-helpers" }
@@ -62,9 +64,9 @@ pallet-dutch-auction = { path = "../dutch-auction" }
 pallet-liquidations = { path = "../liquidations" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.18" }
 proptest = "1.0"
+rand = { version = "0.7.2" }
 serde = { version = '1.0.136' }
 smallvec = "1.7.0"
-rand = { version = "0.7.2"}
 
 [features]
 default = ["std"]


### PR DESCRIPTION
## Issue
[Link to the clickup issue](https://app.clickup.com/t/20xxvyc)

## Description
- make lock optional
- make penalty optional
- allow protocols to `transfer_reward` in any state by buffer the rewards accordingly
- add the stake `asset` to `Staked` and `Unstaked` events
- refactor rewards by allowing positions to get rewarded with new tokens on the
  fly (we were defining which reward assets a nft could get at its creation)
- refactor the tests
- add more tests for `transfer_reward`
- add a full `usecase` test that execute a full `stake` + `transfer_reward` +
  `claim` + `unstake`

## Checklist

- [x] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [x] I have updated the `book/` to reflect changes made by this PR _(if applicable)_