### PR TITLE
update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,8 @@ Makefile @ComposableFi/sre
 # Parachain related files
 runtime/ @ComposableFi/parachain-leads
 node/ @ComposableFi/parachain-leads
-frame/* @ComposableFi/parachain
+frame/ @ComposableFi/parachain
+integration-tests/ @ComposableFi/parachain
 
 frame/*/rpc/ @ComposableFi/parachain-rpc
 frame/*/runtime-api @ComposableFi/parachain-rpc


### PR DESCRIPTION
Fix frame and add parachain team as integration-tests owners.

Signed-off-by: Karel L. Kubat <k.l.kubat@gmail.com>

## Issue
*Please replace this line with either a link to the ClickUp issue, or a reference to the GitHub issue.*

## Description
*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_