### PR TITLE
Add ignore-build.js to be picked up by Vercel

### DIFF
--- a/frontend/ui-pablo/ignore-build.js
+++ b/frontend/ui-pablo/ignore-build.js
@@ -1,0 +1,63 @@
+const childProcess = require("child_process");
+const path = require("path");
+const ABORT = 0;
+const CONTINUE = 1;
+const BASE_PATH = "frontend";
+const PREFIX = `picasso-`;
+const PROTECTED_BRANCHES = ["main"];
+
+function abort(message) {
+    message && console.error(message);
+    process.exit(ABORT);
+}
+function resume() {
+    process.exit(CONTINUE);
+}
+
+function getCurrentGitBranch() {
+    return childProcess
+        .execSync("git rev-parse --abbrev-ref HEAD")
+        .toString()
+        .trim();
+}
+
+function getCurrentGitTag() {
+    return childProcess
+        .execSync("git describe --tags --exact-match")
+        .toString()
+        .trim();
+}
+
+const PROJECT = process.argv[2] || path.basename(path.resolve());
+
+function main() {
+    if (!PROJECT) abort(`No project specified.`);
+    const fileNameList = childProcess
+        .execSync("git diff --name-only HEAD~10")
+        .toString()
+        .trim()
+        .split("\n");
+    const hasProjectSpecificChanges = fileNameList.some((file) =>
+        file.startsWith(`${BASE_PATH}/${PROJECT}`)
+    );
+
+    !hasProjectSpecificChanges &&
+    abort(`No changes detected specific to ${BASE_PATH}/${PROJECT}`);
+    const currentBranch = getCurrentGitBranch();
+    try {
+        const currentTag = getCurrentGitTag();
+        if (PROTECTED_BRANCHES.includes(currentBranch)) {
+            if (!currentTag.startsWith(PREFIX))
+                abort(
+                    `Branch ${currentBranch} is protected, it requires a specific tag starting with ${PREFIX} to build`
+                );
+            resume();
+        } else {
+            abort();
+        }
+    } catch (e) {
+        abort();
+    }
+}
+
+main();

--- a/frontend/ui-picasso/ignore-build.js
+++ b/frontend/ui-picasso/ignore-build.js
@@ -1,0 +1,63 @@
+const childProcess = require("child_process");
+const path = require("path");
+const ABORT = 0;
+const CONTINUE = 1;
+const BASE_PATH = "frontend";
+const PREFIX = `picasso-`;
+const PROTECTED_BRANCHES = ["main"];
+
+function abort(message) {
+  message && console.error(message);
+  process.exit(ABORT);
+}
+function resume() {
+  process.exit(CONTINUE);
+}
+
+function getCurrentGitBranch() {
+  return childProcess
+    .execSync("git rev-parse --abbrev-ref HEAD")
+    .toString()
+    .trim();
+}
+
+function getCurrentGitTag() {
+  return childProcess
+    .execSync("git describe --tags --exact-match")
+    .toString()
+    .trim();
+}
+
+const PROJECT = process.argv[2] || path.basename(path.resolve());
+
+function main() {
+  if (!PROJECT) abort(`No project specified.`);
+  const fileNameList = childProcess
+    .execSync("git diff --name-only HEAD~10")
+    .toString()
+    .trim()
+    .split("\n");
+  const hasProjectSpecificChanges = fileNameList.some((file) =>
+    file.startsWith(`${BASE_PATH}/${PROJECT}`)
+  );
+
+  !hasProjectSpecificChanges &&
+    abort(`No changes detected specific to ${BASE_PATH}/${PROJECT}`);
+  const currentBranch = getCurrentGitBranch();
+  try {
+    const currentTag = getCurrentGitTag();
+    if (PROTECTED_BRANCHES.includes(currentBranch)) {
+      if (!currentTag.startsWith(PREFIX))
+        abort(
+          `Branch ${currentBranch} is protected, it requires a specific tag starting with ${PREFIX} to build`
+        );
+      resume();
+    } else {
+      abort();
+    }
+  } catch (e) {
+    abort();
+  }
+}
+
+main();


### PR DESCRIPTION
+ this is to detect if a production build should be triggered based on:
1- File changes in Project directory, and
2- Branch is main and a tag is preset.

## Description
*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_