### PR TITLE
Update run_benchmarks.sh

### DIFF
--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -3,9 +3,9 @@
 # `cargo build --release --features runtime-benchmarks`
 
 chains=(
-  "./runtime/dali/src/weights,dali-dev"
-  "./runtime/picasso/src/weights,picasso-dev"
-  "./runtime/composable/src/weights,composable-dev"
+  "dali-dev"
+  "picasso-dev"
+  "composable-dev"
 )
 
 steps=50


### PR DESCRIPTION
I was not able to run this script on the local machine, looks like value of `chain` parameter should match with config name

Signed-off-by: mikolaichuk <45576473+mikolaichuk@users.noreply.github.com>

## Issue
*Please replace this line with either a link to the ClickUp issue, or a reference to the GitHub issue.*

## Description
*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_