### PR TITLE
Cu 2j8gc2a story 1 mvp of rebalance without get apy mike belous

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,6 +4544,8 @@ dependencies = [
 name = "instrumental-strategy-pablo"
 version = "0.1.0"
 dependencies = [
+ "composable-maths",
+ "composable-support",
  "composable-traits",
  "frame-benchmarking",
  "frame-support",
@@ -4554,6 +4556,7 @@ dependencies = [
  "pallet-balances",
  "pallet-currency-factory",
  "pallet-instrumental",
+ "pallet-pablo",
  "pallet-vault",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,7 +4544,6 @@ dependencies = [
 name = "instrumental-strategy-pablo"
 version = "0.1.0"
 dependencies = [
- "composable-maths",
  "composable-support",
  "composable-traits",
  "frame-benchmarking",
@@ -4556,7 +4555,6 @@ dependencies = [
  "pallet-balances",
  "pallet-currency-factory",
  "pallet-instrumental",
- "pallet-pablo",
  "pallet-vault",
  "parity-scale-codec",
  "scale-info",

--- a/frame/composable-traits/src/vault.rs
+++ b/frame/composable-traits/src/vault.rs
@@ -23,8 +23,8 @@ pub enum FundsAvailability<Balance> {
 	/// Example, the strategy was removed by the fund manager or governance, so all funds should
 	/// be returned.
 	MustLiquidate,
-	/// When there are no balance that can be withdrawn or deposit and don't need to be liquidated
-	Equilibrable,
+	/// When there are no balance that can be withdrawn or deposit and don't need to be liquidated.
+	None,
 }
 
 #[derive(Copy, Clone, Encode, Decode, Debug, PartialEq, MaxEncodedLen, TypeInfo)]

--- a/frame/composable-traits/src/vault.rs
+++ b/frame/composable-traits/src/vault.rs
@@ -23,6 +23,8 @@ pub enum FundsAvailability<Balance> {
 	/// Example, the strategy was removed by the fund manager or governance, so all funds should
 	/// be returned.
 	MustLiquidate,
+	/// When there are no balance that can be withdrawn or deposit and don't need to be liquidated
+	Equilibrable,
 }
 
 #[derive(Copy, Clone, Encode, Decode, Debug, PartialEq, MaxEncodedLen, TypeInfo)]

--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -25,6 +25,7 @@ codec = { default-features = false, package = "parity-scale-codec", version = "3
 scale-info = { version = "2.1.2", default-features = false, features = ["derive",] }
 log = { version = "0.4.14", default-features = false }
 serde = { version = '1', optional = true }
+pallet-pablo = { path = "../pablo" }
 
 [dev-dependencies]
 pallet-instrumental = { version = "0.1.0", path = "../instrumental", default-features = false }

--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -19,7 +19,6 @@ sp-io = { default-features = false, git = "https://github.com/paritytech/substra
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 
-composable-maths = { path = "../composable-maths", default-features = false }
 composable-support = { path = "../composable-support", default-features = false }
 composable-traits = { version = "0.0.1", path = "../composable-traits", default-features = false }
 
@@ -27,7 +26,6 @@ codec = { default-features = false, package = "parity-scale-codec", version = "3
 scale-info = { version = "2.1.2", default-features = false, features = ["derive",] }
 log = { version = "0.4.14", default-features = false }
 serde = { version = '1', optional = true }
-pallet-pablo = { path = "../pablo" }
 
 [dev-dependencies]
 pallet-instrumental = { version = "0.1.0", path = "../instrumental", default-features = false }

--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -19,6 +19,8 @@ sp-io = { default-features = false, git = "https://github.com/paritytech/substra
 sp-core = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 
+composable-maths = { path = "../composable-maths", default-features = false }
+composable-support = { path = "../composable-support", default-features = false }
 composable-traits = { version = "0.0.1", path = "../composable-traits", default-features = false }
 
 codec = { default-features = false, package = "parity-scale-codec", version = "3.0.0", features = ["derive",] }

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -24,9 +24,8 @@ pub mod pallet {
 		dispatch::{DispatchError, DispatchResult},
 		pallet_prelude::*,
 		storage::bounded_btree_set::BoundedBTreeSet,
+		traits::fungibles::{Inspect, Mutate, MutateHold, Transfer},
 		transactional, Blake2_128Concat, PalletId,
-		traits::{fungibles::{Inspect, Mutate, MutateHold, Transfer},
-		},
 	};
 	use sp_runtime::traits::{
 		AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedMul, CheckedSub, One, Zero,
@@ -304,7 +303,7 @@ pub mod pallet {
 						T::Balance::zero(),
 						balance_of_asset,
 					)?;
-				}
+				},
 				FundsAvailability::Equilibrable => {
 					();
 				},

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -14,7 +14,6 @@ pub mod pallet {
 	//                                   Imports and Dependencies
 	// -------------------------------------------------------------------------------------------
 	use codec::{Codec, FullCodec};
-	use composable_support::math::safe::SafeArithmetic;
 	use composable_traits::{
 		dex::Amm,
 		instrumental::InstrumentalProtocolStrategy,
@@ -28,7 +27,7 @@ pub mod pallet {
 		transactional, Blake2_128Concat, PalletId,
 	};
 	use sp_runtime::traits::{
-		AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedMul, CheckedSub, One, Zero,
+		AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedMul, CheckedSub, Zero,
 	};
 	use sp_std::fmt::Debug;
 
@@ -100,7 +99,8 @@ pub mod pallet {
 			VaultId = Self::VaultId,
 		>;
 
-		/// The [`Currency`](Config::Currency)
+		/// The [`Currency`](Config::Currency).
+		///
 		/// Currency is used for the assets managed by the vaults.
 		type Currency: Transfer<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ Mutate<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
@@ -122,10 +122,7 @@ pub mod pallet {
 			+ Eq
 			+ PartialEq
 			+ Ord
-			+ Copy
-			+ Zero
-			+ One
-			+ SafeArithmetic;
+			+ Copy;
 
 		/// The maximum number of vaults that can be associated with this strategy.
 		#[pallet::constant]

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -257,7 +257,7 @@ pub mod pallet {
 		fn do_rebalance(vault_id: &T::VaultId) -> DispatchResult {
 			let asset_id = T::Vault::asset_id(vault_id)?;
 			let account_id = T::Vault::account_id(vault_id);
-			let pool_id = Self::pools(asset_id).ok_or_else(|| Error::<T>::PoolNotFound)?;
+			let pool_id = Self::pools(asset_id).ok_or(Error::<T>::PoolNotFound)?;
 			let task = T::Vault::available_funds(vault_id, &Self::account_id())?;
 			match task {
 				FundsAvailability::Withdrawable(balance) => {

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -92,7 +92,7 @@ pub mod pallet {
 			+ Ord
 			+ TypeInfo
 			+ Into<u128>;
-
+		
 		type Vault: StrategicVault<
 			AssetId = Self::AssetId,
 			Balance = Self::Balance,
@@ -100,6 +100,7 @@ pub mod pallet {
 			VaultId = Self::VaultId,
 		>;
 
+		/// The [`Currency`](Config::Currency)
 		/// Currency is used for the assets managed by the vaults.
 		type Currency: Transfer<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ Mutate<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
@@ -112,7 +113,7 @@ pub mod pallet {
 			PoolId = Self::PoolId,
 		>;
 
-		// Type representing the unique ID of a pool.
+		/// Type representing the unique ID of a pool.
 		type PoolId: FullCodec
 			+ MaxEncodedLen
 			+ Default
@@ -302,7 +303,7 @@ pub mod pallet {
 						T::Balance::zero(),
 					)?;
 				},
-				FundsAvailability::Equilibrable => {},
+				FundsAvailability::None => {},
 			};
 			Ok(())
 		}

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -104,7 +104,7 @@ pub mod pallet {
 		type Currency: Transfer<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ Mutate<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ MutateHold<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>;
-
+	
 		type Pablo: Amm<
 			AssetId = Self::AssetId,
 			Balance = Self::Balance,
@@ -259,7 +259,7 @@ pub mod pallet {
 			let account_id = T::Vault::account_id(vault_id);
 			let pool_id = Self::pools(asset_id).ok_or_else(|| Error::<T>::PoolNotFound)?;
 			let task = T::Vault::available_funds(vault_id, &Self::account_id())?;
-			let action = match task {
+			match task {
 				FundsAvailability::Withdrawable(balance) => {
 					let vault_account = T::Vault::account_id(vault_id);
 					let lp_token_amount = T::Pablo::amount_of_lp_token_for_added_liquidity(
@@ -288,20 +288,19 @@ pub mod pallet {
 						pool_id,
 						lp_token_amount,
 						T::Balance::zero(),
-						balance,
+						T::Balance::zero(),
 					)?;
 				},
 				FundsAvailability::MustLiquidate => {
 					let vault_account = T::Vault::account_id(vault_id);
 					let lp_token_id = T::Pablo::lp_token(pool_id)?;
 					let balance_of_lp_token = T::Currency::balance(lp_token_id, &account_id);
-					let balance_of_asset = T::Currency::balance(asset_id, &account_id);
 					T::Pablo::remove_liquidity(
 						&vault_account,
 						pool_id,
 						balance_of_lp_token,
 						T::Balance::zero(),
-						balance_of_asset,
+						T::Balance::zero(),
 					)?;
 				},
 				FundsAvailability::Equilibrable => {
@@ -310,24 +309,6 @@ pub mod pallet {
 			};
 			Ok(())
 		}
-
-		// #[transactional]
-		// fn get_pool(asset_id: &T::AssetId) -> Result<T::PoolId, DispatchError> {
-		// 	let pica: T::AssetId;
-		// 	match InstrumentalPools::<T>::get(asset_id) {
-		// 		Some(pool_id) => Ok(pool_id),
-		// 		None => {
-		// 			Pools::<T>::iter_keys().for_each(|pool_id| {
-		// 				if T::Pablo::currency_pair(pool_id)?.quote == *asset_id &&
-		// 					T::Pablo::currency_pair(pool_id)?.base == pica {
-		// 					InstrumentalPools::<T>::insert(asset_id, pool_id);
-		// 					return Ok(pool_id)
-		// 				}
-		// 			});
-		// 			todo!(); // TODO(belousm): return other strategy pool
-		// 		},
-		// 	}
-		// }
 	}
 }
 

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -149,8 +149,9 @@ pub mod pallet {
 	pub type AssociatedVaults<T: Config> =
 		StorageValue<_, BoundedBTreeSet<T::VaultId, T::MaxAssociatedVaults>, ValueQuery>;
 
-	/// An asset whitelisted by Instrumental
-	/// The corresponding Pool to invest the whitelisted asset into
+	/// An asset whitelisted by Instrumental.
+	///
+	/// The corresponding Pool to invest the whitelisted asset into.
 	#[pallet::storage]
 	#[pallet::getter(fn pools)]
 	pub type Pools<T: Config> = StorageMap<_, Blake2_128Concat, T::AssetId, T::PoolId>;

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -92,7 +92,7 @@ pub mod pallet {
 			+ Ord
 			+ TypeInfo
 			+ Into<u128>;
-		
+
 		type Vault: StrategicVault<
 			AssetId = Self::AssetId,
 			Balance = Self::Balance,

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -13,12 +13,14 @@ pub mod pallet {
 	// -------------------------------------------------------------------------------------------
 	//                                   Imports and Dependencies
 	// -------------------------------------------------------------------------------------------
+	use pablo::Pools;
 	use codec::{Codec, FullCodec};
-	use composable_traits::{instrumental::InstrumentalProtocolStrategy, vault::StrategicVault};
+	use composable_traits::{instrumental::InstrumentalProtocolStrategy, 
+		vault::StrategicVault};
 	use frame_support::{
 		dispatch::DispatchResult, pallet_prelude::*, storage::bounded_btree_set::BoundedBTreeSet,
 		transactional, PalletId,
-	};
+	}; 
 	use sp_runtime::traits::{
 		AccountIdConversion, AtLeast32BitUnsigned, CheckedAdd, CheckedMul, CheckedSub, Zero,
 	};
@@ -103,6 +105,8 @@ pub mod pallet {
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 	}
+
+	type PICA: AssetId; // DELETE(belousm) just for testing MVP
 
 	// -------------------------------------------------------------------------------------------
 	//                                         Pallet Types
@@ -210,6 +214,20 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		#[transactional]
 		fn do_rebalance(_vault_id: &T::VaultId) -> DispatchResult {
+			let task = T::Vault::available_funds(vault_id, &Self::account_id())?;
+			// TODO(belousm): check, that Vault is associated
+			let action = match task {
+				FundsAvailability::Withdrawable(balance) => {
+					// Pools.iter()
+					//      .find(|&&pool| pool)
+					todo!();
+				},
+				FundsAvailability::Depositable(balance) => todo!(),
+				FundsAvailability::MustLiquidate => {
+					// TODO(belousm): should we transfer all assets to Vault from strategy?
+					todo!();
+				},
+			};
 			Ok(())
 		}
 	}

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -256,8 +256,7 @@ pub mod pallet {
 			let asset_id = T::Vault::asset_id(vault_id)?;
 			let account_id = T::Vault::account_id(vault_id);
 			let pool_id = Self::pools(asset_id).ok_or(Error::<T>::PoolNotFound)?;
-			let task = T::Vault::available_funds(vault_id, &Self::account_id())?;
-			match task {
+			match T::Vault::available_funds(vault_id, &Self::account_id())? {
 				FundsAvailability::Withdrawable(balance) => {
 					let vault_account = T::Vault::account_id(vault_id);
 					let lp_token_amount = T::Pablo::amount_of_lp_token_for_added_liquidity(
@@ -271,7 +270,7 @@ pub mod pallet {
 						T::Balance::zero(),
 						balance,
 						lp_token_amount,
-						bool::default(),
+						true,
 					)?;
 				},
 				FundsAvailability::Depositable(balance) => {

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -228,10 +228,11 @@ pub mod pallet {
 		#[transactional]
 		fn do_rebalance(_vault_id: &T::VaultId) -> DispatchResult {
 			let task = T::Vault::available_funds(vault_id, &Self::account_id())?;
+
 			let action = match task {
 				FundsAvailability::Withdrawable(balance) => {
 					let vault_account = T::Vault::account_id(vault_id);
-					Pools::iter_values().for_each(|pool_id| {
+					Pools::iter_keys().for_each(|pool_id| {
 						if T::Pablo::currency_pair(pool_id).unwrap() == PICA  && 
 						T::Vault::asset_id.unwrap() == PICA {
 							let lp_token_amount = amount_of_lp_token_for_added_liquidity(pool_id, balance, T::Balance.set_zero());

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -104,7 +104,7 @@ pub mod pallet {
 		type Currency: Transfer<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ Mutate<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>
 			+ MutateHold<Self::AccountId, Balance = Self::Balance, AssetId = Self::AssetId>;
-	
+
 		type Pablo: Amm<
 			AssetId = Self::AssetId,
 			Balance = Self::Balance,
@@ -151,9 +151,8 @@ pub mod pallet {
 	pub type AssociatedVaults<T: Config> =
 		StorageValue<_, BoundedBTreeSet<T::VaultId, T::MaxAssociatedVaults>, ValueQuery>;
 
-	// TODO(belousm): where pools will be added?
-	// An asset whitelisted by Instrumental
-	// The corresponding Pool to invest the whitelisted asset into
+	/// An asset whitelisted by Instrumental
+	/// The corresponding Pool to invest the whitelisted asset into
 	#[pallet::storage]
 	#[pallet::getter(fn pools)]
 	pub type Pools<T: Config> = StorageMap<_, Blake2_128Concat, T::AssetId, T::PoolId>;

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -303,9 +303,7 @@ pub mod pallet {
 						T::Balance::zero(),
 					)?;
 				},
-				FundsAvailability::Equilibrable => {
-					();
-				},
+				FundsAvailability::Equilibrable => {},
 			};
 			Ok(())
 		}

--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -124,7 +124,7 @@ parameter_types! {
 	pub const MinimumDeposit: Balance = 0;
 	pub const MinimumWithdrawal: Balance = 0;
 	pub const VaultPalletId: PalletId = VAULT_PALLET_ID;
-	  pub const TombstoneDuration: u64 = 42;
+	pub const TombstoneDuration: u64 = 42;
 }
 
 impl pallet_vault::Config for MockRuntime {

--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -14,7 +14,6 @@ pub type Amount = i128;
 pub type BlockNumber = u64;
 pub type Balance = u128;
 pub type CurrencyId = u128;
-pub type PoolId = u128;
 
 pub const VAULT_PALLET_ID: PalletId = PalletId(*b"cubic___");
 pub type VaultId = u64;

--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -189,8 +189,6 @@ frame_support::construct_runtime!(
 
 		Vault: pallet_vault::{Pallet, Call, Storage, Event<T>},
 		PabloStrategy: pallet_pablo_strategy::{Pallet, Call, Storage, Event<T>},
-
-		Pablo: pallet_pablo::{Pallet, Call, Storage, Event<T>},
 	}
 );
 

--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -14,6 +14,7 @@ pub type Amount = i128;
 pub type BlockNumber = u64;
 pub type Balance = u128;
 pub type CurrencyId = u128;
+pub type PoolId = u128;
 
 pub const VAULT_PALLET_ID: PalletId = PalletId(*b"cubic___");
 pub type VaultId = u64;
@@ -188,6 +189,8 @@ frame_support::construct_runtime!(
 
 		Vault: pallet_vault::{Pallet, Call, Storage, Event<T>},
 		PabloStrategy: pallet_pablo_strategy::{Pallet, Call, Storage, Event<T>},
+
+		Pablo: pallet_pablo::{Pallet, Call, Storage, Event<T>},
 	}
 );
 

--- a/frame/instrumental/src/lib.rs
+++ b/frame/instrumental/src/lib.rs
@@ -559,6 +559,7 @@ pub mod pallet {
 					<T::Vault as StrategicVault>::withdraw(&vault_id, issuer, amount),
 				FundsAvailability::MustLiquidate =>
 					<T::Vault as StrategicVault>::withdraw(&vault_id, issuer, amount),
+				FundsAvailability::None => {},
 				_ => Err(Error::<T>::NotEnoughLiquidity.into()),
 			}
 			.map_err(|_| Error::<T>::NotEnoughLiquidity)?;

--- a/frame/instrumental/src/lib.rs
+++ b/frame/instrumental/src/lib.rs
@@ -559,7 +559,6 @@ pub mod pallet {
 					<T::Vault as StrategicVault>::withdraw(&vault_id, issuer, amount),
 				FundsAvailability::MustLiquidate =>
 					<T::Vault as StrategicVault>::withdraw(&vault_id, issuer, amount),
-				FundsAvailability::None => {},
 				_ => Err(Error::<T>::NotEnoughLiquidity.into()),
 			}
 			.map_err(|_| Error::<T>::NotEnoughLiquidity)?;

--- a/frame/lending/src/lib.rs
+++ b/frame/lending/src/lib.rs
@@ -932,6 +932,7 @@ pub mod pallet {
 								Self::handle_must_liquidate(&config, &market_account)?;
 								call_counters.handle_must_liquidate += 1;
 							},
+							FundsAvailability::None => {},
 						}
 
 						call_counters.available_funds += 1;

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -103,8 +103,7 @@ pub mod pallet {
 		},
 		ArithmeticError, DispatchError, FixedPointNumber, Perquintill,
 	};
-	use sp_std::fmt::Debug;
-	use std::cmp::Ordering;
+	use sp_std::{cmp::Ordering, fmt::Debug};
 
 	#[allow(missing_docs)]
 	pub type AssetIdOf<T> =
@@ -972,8 +971,9 @@ pub mod pallet {
 							.mul_floor(<T::Convert as Convert<T::Balance, u128>>::convert(aum)),
 					);
 					match balance.cmp(&max_allowed) {
-						Ordering::Less => Ok(FundsAvailability::Depositable(balance - max_allowed)),
 						Ordering::Greater =>
+							Ok(FundsAvailability::Depositable(balance - max_allowed)),
+						Ordering::Less =>
 							Ok(FundsAvailability::Withdrawable(max_allowed - balance)),
 						Ordering::Equal => Ok(FundsAvailability::None),
 					}

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -976,7 +976,7 @@ pub mod pallet {
 					} else if balance < max_allowed {
 						Ok(FundsAvailability::Withdrawable(max_allowed - balance))
 					} else {
-						Ok(FundsAvailability::Equilibrable)
+						Ok(FundsAvailability::None)
 					}
 				},
 				(_, _) => Ok(FundsAvailability::MustLiquidate),

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -971,10 +971,12 @@ pub mod pallet {
 						allocation
 							.mul_floor(<T::Convert as Convert<T::Balance, u128>>::convert(aum)),
 					);
-					if balance >= max_allowed {
+					if balance > max_allowed {
 						Ok(FundsAvailability::Depositable(balance - max_allowed))
-					} else {
+					} else if balance < max_allowed {
 						Ok(FundsAvailability::Withdrawable(max_allowed - balance))
+					} else {
+						Ok(FundsAvailability::Equilibrable)
 					}
 				},
 				(_, _) => Ok(FundsAvailability::MustLiquidate),

--- a/frame/vault/src/mocks/strategy.rs
+++ b/frame/vault/src/mocks/strategy.rs
@@ -98,9 +98,7 @@ pub mod pallet {
 			let asset_id = T::Vault::asset_id(&vault)?;
 			let task = T::Vault::available_funds(&vault, &Self::account_id())?;
 			let action = match task {
-				FundsAvailability::None => {
-					T::Currency::balance(asset_id, &Self::account_id())
-				},
+				FundsAvailability::None => T::Currency::balance(asset_id, &Self::account_id()),
 				FundsAvailability::MustLiquidate => {
 					let balance = T::Currency::balance(asset_id, &Self::account_id());
 					T::Currency::transfer(

--- a/frame/vault/src/mocks/strategy.rs
+++ b/frame/vault/src/mocks/strategy.rs
@@ -98,7 +98,7 @@ pub mod pallet {
 			let asset_id = T::Vault::asset_id(&vault)?;
 			let task = T::Vault::available_funds(&vault, &Self::account_id())?;
 			let action = match task {
-				FundsAvailability::Equilibrable => {
+				FundsAvailability::None => {
 					let balance = T::Currency::balance(asset_id, &Self::account_id());
 					balance
 				},

--- a/frame/vault/src/mocks/strategy.rs
+++ b/frame/vault/src/mocks/strategy.rs
@@ -98,6 +98,10 @@ pub mod pallet {
 			let asset_id = T::Vault::asset_id(&vault)?;
 			let task = T::Vault::available_funds(&vault, &Self::account_id())?;
 			let action = match task {
+				FundsAvailability::Equilibrable => {
+					let balance = T::Currency::balance(asset_id, &Self::account_id());
+					balance
+				},
 				FundsAvailability::MustLiquidate => {
 					let balance = T::Currency::balance(asset_id, &Self::account_id());
 					T::Currency::transfer(

--- a/frame/vault/src/mocks/strategy.rs
+++ b/frame/vault/src/mocks/strategy.rs
@@ -99,8 +99,7 @@ pub mod pallet {
 			let task = T::Vault::available_funds(&vault, &Self::account_id())?;
 			let action = match task {
 				FundsAvailability::None => {
-					let balance = T::Currency::balance(asset_id, &Self::account_id());
-					balance
+					T::Currency::balance(asset_id, &Self::account_id())
 				},
 				FundsAvailability::MustLiquidate => {
 					let balance = T::Currency::balance(asset_id, &Self::account_id());


### PR DESCRIPTION
## Issue
[*Issue*](https://app.clickup.com/t/2j8gc2a)

## Description
Creating an MVP of the rebalancing function without defining a pool to which to add / remove liquidity. So far, this cannot be done, since the function of getting and saving APY (`get_apy`) for each pool should be implemented in Pablo.

## Checklist

- [x] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [x] I have updated the `book/` to reflect changes made by this PR _(if applicable)_