### PR TITLE
Add Design QA

### DIFF
--- a/frontend/ui-pablo/app/components/Atoms/AssetSelectionModal.tsx
+++ b/frontend/ui-pablo/app/components/Atoms/AssetSelectionModal.tsx
@@ -46,7 +46,7 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
   const theme = useTheme();
   const [keyword, setKeyword] = React.useState<string>("");
 
-  const handleKewordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleKeywordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(event.target.value);
   };
 
@@ -55,7 +55,7 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
       (option) => {
         let re = new RegExp(keyword, 'i');
         return selected === option.value
-                || [option?.shortLabel, option.label].some(x => x && re.test(x))
+          || [option?.shortLabel, option.label].some(x => x && re.test(x))
       }
     );
   };
@@ -67,6 +67,12 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
 
   return (
     <Popover
+      sx={{
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+      }}
+      anchorReference="none"
       anchorEl={anchorEl}
       onClose={onClose}
       BackdropProps={{
@@ -80,7 +86,7 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
             transform: 'translate(-50%, -50%) !important',
             top: '50% !important',
             left: '50% !important',
-          }: {}),
+          } : {}),
           padding: 0,
           backdropFilter: 'blur(48px)',
           borderColor: alpha(theme.palette.common.white, theme.custom.opacity.light),
@@ -105,12 +111,12 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
             width: '100%',
           },
           borderRadius: 1,
