### PR TITLE
fix(Codespace): Fixed Basilisk binary missing.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,8 +31,8 @@ RUN wget "https://github.com/paritytech/polkadot/releases/download/v0.9.22/polka
     chmod +x polkadot
 
 
-# # Add Basilisk node
-WORKDIR /Basilisk-node
+# # Add basilisk node
+WORKDIR /basilisk-node
 RUN wget "https://github.com/galacticcouncil/Basilisk-node/releases/download/v8.0.0/basilisk" && \
     chmod +x basilisk
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -30,6 +30,12 @@ WORKDIR /polkadot-binary
 RUN wget "https://github.com/paritytech/polkadot/releases/download/v0.9.22/polkadot" && \
     chmod +x polkadot
 
+
+# # Add Basilisk node
+WORKDIR /Basilisk-node
+RUN wget "https://github.com/galacticcouncil/Basilisk-node/releases/download/v8.0.0/basilisk" && \
+    chmod +x basilisk
+
 # Add mdbook
 WORKDIR /mdbook-binary
 RUN wget "https://github.com/rust-lang/mdBook/releases/download/v0.4.18/mdbook-v0.4.18-x86_64-unknown-linux-gnu.tar.gz" && \ 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -79,7 +79,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	"onCreateCommand": "cd /workspaces/composable/scripts/polkadot-launch && yarn && cd /workspaces/composable/integration-tests/runtime-tests && npm install",
-	"postCreateCommand": "mkdir -p /workspaces/polkadot/target/release && cp /polkadot-binary/polkadot /workspaces/polkadot/target/release/polkadot",
+  	"postCreateCommand": "mkdir -p /workspaces/polkadot/target/release && cp /polkadot-binary/polkadot /workspaces/polkadot/target/release/polkadot && mkdir -p /workspaces/Basilisk-node/target/release && cp /Basilisk-node/basilisk /workspaces/Basilisk-node/target/release/basilisk",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -79,7 +79,7 @@
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	"onCreateCommand": "cd /workspaces/composable/scripts/polkadot-launch && yarn && cd /workspaces/composable/integration-tests/runtime-tests && npm install",
-  	"postCreateCommand": "mkdir -p /workspaces/polkadot/target/release && cp /polkadot-binary/polkadot /workspaces/polkadot/target/release/polkadot && mkdir -p /workspaces/Basilisk-node/target/release && cp /Basilisk-node/basilisk /workspaces/Basilisk-node/target/release/basilisk",
+  	"postCreateCommand": "mkdir -p /workspaces/polkadot/target/release && cp /polkadot-binary/polkadot /workspaces/polkadot/target/release/polkadot && mkdir -p /workspaces/basilisk-node/target/release && cp /basilisk-node/basilisk /workspaces/basilisk-node/target/release/basilisk",
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode",
 	"features": {

--- a/docker/composable-sandbox.dockerfile
+++ b/docker/composable-sandbox.dockerfile
@@ -16,13 +16,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN groupadd -g 1000 service && useradd -m -s /bin/sh -g 1000 -G service service && \
-	mkdir -p /apps/composable/scripts /apps/composable/target/release /apps/Basilisk-node/target/release /apps/polkadot/target/release && \
+	mkdir -p /apps/composable/scripts /apps/composable/target/release /apps/basilisk-node/target/release /apps/polkadot/target/release && \
 	apt-get update && apt-get install -y --no-install-recommends apt-utils ca-certificates curl git && \
 	curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
 	apt-get update && apt-get install -y --no-install-recommends nodejs && \
 	npm install --global npm yarn && \
-	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo /apps/Basilisk-node/target/release/basilisk && \
-	chmod +x /apps/Basilisk-node/target/release/basilisk && \
+	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo /apps/basilisk-node/target/release/basilisk && \
+	chmod +x /apps/basilisk-node/target/release/basilisk && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete;
 

--- a/docker/composable-sandbox.dockerfile
+++ b/docker/composable-sandbox.dockerfile
@@ -21,7 +21,7 @@ RUN groupadd -g 1000 service && useradd -m -s /bin/sh -g 1000 -G service service
 	curl -fsSL https://deb.nodesource.com/setup_17.x | bash - && \
 	apt-get update && apt-get install -y --no-install-recommends nodejs && \
 	npm install --global npm yarn && \
-	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo /apps/basilisk-node/target/release/basilisk && \
+	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v8.0.0/basilisk -Lo /apps/basilisk-node/target/release/basilisk && \
 	chmod +x /apps/basilisk-node/target/release/basilisk && \
 	apt-get clean && \
 	find /var/lib/apt/lists/ -type f -not -name lock -delete;

--- a/scripts/polkadot-launch/README.md
+++ b/scripts/polkadot-launch/README.md
@@ -62,7 +62,7 @@ Need to do to run 5 Relay Chain nodes, 2 Composable collators and 2 Basilisk col
 
 	```bash
 	mkdir -p ../../../Basilisk-node/target/release
-	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo ../../../basilisk-node/target/release/basilisk
+	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v8.0.0/basilisk -Lo ../../../basilisk-node/target/release/basilisk
 	chmod +x ../../../basilisk-node/target/release/basilisk
 	../../../basilisk-node/target/release/basilisk --version
 	```

--- a/scripts/polkadot-launch/README.md
+++ b/scripts/polkadot-launch/README.md
@@ -62,9 +62,9 @@ Need to do to run 5 Relay Chain nodes, 2 Composable collators and 2 Basilisk col
 
 	```bash
 	mkdir -p ../../../Basilisk-node/target/release
-	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo ../../../Basilisk-node/target/release/basilisk
-	chmod +x ../../../Basilisk-node/target/release/basilisk
-	../../../Basilisk-node/target/release/basilisk --version
+	curl https://github.com/galacticcouncil/Basilisk-node/releases/download/v7.0.1/basilisk -Lo ../../../basilisk-node/target/release/basilisk
+	chmod +x ../../../basilisk-node/target/release/basilisk
+	../../../basilisk-node/target/release/basilisk --version
 	```
 
 4. build this project

--- a/scripts/polkadot-launch/composable_and_basilisk.json
+++ b/scripts/polkadot-launch/composable_and_basilisk.json
@@ -64,7 +64,7 @@
       ]
     },
     {
-      "bin": "../../../Basilisk-node/target/release/basilisk",
+      "bin": "../../../basilisk-node/target/release/basilisk",
       "chain":"local",
       "balance": "1000000000000000000000",
       "nodes": [


### PR DESCRIPTION
## Issue
When building the Codespace image, it's supposed to automatically get all binaries to run the chain.
This PR fixes that the binary for the Basilisk node was missing.