### PR TITLE
lending: sell: denial of service

### DIFF
--- a/frame/lending/src/mocks/general.rs
+++ b/frame/lending/src/mocks/general.rs
@@ -337,6 +337,10 @@ impl pallet_dutch_auction::Config for Runtime {
 	type XcmSender = XcmFake;
 }
 
+parameter_types! {
+	pub const MaxLiquidationStrategiesAmount: u32 = 3;
+}
+
 impl pallet_liquidations::Config for Runtime {
 	type Event = Event;
 	type UnixTime = Timestamp;
@@ -347,6 +351,7 @@ impl pallet_liquidations::Config for Runtime {
 	type WeightInfo = ();
 	type CanModifyStrategies = EnsureRoot<Self::AccountId>;
 	type XcmSender = XcmFake;
+	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;
 }
 
 pub type Extrinsic = TestXt<Call, ()>;

--- a/frame/lending/src/mocks/offchain.rs
+++ b/frame/lending/src/mocks/offchain.rs
@@ -69,6 +69,7 @@ pub type Public = AuthorityId;
 pub type Header = HeaderType;
 parameter_types! {
 	pub const LiquidationsPalletId : PalletId = PalletId(*b"liqd_tns");
+	pub const MaxLiquidationStrategiesAmount: u32 = 3;
 }
 
 pub static ALICE: Lazy<AccountId> = Lazy::new(|| 0);
@@ -360,6 +361,7 @@ impl pallet_liquidations::Config for Runtime {
 	type WeightInfo = ();
 	type CanModifyStrategies = EnsureRoot<Self::AccountId>;
 	type XcmSender = XcmFake;
+	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;
 }
 
 pub type Extrinsic = TestExtrinsic;

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -266,8 +266,7 @@ pub mod pallet {
 				configuration
 					.try_push(DefaultStrategyIndex::<T>::get())
 					.map_err(|()| Error::<T>::InvalidLiquidationStrategiesVector)?;
-			};
-			println!("Configuration: {:?}", configuration);
+			};			
 			for id in configuration {
 				let configuration = Strategies::<T>::get(id);
 				if let Some(configuration) = configuration {

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -68,7 +68,7 @@ pub mod pallet {
 		dispatch::DispatchResultWithPostInfo,
 		pallet_prelude::{OptionQuery, StorageMap, StorageValue},
 		traits::{EnsureOrigin, Get, IsType, UnixTime},
-		PalletId, Parameter, Twox64Concat,
+		BoundedVec, PalletId, Parameter, Twox64Concat,
 	};
 	use frame_system::{ensure_signed, pallet_prelude::OriginFor};
 	use scale_info::TypeInfo;
@@ -115,6 +115,7 @@ pub mod pallet {
 		type XcmSender: xcm::latest::SendXcm;
 
 		type CanModifyStrategies: EnsureOrigin<Self::Origin>;
+		type MaxLiquidationStrategiesAmount: Get<u32>;
 	}
 
 	#[pallet::event]
@@ -126,6 +127,7 @@ pub mod pallet {
 	#[pallet::error]
 	pub enum Error<T> {
 		NoLiquidationEngineFound,
+		InvalidLiquidationStrategiesVector,
 	}
 
 	#[pallet::pallet]
@@ -247,10 +249,25 @@ pub mod pallet {
 			order: Sell<Self::MayBeAssetId, Self::Balance>,
 			configuration: Vec<Self::LiquidationStrategyId>,
 		) -> Result<T::OrderId, DispatchError> {
+			let configuration = BoundedVec::try_from(configuration)
+				.map_err(|()| Error::<T>::InvalidLiquidationStrategiesVector)?;
+			Self::do_liquidate(from_to, order, configuration)
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		fn do_liquidate(
+			from_to: &T::AccountId,
+			order: Sell<T::MayBeAssetId, T::Balance>,
+			configuration: BoundedVec<T::LiquidationStrategyId, T::MaxLiquidationStrategiesAmount>,
+		) -> Result<T::OrderId, DispatchError> {
 			let mut configuration = configuration;
 			if configuration.is_empty() {
-				configuration.push(DefaultStrategyIndex::<T>::get())
+				configuration
+					.try_push(DefaultStrategyIndex::<T>::get())
+					.map_err(|()| Error::<T>::InvalidLiquidationStrategiesVector)?;
 			};
+			println!("Configuration: {:?}", configuration);
 			for id in configuration {
 				let configuration = Strategies::<T>::get(id);
 				if let Some(configuration) = configuration {
@@ -259,7 +276,7 @@ pub mod pallet {
 							T::DutchAuction::ask(from_to, order.clone(), configuration),
 						_ =>
 							return Err(DispatchError::Other(
-								"as for now, only auction liquidators implemented",
+								"As for now, only auction liquidation strategy is implemented",
 							)),
 					};
 					if let Ok(order_id) = result {

--- a/frame/liquidations/src/mock/runtime.rs
+++ b/frame/liquidations/src/mock/runtime.rs
@@ -21,7 +21,7 @@ use sp_core::{
 };
 use sp_runtime::{
 	testing::Header,
-	traits::{BlakeTwo256, ConvertInto, IdentifyAccount, IdentityLookup, Verify},
+	traits::{BlakeTwo256, IdentifyAccount, IdentityLookup, Verify},
 	Perbill,
 };
 use xcm::latest::SendXcm;
@@ -35,6 +35,7 @@ pub type OrderId = u32;
 pub type Amount = i64;
 
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
+pub type SystemOriginOf<T> = <T as frame_system::Config>::Origin;
 
 frame_support::construct_runtime! {
 	pub enum Runtime where
@@ -231,6 +232,7 @@ impl pallet_dutch_auction::Config for Runtime {
 
 parameter_types! {
 	pub const LiquidationPalletId : PalletId = PalletId(*b"liqudatn");
+	pub const MaxLiquidationStrategiesAmount: u32 = 3;
 }
 
 type LiquidationStrategyId = u32;
@@ -244,6 +246,7 @@ impl pallet_liquidations::Config for Runtime {
 	type PalletId = LiquidationPalletId;
 	type CanModifyStrategies = EnsureRoot<Self::AccountId>;
 	type XcmSender = XcmFake;
+	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;
 }
 
 #[allow(dead_code)] // not really dead


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/32b4yy5

## Description
Halborn Report:

> The liquidation pallet defines a sell function which internally calls
> the liquidate function, which takes a Vec as a parameter and can be
> called by anyone. The user controls the length and contents of this Vec.
> The liquidate function loops through every element in the vector until
> it reaches one which corresponds to the existing Liquidation Strategy.
> However, if an attacker submits a vector of big enough length containing
> values not corresponding to any Strategy, the block production might be
> halted, which leads to the Denial of Service condition for the whole chain.  

To solve the issue liquidation logic was moved to the `do_liquidate()` private function. 
The function requires `BoundedVec` of strategies ids as input. 
This makes impossible to pass a vector of arbitrary size.

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_