### PR TITLE
CU-32b4zaw Dutch Auction creation with the same asset

### DIFF
--- a/frame/dutch-auction/src/lib.rs
+++ b/frame/dutch-auction/src/lib.rs
@@ -76,6 +76,7 @@ mod mock;
 mod prelude;
 mod support;
 mod types;
+mod validation;
 pub mod weights;
 
 #[frame_support::pallet]
@@ -84,7 +85,7 @@ pub mod pallet {
 	use crate::{prelude::*, types::*};
 	use xcm::latest::{prelude::*, MultiAsset, WeightLimit::Unlimited};
 
-	use crate::{math::*, support::DefiMultiReservableCurrency};
+	use crate::{math::*, support::DefiMultiReservableCurrency, validation::XcmSellRequestValid};
 	use composable_support::{
 		abstractions::{
 			nonce::Nonce,
@@ -94,6 +95,7 @@ pub mod pallet {
 			},
 		},
 		math::wrapping_next::WrappingNext,
+		validation::Validate,
 	};
 	use composable_traits::{
 		defi::{DeFiComposableConfig, DeFiEngine, OrderIdLike, Sell, SellEngine, Take},
@@ -192,7 +194,6 @@ pub mod pallet {
 		XcmCannotDecodeRemoteParametersToLocalRepresentations,
 		XcmCannotFindLocalIdentifiersAsDecodedFromRemote,
 		XcmNotFoundConfigurationById,
-		XcmBaseEqQuote,
 	}
 
 	#[pallet::pallet]
@@ -350,13 +351,14 @@ pub mod pallet {
 		) -> DispatchResultWithPostInfo {
 			// TODO: make events/logs from all failed liqudations
 
+			let request = XcmSellRequestValid::validate(request)?;
+
 			// incoming message is generic in representations, so need to map it back to local,
 			let parachain_id = ensure_sibling_para(<T as Config>::XcmOrigin::from(origin))?;
 			let base = T::MayBeAssetId::decode(&mut &request.order.pair.base.encode()[..])
 				.map_err(|_| Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations)?;
 			let quote = T::MayBeAssetId::decode(&mut &request.order.pair.quote.encode()[..])
 				.map_err(|_| Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations)?;
-			ensure!(base != quote, Error::<T>::XcmBaseEqQuote);
 			let amount: T::Balance =
 				request.order.take.amount.try_into().map_err(|_| {
 					Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations

--- a/frame/dutch-auction/src/lib.rs
+++ b/frame/dutch-auction/src/lib.rs
@@ -192,6 +192,7 @@ pub mod pallet {
 		XcmCannotDecodeRemoteParametersToLocalRepresentations,
 		XcmCannotFindLocalIdentifiersAsDecodedFromRemote,
 		XcmNotFoundConfigurationById,
+		XcmBaseEqQuote,
 	}
 
 	#[pallet::pallet]
@@ -355,6 +356,7 @@ pub mod pallet {
 				.map_err(|_| Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations)?;
 			let quote = T::MayBeAssetId::decode(&mut &request.order.pair.quote.encode()[..])
 				.map_err(|_| Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations)?;
+			ensure!(base != quote, Error::<T>::XcmBaseEqQuote);
 			let amount: T::Balance =
 				request.order.take.amount.try_into().map_err(|_| {
 					Error::<T>::XcmCannotDecodeRemoteParametersToLocalRepresentations

--- a/frame/dutch-auction/src/tests.rs
+++ b/frame/dutch-auction/src/tests.rs
@@ -4,9 +4,10 @@ use crate::mock::{currency::*, runtime::*};
 use composable_traits::{
 	defi::{LiftedFixedBalance, Sell, Take},
 	time::{LinearDecrease, TimeReleaseFunction},
+	xcm::XcmSellRequest,
 };
 use frame_support::{
-	assert_ok,
+	assert_noop, assert_ok,
 	traits::{
 		fungible::{self, Mutate as NativeMutate},
 		fungibles::{Inspect, Mutate},
@@ -36,6 +37,34 @@ pub fn new_test_externalities() -> sp_io::TestExternalities {
 		Timestamp::set_timestamp(System::block_number() * MILLISECS_PER_BLOCK);
 	});
 	externatlities
+}
+
+// ensure that we take extra for sell, at least amount to remove
+#[test]
+fn xcm_sell_with_same_asset() {
+	new_test_externalities().execute_with(|| {
+		let seller = AccountId::from_raw(ALICE.0);
+		let sell = Sell::new(BTC, BTC, 1, fixed(1000));
+		let configuration = TimeReleaseFunction::LinearDecrease(LinearDecrease { total: 42 });
+		let configuration_id = 1;
+		DutchAuction::add_configuration(
+			Origin::signed(seller),
+			configuration_id,
+			configuration.clone(),
+		)
+		.unwrap();
+		let order_id = crate::OrdersIndex::<Runtime>::get();
+		let request = XcmSellRequest {
+			order_id: order_id.into(),
+			order: sell,
+			from_to: ALICE.0,
+			configuration: configuration_id,
+		};
+		assert_noop!(
+			DutchAuction::xcm_sell(Origin::signed(seller), request),
+			sp_runtime::DispatchError::Other("Auction creation with the same asset."),
+		);
+	});
 }
 
 // ensure that we take extra for sell, at least amount to remove

--- a/frame/dutch-auction/src/validation.rs
+++ b/frame/dutch-auction/src/validation.rs
@@ -1,0 +1,18 @@
+use composable_support::validation::Validate;
+use composable_traits::xcm::XcmSellRequest;
+use frame_support::pallet_prelude::*;
+use scale_info::TypeInfo;
+
+#[derive(Clone, Copy, RuntimeDebug, PartialEq, TypeInfo, Default)]
+pub struct XcmSellRequestValid;
+
+impl Validate<XcmSellRequest, XcmSellRequestValid> for XcmSellRequestValid {
+	fn validate(request: XcmSellRequest) -> Result<XcmSellRequest, &'static str> {
+		let base = request.order.pair.base;
+		let quote = request.order.pair.quote;
+		if base == quote {
+			return Err("Auction creation with the same asset.")
+		}
+		Ok(request)
+	}
+}


### PR DESCRIPTION
## Issue
CU-32b4zaw

## Description
Inside the dutch-auction pallet the ask function accepts sell offers with the same asset provided as both base and quote. Please note, that this vulnerability also exists for a xcm_sell function. This can result in situations when a victim pays, for example, 1000 tokens to get 100 tokens of the same type. This vulnerability facilitates attacks, which require very little effort from the attacker and might yield high rewards.

## Recommendation:
Implementing a validation mechanism in the ask and xcm-sell functions is recommended to ensure that the base asset is not the same as the quote asset. 
