### PR TITLE
Removed serde derives from RemoteAccount

### DIFF
--- a/frame/crowdloan-rewards/src/models.rs
+++ b/frame/crowdloan-rewards/src/models.rs
@@ -17,7 +17,6 @@ pub enum Proof<AccountId> {
 }
 
 #[derive(Hash, Clone, PartialEq, Eq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-// #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum RemoteAccount<AccountId> {
 	RelayChain(AccountId),
 	Ethereum(EthereumAddress),

--- a/frame/crowdloan-rewards/src/models.rs
+++ b/frame/crowdloan-rewards/src/models.rs
@@ -17,7 +17,7 @@ pub enum Proof<AccountId> {
 }
 
 #[derive(Hash, Clone, PartialEq, Eq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
-#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+// #[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 pub enum RemoteAccount<AccountId> {
 	RelayChain(AccountId),
 	Ethereum(EthereumAddress),


### PR DESCRIPTION
## Issue
N/A
See [Slack conversation](https://composablefinance.slack.com/archives/C02MSA16DCP/p1654015168905859)

## Description
pallet does not support these derives when checked on its own with the following command:  

`cargo check -p pallet-crowdloan-rewards`

Due to cargo unionizing dependencies, this was not caught by CI.

## Checklist

- ~[ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~
- ~[ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~