### PR TITLE
Instrumental pallet: update mock to polkadot v0.9.22

### DIFF
--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -85,6 +85,7 @@ parameter_type_with_key! {
 	};
 }
 
+type ReserveIdentifier = [u8; 8];
 impl orml_tokens::Config for MockRuntime {
 	type Event = Event;
 	type Balance = Balance;
@@ -94,6 +95,8 @@ impl orml_tokens::Config for MockRuntime {
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
 	type MaxLocks = ();
+	type ReserveIdentifier = ReserveIdentifier;
+	type MaxReserves = frame_support::traits::ConstU32<2>;
 	type DustRemovalWhitelist = Everything;
 }
 

--- a/frame/instrumental-strategy/src/mock/runtime.rs
+++ b/frame/instrumental-strategy/src/mock/runtime.rs
@@ -85,6 +85,7 @@ parameter_type_with_key! {
 	};
 }
 
+type ReserveIdentifier = [u8; 8];
 impl orml_tokens::Config for MockRuntime {
 	type Event = Event;
 	type Balance = Balance;
@@ -94,6 +95,8 @@ impl orml_tokens::Config for MockRuntime {
 	type ExistentialDeposits = ExistentialDeposits;
 	type OnDust = ();
 	type MaxLocks = ();
+	type ReserveIdentifier = ReserveIdentifier;
+	type MaxReserves = frame_support::traits::ConstU32<2>;
 	type DustRemovalWhitelist = Everything;
 }
 


### PR DESCRIPTION
## Description

I forget to update mock's runtime to polkadot v0.9.22 in #1064.