### PR TITLE
Add karel and hussein to codeowners of .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 # Any change inside this directory will require approval from senior maintainers
 
 # CI and deployment related files
-.github/ @haroldsphinx @seunlanlege
+.github/ @haroldsphinx @seunlanlege @kaiserkarel @hussein-aitlahcen
 docker/ @haroldsphinx @seunlanlege
 Makefile @haroldsphinx
 


### PR DESCRIPTION
## Description
Updates the .github permissions to allow maintainers to change, mainly so that we can update CODEOWNERS using `bors`.

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_