### PR TITLE
Make Dex-Router permissioned.

### DIFF
--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -332,12 +332,11 @@ pub enum DexRoute<PoolId, MaxHops: Get<u32>> {
 	Direct(BoundedVec<PoolId, MaxHops>),
 }
 
-pub trait DexRouter<AccountId, AssetId, PoolId, Balance, MaxHops> {
+pub trait DexRouter<AssetId, PoolId, Balance, MaxHops> {
 	/// If route is `None` then delete existing entry for `asset_pair`
 	/// If route is `Some` and no entry exist for `asset_pair` then add new entry
 	/// else update existing entry.
 	fn update_route(
-		who: &AccountId,
 		asset_pair: CurrencyPair<AssetId>,
 		route: Option<BoundedVec<PoolId, MaxHops>>,
 	) -> Result<(), DispatchError>;

--- a/frame/dex-router/src/benchmarking.rs
+++ b/frame/dex-router/src/benchmarking.rs
@@ -193,8 +193,8 @@ benchmarks! {
 	// benchmarks inserting new route
 	update_route {
 		let (currency_pair, dex_route) = create_pools_route::<T>();
-		let owner : <T as frame_system::Config>::AccountId= whitelisted_caller();
-	} : _(RawOrigin::Signed(owner), currency_pair, Some(dex_route.clone().try_into().unwrap()))
+		// let owner : <T as frame_system::Config>::AccountId= whitelisted_caller();
+	} : _(RawOrigin::Root, currency_pair, Some(dex_route.clone().try_into().unwrap()))
 
 	exchange {
 		let unit = 1_000_000_000_000_u128;
@@ -204,7 +204,7 @@ benchmarks! {
 		let origin = RawOrigin::Signed(owner.clone());
 		let pica : <T as pallet_pablo::Config>::AssetId = 100_u128.into();
 		<T as pallet_pablo::Config>::Assets::mint_into(pica, &owner, pica_amount.into()).expect("Mint pica failed");
-		pallet_dex_router::Pallet::<T>::update_route(origin.clone().into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
+		pallet_dex_router::Pallet::<T>::update_route(RawOrigin::Root.into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
 		// exchange 1000 PICA via route
 	} : _(origin, currency_pair.swap(), (1000_u128 * unit).into(), 0_u128.into())
 
@@ -216,7 +216,7 @@ benchmarks! {
 		let origin = RawOrigin::Signed(owner.clone());
 		let usdc : <T as pallet_pablo::Config>::AssetId = 104_u128.into();
 		<T as pallet_pablo::Config>::Assets::mint_into(usdc, &owner, usdc_amount.into()).expect("Mint usdc failed");
-		pallet_dex_router::Pallet::<T>::update_route(origin.clone().into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
+		pallet_dex_router::Pallet::<T>::update_route(RawOrigin::Root.into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
 		// buy 100 PICA via route
 	} : _(origin, currency_pair, (100_u128 * unit).into(), 0_u128.into())
 
@@ -229,7 +229,7 @@ benchmarks! {
 		let origin = RawOrigin::Signed(owner.clone());
 		let usdc : <T as pallet_pablo::Config>::AssetId = 104_u128.into();
 		<T as pallet_pablo::Config>::Assets::mint_into(usdc, &owner, usdc_amount.into()).expect("Mint usdc failed");
-		pallet_dex_router::Pallet::<T>::update_route(origin.clone().into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
+		pallet_dex_router::Pallet::<T>::update_route(RawOrigin::Root.into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
 		// sell 1000 usdc via route
 	} : _(origin, currency_pair, (1000_u128 * unit).into(), 0_u128.into())
 
@@ -241,7 +241,7 @@ benchmarks! {
 		let usdc_amount = 1000 * unit;
 		let usdt_amount = 1000 * unit;
 		let origin = RawOrigin::Signed(owner.clone());
-		pallet_dex_router::Pallet::<T>::update_route(origin.clone().into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
+		pallet_dex_router::Pallet::<T>::update_route(RawOrigin::Root.into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
 	} : _(origin, currency_pair, usdc_amount.into(), usdt_amount.into(), 0_u128.into(), false)
 
 	remove_liquidity {
@@ -252,7 +252,7 @@ benchmarks! {
 		let usdc_amount = 1000 * unit;
 		let usdt_amount = 1000 * unit;
 		let origin = RawOrigin::Signed(owner.clone());
-		pallet_dex_router::Pallet::<T>::update_route(origin.clone().into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
+		pallet_dex_router::Pallet::<T>::update_route(RawOrigin::Root.into(), currency_pair, Some(dex_route.clone().try_into().unwrap())).expect("update route failed");
 		pallet_dex_router::Pallet::<T>::add_liquidity(origin.clone().into(), currency_pair, usdc_amount.into(), usdt_amount.into(), 0_u128.into(), false).expect("add_liquidity failed");
 		// remove 1 lp_token
 	} : _(origin, currency_pair, 1_u128.into(), 0_u128.into(), 0_u128.into())

--- a/frame/dex-router/src/mock.rs
+++ b/frame/dex-router/src/mock.rs
@@ -191,7 +191,7 @@ impl dex_router::Config for Test {
 	type Pablo = Pablo;
 	type PalletId = TestDexRouterPalletID;
 	type WeightInfo = ();
-	type UpdateRouteOrigin = EnsureSigned<Self::AccountId>;
+	type UpdateRouteOrigin = EnsureRoot<AccountId>;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -1023,7 +1023,7 @@ impl dex_router::Config for Runtime {
 	type PoolId = PoolId;
 	type Pablo = Pablo;
 	type PalletId = DexRouterPalletID;
-	type UpdateRouteOrigin = EnsureSigned<Self::AccountId>;
+	type UpdateRouteOrigin = EnsureRootOrHalfCouncil;
 	type WeightInfo = weights::dex_router::WeightInfo<Runtime>;
 }
 


### PR DESCRIPTION
## Issue
In integration test it is found that any user with signed extrinsic can update the route in dex-router. Which is not expected, instead we make dex-router update a permissioned operation. 




## Checklist

~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~
~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~