### PR TITLE
#CU-32b5019 HAL-03 Invalid Extrinsic Weight Calculation Leads to Multiple Issues

### DIFF
--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -148,7 +148,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
-		#[pallet::weight(T::WeightInfo::sell())]
+		#[pallet::weight(T::WeightInfo::sell::<T>(configuration))]
 		pub fn sell(
 			origin: OriginFor<T>,
 			order: Sell<T::MayBeAssetId, T::Balance>,

--- a/frame/liquidations/src/weights.rs
+++ b/frame/liquidations/src/weights.rs
@@ -12,7 +12,7 @@ pub trait WeightInfo {
 
 	fn sell<T: Config>(confs: &[T::LiquidationStrategyId]) -> Weight {
 		use frame_support::traits::Get as _;
-		let len = if confs.len() == 0 {
+		let len = if confs.is_empty() {
 			1 // because if configurations is empty we add default Configuration
 		} else {
 			confs.len() as Weight

--- a/frame/liquidations/src/weights.rs
+++ b/frame/liquidations/src/weights.rs
@@ -1,3 +1,4 @@
+use crate::Config;
 use frame_support::dispatch::Weight;
 
 pub trait WeightInfo {
@@ -9,8 +10,16 @@ pub trait WeightInfo {
 		10_000
 	}
 
-	fn sell() -> Weight {
-		10_000
+	fn sell<T: Config>(confs: &[T::LiquidationStrategyId]) -> Weight {
+		use frame_support::traits::Get as _;
+		let len = if confs.len() == 0 {
+			1 // because if configurations is empty we add default Configuration
+		} else {
+			confs.len() as Weight
+		};
+		let reads = T::DbWeight::get().reads(5);
+		let writes = T::DbWeight::get().writes(3);
+		len.saturating_mul(reads.saturating_add(writes)).saturating_add(10_000)
 	}
 }
 


### PR DESCRIPTION
## Issue
CU-32b5019

## Description

The liquidations pallet defines a sell function responsible for creating a Dutch Auction for Liquidating a position. The weight associated with calling this extrinsic is a constant value of 10000. Such configuration is invalid, as the sell function accepts a Vector as a parameter, which length is controlled by the user. Two issues originate from this fact. The first one is that regardless of the Vector size, the extrinsic will have a constant weight and would always be perceived as filling a constant space in the block. The second one is related to fees associated with calling the extrinsic. Currently, the sell function is internally creating a Dutch Auction. Anyone can call the sell auction, similarly to the fact that anyone can create their own Dutch Auction via the dutch-auction pallet. There is a correlation between weights and fees. With the current weight configuration for the sell function, it is cheaper to create a Dutch Auction via the liquidations pallet rather than via the dutch-auction itself. The prerequisite for this is that there is already a desired configuration defined in the liquidations pallet.

## Recommendation:
It is recommended to implement a dynamic weight calculation based on the size of user-supplied parameters, which size is unknown before the extrinsic call. Furthermore, it is advised to calculate the weight for the sell function so that the fees are the same or greater than the ones associated with interacting with dutch-auction directly.