-          paddingTop: theme.spacing(anchorEl ? 2: 3)
+          paddingTop: theme.spacing(anchorEl ? 2 : 3)
         }}
       >
         {(!anchorEl || searchable) && (
           <Box
-            paddingX={theme.spacing(anchorEl ? 2: 4)}
+            paddingX={theme.spacing(anchorEl ? 2 : 4)}
           >
             {!anchorEl && (
               <Box
@@ -135,7 +141,7 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
                   fullWidth
                   value={keyword}
                   setValue={setKeyword}
-                  onChange={handleKewordChange}
+                  onChange={handleKeywordChange}
                   onKeyDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                 />
@@ -145,8 +151,8 @@ export const AssetSelectionModal: React.FC<AssetSelectionModalProps> = ({
         )}
 
         <Box
-          mt={anchorEl ? 2: 3}
-          height={anchorEl ? 270 : 384}
+          mt={anchorEl ? 2 : 3}
+          height="auto"
           overflow="auto"
         >
           <MenuList>

--- a/frontend/ui-pablo/app/components/Atoms/Select.tsx
+++ b/frontend/ui-pablo/app/components/Atoms/Select.tsx
@@ -67,7 +67,7 @@ export const Select: React.FC<SelectProps> = ({
   const [open, setOpen] = React.useState<boolean>(false);
 
   useEffect(() => {
-    if (initialAsset) setValue(initialAsset);
+    if (initialAsset !== undefined) setValue(initialAsset);
   }, []);
 
   const handleKeywordChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/ui-pablo/app/components/Atoms/Select.tsx
+++ b/frontend/ui-pablo/app/components/Atoms/Select.tsx
@@ -20,7 +20,6 @@ import { Option } from "../types";
 
 export type SelectProps = {
   value?: any;
-  setValue?: () => void;
   options?: Option[];
   noBorder?: boolean;
   borderRight?: boolean;
@@ -68,7 +67,7 @@ export const Select: React.FC<SelectProps> = ({
   const [open, setOpen] = React.useState<boolean>(false);
 
   useEffect(() => {
-    if (initialAsset !== undefined) setValue(initialAsset);
+    if (initialAsset) setValue?.(initialAsset);
   }, []);
 
   const handleKeywordChange = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/ui-pablo/app/components/Atoms/Select.tsx
+++ b/frontend/ui-pablo/app/components/Atoms/Select.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import {
   alpha,
   ListSubheader,
@@ -35,6 +35,7 @@ export type SelectProps = {
   forceHiddenLabel?: boolean;
   anchorEl?: HTMLElement | null;
   renderShortLabel?: boolean;
+  initialAsset?: string;
 } & InputProps;
 
 export const Select: React.FC<SelectProps> = ({
@@ -43,7 +44,7 @@ export const Select: React.FC<SelectProps> = ({
   options,
   noBorder,
   borderRight,
-  noBackground=false,
+  noBackground = false,
   borderLeft,
   minWidth,
   mobileWidth,
@@ -56,6 +57,7 @@ export const Select: React.FC<SelectProps> = ({
   forceHiddenLabel,
   anchorEl = null,
   renderShortLabel = false,
+  initialAsset,
   SelectProps,
   ...inputProps
 }) => {
@@ -64,7 +66,11 @@ export const Select: React.FC<SelectProps> = ({
   const [keyword, setKeyword] = React.useState<string>("");
   const [open, setOpen] = React.useState<boolean>(false);
 
-  const handleKewordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  useEffect(() => {
+    if (initialAsset) setValue(initialAsset);
+  }, []);
+
+  const handleKeywordChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setKeyword(event.target.value);
   };
 
@@ -78,7 +84,7 @@ export const Select: React.FC<SelectProps> = ({
       (option) => {
         let re = new RegExp(keyword, 'i');
         return value === option.value
-                || [option?.shortLabel, option.label].some(x => x && re.test(x))
+          || [option?.shortLabel, option.label].some(x => x && re.test(x))
       }
     );
   };
@@ -137,7 +143,7 @@ export const Select: React.FC<SelectProps> = ({
                     forceHiddenLabel
                       ? undefined
                       : (renderShortLabel && option.shortLabel)
-                        || option.label || option.value
+                      || option.label || option.value
                   }
                   icon={option.icon}
                   centeredLabel={centeredLabel}
@@ -155,15 +161,15 @@ export const Select: React.FC<SelectProps> = ({
         sx={{
           borderRight: borderRight
             ? `1px solid ${alpha(
-                theme.palette.common.white,
-                theme.custom.opacity.main
-              )}`
+              theme.palette.common.white,
+              theme.custom.opacity.main
+            )}`
             : undefined,
           borderLeft: borderLeft
             ? `1px solid ${alpha(
-                theme.palette.common.white,
-                theme.custom.opacity.main
-              )}`
+              theme.palette.common.white,
+              theme.custom.opacity.main
+            )}`
             : undefined,
           "& .MuiOutlinedInput-root.MuiInputBase-root": {
             background: noBackground ? 'none' : undefined,
@@ -215,7 +221,7 @@ export const Select: React.FC<SelectProps> = ({
               fullWidth
               value={keyword}
               setValue={setKeyword}
-              onChange={handleKewordChange}
+              onChange={handleKeywordChange}
               onKeyDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
             />

--- a/frontend/ui-pablo/app/components/Atoms/Select.tsx
+++ b/frontend/ui-pablo/app/components/Atoms/Select.tsx
@@ -20,6 +20,7 @@ import { Option } from "../types";
 
 export type SelectProps = {
   value?: any;
+  setValue?: () => void;
   options?: Option[];
   noBorder?: boolean;
   borderRight?: boolean;

--- a/frontend/ui-pablo/app/components/Molecules/AccountIndicator.tsx
+++ b/frontend/ui-pablo/app/components/Molecules/AccountIndicator.tsx
@@ -37,7 +37,6 @@ export const AccountIndicator: React.FC<AccountIndicatorProps> = ({
         gridTemplateColumns: "24px auto 24px",
         gap: theme.spacing(2),
         flexShrink: 0,
-        minWidth: theme.spacing(31.25),
         background: alpha(theme.palette.primary.main, theme.custom.opacity.light),
         cursor: 'pointer',
         "&:hover": {
@@ -46,7 +45,7 @@ export const AccountIndicator: React.FC<AccountIndicatorProps> = ({
       }}
     >
       <Box sx={{ width: theme.spacing(3), height: theme.spacing(3) }}>
-        <Image src={icon} width="24" height="24" />
+        <Image src={icon} width="24" height="24" alt="account indicator" />
       </Box>
       {isMobile ? (
         <Circle fontSize="large" sx={{ fontSize: 28 }} />

--- a/frontend/ui-pablo/app/components/Organisms/TransactionSettings/index.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/TransactionSettings/index.tsx
@@ -135,6 +135,7 @@ export const TransactionSettings: React.FC<TransactionSettingsProps> = ({
                       label={`${value.toFixed(1)} %`}
                       sx={{
                         color: toleranceSelected(value) ? theme.palette.primary.main : undefined,
+                        "&:hover": { color: theme.palette.common.white },
                       }}
                     />
                   ))}

--- a/frontend/ui-pablo/app/components/Organisms/Wallet/PolkadotConnect.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/Wallet/PolkadotConnect.tsx
@@ -49,7 +49,7 @@ const Status = () => {
               value: asset.assetId,
               label:
               balance.lte(1000)
-                  ? balance.toFixed(2).toString()
+                  ? balance.toFixed(2)
                   : (balance.div(1000)).toFixed(1) + "K",
               icon: asset.icon,
             }

--- a/frontend/ui-pablo/app/components/Organisms/Wallet/PolkadotConnect.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/Wallet/PolkadotConnect.tsx
@@ -49,7 +49,7 @@ const Status = () => {
               value: asset.assetId,
               label:
               balance.lte(1000)
-                  ? balance.toString()
+                  ? balance.toFixed(2).toString()
                   : (balance.div(1000)).toFixed(1) + "K",
               icon: asset.icon,
             }

--- a/frontend/ui-pablo/app/components/Organisms/pool/CreatePool/steps/ChooseTokensStep.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/pool/CreatePool/steps/ChooseTokensStep.tsx
@@ -59,6 +59,7 @@ const gridItem4ColumnProps = {
 const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
   const theme = useTheme();
   const dispatch = useDispatch();
+  const placeholder = "Select a token";
 
   const {
     createPool
@@ -94,6 +95,18 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
       }));
   }, [baseAsset]);
 
+  const getAssetOptions = (assetList: any[]) => ([
+    ...[{
+      value: "none",
+      label: placeholder,
+      shortLabel: undefined,
+      icon: undefined,
+      disabled: true,
+      hidden: true
+    }],
+    ...assetList.map(asset => asset),
+  ]);
+
   const isUnverifiedPoolWarningOpen = useAppSelector(
     (state) => state.ui.isConfirmingModalOpen
   );
@@ -106,9 +119,9 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
 
   const _setSelectable =
     (item: "baseAsset" | "quoteAsset" | "ammId" | "swapFee") =>
-    (v: AssetId | LiquidityPoolType | BigNumber) => {
-      setSelectable({ [item]: v });
-  };
+      (v: AssetId | LiquidityPoolType | BigNumber) => {
+        setSelectable({ [item]: v });
+      };
 
   const [initialFunds] = useState<BigNumber>(new BigNumber(20000));
   const [currentFunds] = useState<BigNumber>(new BigNumber(340));
@@ -147,13 +160,21 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
     ammId === "balancer"
       ? gridItem8ColumnProps
       : {
-          item: true,
-          xs: 12,
-          pl: 0,
-        };
+        item: true,
+        xs: 12,
+        pl: 0,
+      };
 
   const onSettingHandler = () => {
     dispatch(openTransactionSettingsModal());
+  };
+
+  const SelectProps = {
+    sx: {
+      "& .MuiSelect-select": {
+        pl: 3,
+      },
+    },
   };
 
   return (
@@ -170,13 +191,7 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
           setValue={_setSelectable("ammId")}
           options={getAMMOptions("Select")}
           LabelProps={{ label: "AMM" }}
-          SelectProps={{
-            sx: {
-              "& .MuiSelect-select": {
-                pl: 3,
-              },
-            },
-          }}
+          SelectProps={SelectProps}
         />
       </Box>
 
@@ -186,8 +201,9 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
             <Select
               value={baseAsset}
               setValue={_setSelectable("baseAsset")}
-              options={baseAssetList}
+              options={getAssetOptions(baseAssetList)}
               {...selectProps("Token 1", !validAMM)}
+              SelectProps={SelectProps}
             />
           </Grid>
           {ammId === "balancer" ? (
@@ -209,8 +225,9 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
             <Select
               value={quoteAsset}
               setValue={_setSelectable("quoteAsset")}
-              options={quoteAssetList}
+              options={getAssetOptions(quoteAssetList)}
               {...selectProps("Token 2", !validAMM)}
+              SelectProps={SelectProps}
             />
           </Grid>
           {ammId === "balancer" ? (
@@ -232,7 +249,7 @@ const ChooseTokensStep: React.FC<BoxProps> = ({ ...boxProps }) => {
         <NotificationBox
           mt={4}
           type="warning"
-          icon={<InfoOutlinedIcon color="primary" fontSize="small" />}
+          icon={<InfoOutlinedIcon color="warning" fontSize="small" />}
           mainText={`It’s recommended to provide new pools with at least $${initialFunds.toFormat()} in initial funds`}
           subText={`Based on your wallet balances for these tokens, the maximum amount you can fund this pool with is ~$${currentFunds.toFormat(
             2

--- a/frontend/ui-pablo/app/components/Organisms/pool/CreatePool/steps/SetFeesStep.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/pool/CreatePool/steps/SetFeesStep.tsx
@@ -65,7 +65,7 @@ const SetFeesStep: React.FC<SetFeesStepProps> = ({
   };
 
   const setSwapFee = (fee: BigNumber) => {
-    createPool.setSelectable({ "swapFee": fee.toString() })
+    createPool.setSelectable({ swapFee: fee.toString() })
   }
 
   const onBackHandler = () => {
@@ -119,7 +119,6 @@ const SetFeesStep: React.FC<SetFeesStepProps> = ({
             value={initialSwapFee}
             setValue={setSwapFee}
             referenceText="%"
-            disabled
           />
         </Grid>
       </Grid>

--- a/frontend/ui-pablo/app/components/Organisms/staking/UnstakeForm/CheckableXPabloItemBox.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/staking/UnstakeForm/CheckableXPabloItemBox.tsx
@@ -7,6 +7,8 @@ import {
   useTheme,
   BoxProps,
 } from "@mui/material";
+import { styled } from '@mui/material/styles';
+
 import { BaseAsset } from "@/components/Atoms";
 import { TOKENS } from "@/defi/Tokens";
 import { XPablo } from "@/defi/types";
@@ -36,10 +38,18 @@ const containerProps = (theme: Theme, selected?: boolean) => ({
 } as const);
 
 export type CheckableXPabloItemBoxProps = {
- xPablo: XPablo,
- selectedXPabloId?: number,
- setSelectedXPabloId?: (id?: number) => void,
+  xPablo: XPablo,
+  selectedXPabloId?: number,
+  setSelectedXPabloId?: (id?: number) => void,
 } & BoxProps;
+
+const CheckBoxIcon = styled('span')(() => ({
+  borderRadius: 3,
+  border: "1px solid #9f9da5",
+  width: 18,
+  height: 18,
+  margin: 3,
+}));
 
 export const CheckableXPabloItemBox: React.FC<CheckableXPabloItemBoxProps> = ({
   xPablo,
@@ -59,6 +69,7 @@ export const CheckableXPabloItemBox: React.FC<CheckableXPabloItemBoxProps> = ({
     <Box {...containerProps(theme, selected)} {...boxProps}>
       <Box {...defaultFlexBoxProps}>
         <Checkbox
+          icon={<CheckBoxIcon />}
           value={xPablo.id}
           checked={selected}
           onChange={handleChange}

--- a/frontend/ui-pablo/app/components/Organisms/swap/SwapForm.tsx
+++ b/frontend/ui-pablo/app/components/Organisms/swap/SwapForm.tsx
@@ -328,6 +328,7 @@ const SwapForm: React.FC<BoxProps> = ({ ...boxProps }) => {
             borderLeft: false,
             minWidth: isMobile ? undefined : 150,
             searchable: true,
+            initialAsset: "pica",
           }}
           LabelProps={{
             label: "From",
@@ -414,6 +415,7 @@ const SwapForm: React.FC<BoxProps> = ({ ...boxProps }) => {
             borderLeft: false,
             minWidth: isMobile ? undefined : 150,
             searchable: true,
+            initialAsset: "ksm",
           }}
           LabelProps={{
             label: "To",
@@ -444,13 +446,13 @@ const SwapForm: React.FC<BoxProps> = ({ ...boxProps }) => {
         {validTokens && (
           <>
             <Typography variant="body2">
-              1 {swaps.ui.quoteAssetSelected} = {spotPriceBn.toFixed()}{" "}
-              {swaps.ui.baseAssetSelected}
+              1 {swaps.ui.quoteAssetSelected.toUpperCase()} = {spotPriceBn.toFixed()}{" "}
+              {swaps.ui.baseAssetSelected.toUpperCase()}
             </Typography>
             <Tooltip
               title={`1 ${
-                swaps.ui.quoteAssetSelected
-              } = ${spotPriceBn.toFixed()} ${swaps.ui.baseAssetSelected}`}
+                swaps.ui.quoteAssetSelected.toUpperCase()
+              } = ${spotPriceBn.toFixed()} ${swaps.ui.baseAssetSelected.toUpperCase()}`}
               placement="top"
             >
               <InfoOutlined sx={{ color: theme.palette.primary.main }} />

--- a/frontend/ui-pablo/app/pages/auctions/index.tsx
+++ b/frontend/ui-pablo/app/pages/auctions/index.tsx
@@ -12,6 +12,7 @@ import {
 import Default from "@/components/Templates/Default";
 import { PageTitle } from "@/components";
 import { AllAuctionsTable } from "@/components/Organisms/AllAuctionsTable";
+import { ConnectWalletFeaturedBox } from "@/components/Organisms/ConnectWalletFeaturedBox";
 import { useEffect, useState } from "react";
 import { useDotSamaContext, useParachainApi } from "substrate-react";
 import { fetchSpotPrice } from "@/updaters/swaps/utils";
@@ -26,6 +27,7 @@ const Auctions: NextPage = () => {
   const theme = useTheme();
   const [enabledCreate] = useState<boolean>(false);
   const { extensionStatus } = useDotSamaContext();
+  const connected = extensionStatus === "connected";
   const { parachainApi } = useParachainApi("picasso");
   const {
     pools: {
@@ -69,65 +71,67 @@ const Auctions: NextPage = () => {
               subtitle="Liquidity Bootstrapping Pools for Pablo"
             />
           </Box>
-          <Grid container mt={4}>
-            <Grid item {...standardPageSize}>
-              <Box
-                padding={4}
-                sx={{
-                  background: theme.palette.gradient.secondary,
-                  borderRadius: 1,
-                }}
-                border={`1px solid ${alpha(
-                  theme.palette.common.white,
-                  theme.custom.opacity.light
-                )}`}
-              >
+          {!connected ? <ConnectWalletFeaturedBox /> : (
+            <Grid container mt={4}>
+              <Grid item {...standardPageSize}>
                 <Box
-                  display="flex"
-                  mb={4}
-                  justifyContent="space-between"
-                  alignItems="center"
+                  padding={4}
+                  sx={{
+                    background: theme.palette.gradient.secondary,
+                    borderRadius: 1,
+                  }}
+                  border={`1px solid ${alpha(
+                    theme.palette.common.white,
+                    theme.custom.opacity.light
+                  )}`}
                 >
-                  <Typography variant="h6">All liquidity</Typography>
-                  <Box>
-                    <Tooltip
-                      title={
-                        extensionStatus !== "connected" ? "Comming soon" : ""
-                      }
-                      arrow
-                    >
-                      {enabledCreate ? (
-                        <Button
-                          onClick={() => {}}
-                          variant="contained"
-                          size="small"
-                          disabled
-                        >
-                          Create auction
-                        </Button>
-                      ) : (
-                        <Box
-                          sx={{
-                            padding: theme.spacing(1.5, 3),
-                            background: alpha(
-                              theme.palette.primary.main,
-                              theme.custom.opacity.main
-                            ),
-                            borderRadius: 9999,
-                          }}
-                        >
-                          <Typography variant="button" color="text.secondary">
+                  <Box
+                    display="flex"
+                    mb={4}
+                    justifyContent="space-between"
+                    alignItems="center"
+                  >
+                    <Typography variant="h6">All liquidity</Typography>
+                    <Box>
+                      <Tooltip
+                        title={
+                          extensionStatus !== "connected" ? "Comming soon" : ""
+                        }
+                        arrow
+                      >
+                        {enabledCreate ? (
+                          <Button
+                            onClick={() => { }}
+                            variant="contained"
+                            size="small"
+                            disabled
+                          >
                             Create auction
-                          </Typography>
-                        </Box>
-                      )}
-                    </Tooltip>
+                          </Button>
+                        ) : (
+                          <Box
+                            sx={{
+                              padding: theme.spacing(1.5, 3),
+                              background: alpha(
+                                theme.palette.primary.main,
+                                theme.custom.opacity.main
+                              ),
+                              borderRadius: 9999,
+                            }}
+                          >
+                            <Typography variant="button" color="text.secondary">
+                              Create auction
+                            </Typography>
+                          </Box>
+                        )}
+                      </Tooltip>
+                    </Box>
                   </Box>
+                  <AllAuctionsTable />
                 </Box>
-                <AllAuctionsTable />
-              </Box>
+              </Grid>
             </Grid>
-          </Grid>
+          )}
         </Box>
       </Container>
     </Default>


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/2j8fe12

## Description
Changes added to Pablo project, now to Composable monorepo

Comments by Design Team addressed:
1. Header balance to 2 point decimal. Wallet box responsive to wallet name
2. Swap page to have default tokens selected
3. Hover state for unselected buttons under 'Slippage tolerance'
4. Empty state for Auctions tab similar to bond page 
5. Select token component: bottom space on dropdown equal to the top. Entire component centered to screen
6. Token names on swap details to All Caps
7. Dropdown states for Token 1 and token 2 set to input text placeholder: "Select a token"
8. Warning box: info icon changed to orange
9. Pool fees input fixed
10. Confirm new pool step: amount of tokens shown (before just token label)
11. Select token component: Bottom space on dropdown set to equal to the top
12. Checkboxes roundness increased

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_

@KaiserKarel 