### PR TITLE
Vault pallet - Added function to calculate shares from asset

### DIFF
--- a/frame/composable-traits/src/vault.rs
+++ b/frame/composable-traits/src/vault.rs
@@ -113,7 +113,7 @@ pub trait Vault {
 		lp_amount: Self::Balance,
 	) -> Result<Self::Balance, DispatchError>;
 
-	fn calculate_lp_tokens_from_asset_amount(
+	fn amount_of_lp_token_for_added_liquidity(
 		vault_id: &Self::VaultId,
 		asset_amount: Self::Balance,
 	) -> Result<Self::Balance, DispatchError>;

--- a/frame/composable-traits/src/vault.rs
+++ b/frame/composable-traits/src/vault.rs
@@ -112,6 +112,11 @@ pub trait Vault {
 		vault_id: &Self::VaultId,
 		lp_amount: Self::Balance,
 	) -> Result<Self::Balance, DispatchError>;
+
+	fn calculate_lp_tokens_from_asset_amount(
+		vault_id: &Self::VaultId,
+		asset_amount: Self::Balance,
+	) -> Result<Self::Balance, DispatchError>;
 }
 
 /// CapabilityVault exposes functionalities for stopping and limiting vault functionality.

--- a/frame/vault/src/lib.rs
+++ b/frame/vault/src/lib.rs
@@ -514,7 +514,7 @@ pub mod pallet {
 					<frame_system::Pallet<T>>::block_number(),
 					vault.deposit,
 				) {
-					return Err(Error::<T>::TombstoneDurationNotExceeded.into());
+					return Err(Error::<T>::TombstoneDurationNotExceeded.into())
 				} else {
 					let deletion_reward_account = &Self::deletion_reward_account(dest);
 					let reward =
@@ -909,9 +909,8 @@ pub mod pallet {
 			config: VaultConfig<Self::AccountId, Self::AssetId>,
 		) -> Result<Self::VaultId, DispatchError> {
 			match Validated::new(config) {
-				Ok(validated_config) => {
-					Self::do_create_vault(deposit, validated_config).map(|(id, _)| id)
-				},
+				Ok(validated_config) =>
+					Self::do_create_vault(deposit, validated_config).map(|(id, _)| id),
 				Err(_) => Err(DispatchError::from(Error::<T>::TooManyStrategies)),
 			}
 		}


### PR DESCRIPTION
## Issue
I needed a function to calculate the amount of `lp_tokens` corresponding to an amount of asset given the current vault conditions. 

## Description
Added a trait function `calculate_lp_tokens_from_asset_amount` and its pallet implementation. 
