### PR TITLE
HAL-04 Zero amount collateral withdrawal

### DIFF
--- a/frame/lending/src/helpers.rs
+++ b/frame/lending/src/helpers.rs
@@ -8,13 +8,19 @@ use crate::{
 	},
 };
 use composable_support::{
-	math::safe::{SafeAdd, SafeDiv, SafeMul},
+	math::safe::{SafeAdd, SafeDiv, SafeMul, SafeSub},
 	validation::{TryIntoValidated, Validated},
 };
 use composable_traits::{
 	currency::CurrencyFactory,
-	defi::{DeFiComposableConfig, *},
-	lending::{math::*, BorrowAmountOf, CollateralLpAmountOf, Lending, MarketConfig, UpdateInput},
+	defi::{
+		CurrencyPair, DeFiComposableConfig, DeFiEngine, LiftedFixedBalance, MoreThanOneFixedU128,
+		OneOrMoreFixedU128, Sell,
+	},
+	lending::{
+		math::InterestRate, BorrowAmountOf, CollateralLpAmountOf, Lending, MarketConfig,
+		UpdateInput,
+	},
 	liquidation::Liquidation,
 	oracle::Oracle,
 	time::{DurationSeconds, SECONDS_PER_YEAR_NAIVE},
@@ -26,6 +32,7 @@ use frame_support::{
 	traits::{
 		fungible::{Inspect as NativeInspect, Transfer as NativeTransfer},
 		fungibles::{Inspect, Transfer},
+		tokens::DepositConsequence,
 		UnixTime,
 	},
 	weights::WeightToFeePolynomial,
@@ -140,6 +147,87 @@ impl<T: Config> Pallet<T> {
 			amount,
 			keep_alive,
 		)?;
+		Ok(())
+	}
+
+	pub(crate) fn do_withdraw_collateral(
+		market_id: &<Self as Lending>::MarketId,
+		account: &T::AccountId,
+		amount: Validated<CollateralLpAmountOf<Self>, BalanceGreaterThenZero>,
+	) -> Result<(), DispatchError> {
+		let amount = amount.value();
+		let (_, market) = Self::get_market(market_id)?;
+
+		let collateral_balance = AccountCollateral::<T>::try_get(market_id, account)
+			// REVIEW: Perhaps don't default to zero
+			// REVIEW: What is expected behaviour if there is no collateral?
+			.unwrap_or_else(|_| CollateralLpAmountOf::<Self>::zero());
+
+		ensure!(amount <= collateral_balance, Error::<T>::NotEnoughCollateralToWithdraw);
+
+		let borrow_asset = T::Vault::asset_id(&market.borrow_asset_vault)?;
+		let borrower_balance_with_interest =
+			Self::total_debt_with_interest(market_id, account)?.unwrap_or_zero();
+
+		let borrow_balance_value = Self::get_price(borrow_asset, borrower_balance_with_interest)?;
+
+		let collateral_balance_after_withdrawal_value =
+			Self::get_price(market.collateral_asset, collateral_balance.safe_sub(&amount)?)?;
+
+		let borrower_after_withdrawal = BorrowerData::new(
+			collateral_balance_after_withdrawal_value,
+			borrow_balance_value,
+			market
+				.collateral_factor
+				.try_into_validated()
+				.map_err(|_| Error::<T>::Overflow)?, // TODO: Use a proper error mesage?
+			market.under_collateralized_warn_percent,
+		);
+
+		ensure!(
+			!borrower_after_withdrawal.should_liquidate()?,
+			Error::<T>::WouldGoUnderCollateralized
+		);
+
+		let market_account = Self::account_id(market_id);
+
+		ensure!(
+			<T as Config>::MultiCurrency::can_deposit(
+				market.collateral_asset,
+				account,
+				amount,
+				false
+			) == DepositConsequence::Success,
+			Error::<T>::TransferFailed
+		);
+		ensure!(
+			<T as Config>::MultiCurrency::can_withdraw(
+				market.collateral_asset,
+				&market_account,
+				amount
+			)
+			.into_result()
+			.is_ok(),
+			Error::<T>::TransferFailed
+		);
+
+		AccountCollateral::<T>::try_mutate(market_id, account, |collateral_balance| {
+			let new_collateral_balance =
+				// REVIEW: Should we default if there's no collateral? Or should an error (something like "NoCollateralToWithdraw") be returned instead?
+				collateral_balance.unwrap_or_default().safe_sub(&amount)?;
+
+			collateral_balance.replace(new_collateral_balance);
+
+			Result::<(), DispatchError>::Ok(())
+		})?;
+		<T as Config>::MultiCurrency::transfer(
+			market.collateral_asset,
+			&market_account,
+			account,
+			amount,
+			true,
+		)
+		.expect("impossible; qed;");
 		Ok(())
 	}
 
@@ -597,7 +685,9 @@ pub(crate) fn accrue_interest_internal<T: Config, I: InterestRate>(
 
 /// Retrieve the current interest rate for the given `market_id`.
 #[cfg(test)]
-pub fn current_interest_rate<T: Config>(market_id: MarketId) -> Result<Rate, DispatchError> {
+pub fn current_interest_rate<T: Config>(
+	market_id: MarketId,
+) -> Result<composable_traits::defi::Rate, DispatchError> {
 	let market_id = MarketIndex::new(market_id);
 	let total_borrowed_from_market_excluding_interest =
 		Pallet::<T>::total_borrowed_from_market_excluding_interest(&market_id)?;

--- a/frame/lending/src/impls/lending.rs
+++ b/frame/lending/src/impls/lending.rs
@@ -1,6 +1,4 @@
-use crate::{
-	helpers::accrue_interest_internal, models::borrower_data::BorrowerData, weights::WeightInfo, *,
-};
+use crate::{helpers::accrue_interest_internal, weights::WeightInfo, *};
 
 use composable_support::{
 	math::safe::{SafeAdd, SafeDiv, SafeMul, SafeSub},
@@ -21,7 +19,6 @@ use frame_support::{
 	traits::{
 		fungible::Transfer as NativeTransfer,
 		fungibles::{Inspect, InspectHold, Mutate, MutateHold, Transfer},
-		tokens::DepositConsequence,
 	},
 	weights::WeightToFeePolynomial,
 };
@@ -72,79 +69,7 @@ impl<T: Config> Lending for Pallet<T> {
 		account: &Self::AccountId,
 		amount: CollateralLpAmountOf<Self>,
 	) -> Result<(), DispatchError> {
-		let (_, market) = Self::get_market(market_id)?;
-
-		let collateral_balance = AccountCollateral::<T>::try_get(market_id, account)
-			// REVIEW: Perhaps don't default to zero
-			// REVIEW: What is expected behaviour if there is no collateral?
-			.unwrap_or_else(|_| CollateralLpAmountOf::<Self>::zero());
-
-		ensure!(amount <= collateral_balance, Error::<T>::NotEnoughCollateralToWithdraw);
-
-		let borrow_asset = T::Vault::asset_id(&market.borrow_asset_vault)?;
-		let borrower_balance_with_interest =
-			Self::total_debt_with_interest(market_id, account)?.unwrap_or_zero();
-
-		let borrow_balance_value = Self::get_price(borrow_asset, borrower_balance_with_interest)?;
-
-		let collateral_balance_after_withdrawal_value =
-			Self::get_price(market.collateral_asset, collateral_balance.safe_sub(&amount)?)?;
-
-		let borrower_after_withdrawal = BorrowerData::new(
-			collateral_balance_after_withdrawal_value,
-			borrow_balance_value,
-			market
-				.collateral_factor
-				.try_into_validated()
-				.map_err(|_| Error::<T>::Overflow)?, // TODO: Use a proper error mesage?
-			market.under_collateralized_warn_percent,
-		);
-
-		ensure!(
-			!borrower_after_withdrawal.should_liquidate()?,
-			Error::<T>::WouldGoUnderCollateralized
-		);
-
-		let market_account = Self::account_id(market_id);
-
-		ensure!(
-			<T as Config>::MultiCurrency::can_deposit(
-				market.collateral_asset,
-				account,
-				amount,
-				false
-			) == DepositConsequence::Success,
-			Error::<T>::TransferFailed
-		);
-		ensure!(
-			<T as Config>::MultiCurrency::can_withdraw(
-				market.collateral_asset,
-				&market_account,
-				amount
-			)
-			.into_result()
-			.is_ok(),
-			Error::<T>::TransferFailed
-		);
-
-		AccountCollateral::<T>::try_mutate(market_id, account, |collateral_balance| {
-			let new_collateral_balance =
-				// REVIEW: Should we default if there's no collateral? Or should an error (something like "NoCollateralToWithdraw") be returned instead?
-				collateral_balance.unwrap_or_default().safe_sub(&amount)?;
-
-			collateral_balance.replace(new_collateral_balance);
-
-			Result::<(), DispatchError>::Ok(())
-		})?;
-		<T as Config>::MultiCurrency::transfer(
-			market.collateral_asset,
-			&market_account,
-			account,
-			amount,
-			true,
-		)
-		.expect("impossible; qed;");
-		Ok(())
+		Self::do_withdraw_collateral(market_id, account, amount.try_into_validated()?)
 	}
 
 	fn get_markets_for_borrow(borrow: Self::VaultId) -> Vec<Self::MarketId> {

--- a/frame/lending/src/tests/borrow.rs
+++ b/frame/lending/src/tests/borrow.rs
@@ -1,5 +1,5 @@
 use super::prelude::*;
-use crate::{models::borrower_data::BorrowerData, validation::BalanceGreaterThenZero};
+use crate::models::borrower_data::BorrowerData;
 use composable_traits::defi::LiftedFixedBalance;
 
 #[test]
@@ -362,9 +362,18 @@ fn borrow_flow() {
 #[test]
 fn zero_amount_collateral_deposit() {
 	new_test_ext().execute_with(|| {
-		let collateral_amount: Result<Validated<u128, BalanceGreaterThenZero>, &str> =
-			0.try_into_validated();
-		assert_err!(collateral_amount, "Can not deposit zero collateral");
+		let (market, _vault) = create_simple_market();
+		let collateral_amount = 0;
+		let error_message = "Can not deposit or withdraw zero collateral";
+		assert_noop!(
+			Lending::deposit_collateral(Origin::signed(*ALICE), market, collateral_amount, false),
+			error_message
+		);
+
+		assert_noop!(
+			Lending::withdraw_collateral(Origin::signed(*ALICE), market, collateral_amount,),
+			error_message
+		);
 	})
 }
 

--- a/frame/lending/src/tests/borrow.rs
+++ b/frame/lending/src/tests/borrow.rs
@@ -360,7 +360,7 @@ fn borrow_flow() {
 }
 
 #[test]
-fn zero_amount_collateral_deposit() {
+fn zero_amount_collateral_deposit_or_withdraw() {
 	new_test_ext().execute_with(|| {
 		let (market, _vault) = create_simple_market();
 		let collateral_amount = 0;

--- a/frame/lending/src/validation.rs
+++ b/frame/lending/src/validation.rs
@@ -93,7 +93,8 @@ where
 	B: Zero + PartialOrd,
 {
 	fn validate(balance: B) -> Result<B, &'static str> {
-		ensure!(balance > B::zero(), "Can not deposit zero collateral");
+		ensure!(balance > B::zero(), "Can not deposit or withdraw zero collateral");
+
 		Ok(balance)
 	}
 }


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/32b50m1

## Description
Halborn Report
> The lending pallet defines a withdraw_collateral function that allows
> users to withdraw zero collateral. Zero amount wrappings can be abused
> if someone constantly calls withdraw_collateral with zero amount and fill
> the block space.

withdraw_collateral() logic was moved to private do_withdraw_collateral() function which requires validated input.
Validator checks if provided balance larger than zero.


## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_