### PR TITLE
CU-225wvg7 - Update funding guard rails

### DIFF
--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -2317,12 +2317,12 @@ pub mod pallet {
 			twap: &T::Decimal,
 		) -> Result<T::Decimal, DispatchError> {
 			let oracle_twap_spread = oracle.try_sub(twap)?;
-			let oracle_33pct = oracle.try_div(&T::Decimal::saturating_from_integer(3))?;
-			Ok(if oracle_twap_spread.saturating_abs() > oracle_33pct {
+			let twap_33pct = twap.try_div(&T::Decimal::saturating_from_integer(3))?;
+			Ok(if oracle_twap_spread.saturating_abs() > twap_33pct {
 				if oracle > twap {
-					twap.try_add(&oracle_33pct)?
+					twap.try_add(&twap_33pct)?
 				} else {
-					twap.try_sub(&oracle_33pct)?
+					twap.try_sub(&twap_33pct)?
 				}
 			} else {
 				*oracle

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -2265,7 +2265,7 @@ pub mod pallet {
 				oracle = math::clip(
 					oracle,
 					last_oracle.try_sub(&last_oracle_10bp)?,
-					last_oracle.try_sub(&last_oracle_10bp)?,
+					last_oracle.try_add(&last_oracle_10bp)?,
 				);
 
 				// TODO(0xangelo): consider further guard rails

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -1247,6 +1247,10 @@ pub mod pallet {
 				Error::<T>::UpdatingFundingTooEarly
 			);
 
+			// Update TWAPs *before* funding rate calculations
+			Self::update_oracle_twap(&mut market)?;
+			T::Vamm::update_twap(market.vamm_id, None, None)?;
+
 			Self::do_update_funding(market_id, &mut market, now)?;
 
 			Markets::<T>::insert(market_id, market);

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -1342,338 +1342,6 @@ pub mod pallet {
 	//                                    Helper Functions
 	// ---------------------------------------------------------------------------------------------
 
-	// Helper functions - core functionality
-	impl<T: Config> Pallet<T> {
-		fn try_update_funding(
-			market_id: &T::MarketId,
-			market: &mut Market<T>,
-		) -> Result<(), DispatchError> {
-			let now = T::UnixTime::now().as_secs();
-			if Self::is_funding_update_time(market, now)? {
-				Self::do_update_funding(market_id, market, now)?;
-			}
-			Ok(())
-		}
-
-		fn do_update_funding(
-			market_id: &T::MarketId,
-			market: &mut Market<T>,
-			now: DurationSeconds,
-		) -> Result<(), DispatchError> {
-			// Pay funding
-			// net position sign | funding rate sign | transfer
-			// --------------------------------------------------------------
-			//                -1 |                -1 | Collateral -> Fee Pool
-			//                -1 |                 1 | Fee Pool -> Collateral
-			//                 1 |                -1 | Fee Pool -> Collateral
-			//                 1 |                 1 | Collateral -> Fee Pool
-			//                 - |                 0 | n/a
-			//                 0 |                 - | n/a
-			let net_base_asset_amount =
-				market.base_asset_amount_long.try_add(&market.base_asset_amount_short)?;
-			let funding_rate = <Self as Instruments>::funding_rate(market)?;
-			let mut funding_rate_long = funding_rate;
-			let mut funding_rate_short = funding_rate;
-
-			if !(funding_rate.is_zero() | net_base_asset_amount.is_zero()) {
-				let uncapped_funding = funding_rate.try_mul(&net_base_asset_amount)?;
-				let collateral_account = Self::get_collateral_account();
-				let fee_pool_account = Self::get_fee_pool_account(market_id.clone());
-				let collateral_asset_id = Self::get_collateral_asset_id()?;
-
-				if uncapped_funding.is_positive() {
-					// Fee Pool receives funding
-					T::Assets::transfer(
-						collateral_asset_id,
-						&collateral_account,
-						&fee_pool_account,
-						uncapped_funding.into_balance()?,
-						false,
-					)?;
-				} else {
-					// Fee Pool pays funding
-					// TODO(0xangelo): set limits for
-					// - total Fee Pool usage (reserve some funds for other operations)
-					// - Fee Pool usage for funding payments per call to `update_funding`
-					let usable_fees: T::Decimal =
-						-T::Assets::balance(collateral_asset_id, &fee_pool_account)
-							.into_decimal()?;
-					let mut capped_funding = sp_std::cmp::max(uncapped_funding, usable_fees);
-
-					// Since we're dealing with negatives, we check if the uncapped funding is
-					// *smaller* (greater in absolute terms) than the capped one
-					if capped_funding > uncapped_funding {
-						// Total funding paid to one side is the sum of the funding paid by the
-						// opposite side plus the complement from the Fee Pool
-						let excess;
-						if net_base_asset_amount.is_positive() {
-							let counterparty_funding = usable_fees
-								.try_sub(&funding_rate.try_mul(&market.base_asset_amount_short)?)?;
-							(funding_rate_long, excess) =
-								counterparty_funding.try_div_rem(&market.base_asset_amount_long)?;
-						} else {
-							let counterparty_funding = funding_rate
-								.try_mul(&market.base_asset_amount_long)?
-								.try_sub(&usable_fees)?;
-							(funding_rate_short, excess) = counterparty_funding
-								.try_div_rem(&market.base_asset_amount_short)?;
-						}
-						capped_funding.try_sub_mut(&excess)?;
-					}
-
-					T::Assets::transfer(
-						collateral_asset_id,
-						&fee_pool_account,
-						&collateral_account,
-						capped_funding.into_balance()?,
-						false,
-					)?;
-				};
-			}
-
-			// Update market state
-			market.cum_funding_rate_long.try_add_mut(&funding_rate_long)?;
-			market.cum_funding_rate_short.try_add_mut(&funding_rate_short)?;
-			market.funding_rate_ts = now;
-
-			Self::deposit_event(Event::FundingUpdated { market: market_id.clone(), time: now });
-			Ok(())
-		}
-
-		fn summarize_account_state(
-			account_id: &T::AccountId,
-			positions: BoundedVec<Position<T>, T::MaxPositions>,
-		) -> Result<AccountSummary<T>, DispatchError> {
-			let collateral = Self::get_collateral(account_id).unwrap_or_else(Zero::zero);
-
-			let mut summary = AccountSummary::<T>::new(collateral)?;
-			for position in positions {
-				let market = Self::try_get_market(&position.market_id)?;
-				if let Some(direction) = position.direction() {
-					// should always succeed
-					let (base_asset_value, unrealized_pnl) =
-						Self::abs_position_notional_and_pnl(&market, &position, direction)?;
-
-					let info = PositionInfo::<T> {
-						direction,
-						margin_requirement_maintenance: base_asset_value
-							.try_mul(&market.margin_ratio_maintenance)?,
-						margin_requirement_partial: base_asset_value
-							.try_mul(&market.margin_ratio_partial)?,
-						base_asset_value,
-						unrealized_pnl,
-						unrealized_funding: <Self as Instruments>::unrealized_funding(
-							&market, &position,
-						)?,
-					};
-
-					summary.update(market, position, info)?;
-				}
-			}
-
-			Ok(summary)
-		}
-
-		/// Fully liquidates the user's positions until its account is brought above the MMR.
-		///
-		/// This function does **not** check if the account is below the MMR beforehand.
-		///
-		/// ## Storage modifications
-		///
-		/// - Updates the [`markets`](Markets) of closed positions (according to changes in
-		///   [`Self::close_position_in_market`])
-		/// - Removes closed [`positions`](Positions)
-		/// - Updates the user's account [`collateral`](Collateral)
-		///
-		/// ## Returns
-		///
-		/// The fees for the liquidator and insurance fund
-		fn fully_liquidate_account(
-			user_id: &T::AccountId,
-			summary: AccountSummary<T>,
-		) -> Result<(T::Balance, T::Balance), DispatchError> {
-			let AccountSummary::<T> {
-				mut collateral,
-				mut margin,
-				margin_requirement_maintenance: mut margin_requirement,
-				base_asset_value,
-				mut positions_summary,
-				..
-			} = summary;
-
-			let mut positions = BoundedVec::<Position<T>, T::MaxPositions>::default();
-			let maximum_fee = Self::full_liquidation_penalty().try_mul(&margin)?;
-			let mut fees = T::Balance::zero();
-			// Sort positions from greatest to lowest margin requirement
-			positions_summary.sort_by_key(|(_, _, info)| info.margin_requirement_maintenance.neg());
-			for (mut market, position, info) in positions_summary {
-				if margin < margin_requirement {
-					Self::close_position_in_market(
-						&position,
-						info.direction,
-						&mut market,
-						info.base_asset_value.into_balance()?,
-					)?;
-					Markets::<T>::insert(&position.market_id, market);
-
-					let base_asset_value_share =
-						info.base_asset_value.try_div(&base_asset_value)?;
-					let fee_decimal = base_asset_value_share.try_mul(&maximum_fee)?;
-					margin.try_sub_mut(&fee_decimal)?;
-					margin_requirement.try_sub_mut(&info.margin_requirement_maintenance)?;
-					fees.try_add_mut(&fee_decimal.into_balance()?)?;
-					collateral = Self::updated_balance(
-						&collateral,
-						&info
-							.unrealized_pnl
-							.try_add(&info.unrealized_funding)?
-							.try_sub(&fee_decimal)?,
-					)?;
-				} else {
-					// AccountSummary::positions_summary isn't constrained to be shorter than the
-					// maximum number of positions, so we keep the error checking here.
-					positions.try_push(position).map_err(|_| Error::<T>::MaxPositionsExceeded)?;
-				}
-			}
-
-			// Charge fees
-			let liquidator_fee =
-				Self::full_liquidation_penalty_liquidator_share().saturating_mul_int(fees);
-			let insurance_fee = fees.try_sub(&liquidator_fee)?;
-
-			Positions::<T>::insert(user_id, positions);
-			Collateral::<T>::insert(user_id, collateral);
-
-			Ok((liquidator_fee, insurance_fee))
-		}
-
-		/// Partially liquidates the user's positions until its account is brought above the PMR.
-		///
-		/// This function does **not** check if the account is below the PMR beforehand.
-		///
-		/// ## Storage modifications
-		///
-		/// - Updates the [`markets`](Markets) of decreased positions (according to changes made by
-		///   [`Self::decrease_position`])
-		/// - Updates reduced [`positions`](Positions) (according to changes made by
-		///   [`Self::decrease_position`])
-		/// - Updates the user's account [`collateral`](Collateral)
-		///
-		/// ## Returns
-		///
-		/// The fees for the liquidator and insurance fund
-		fn partially_liquidate_account(
-			user_id: &T::AccountId,
-			summary: AccountSummary<T>,
-		) -> Result<(T::Balance, T::Balance), DispatchError> {
-			let AccountSummary::<T> {
-				mut collateral,
-				mut margin,
-				margin_requirement_partial: mut margin_requirement,
-				base_asset_value,
-				mut positions_summary,
-				..
-			} = summary;
-
-			let mut positions = BoundedVec::<Position<T>, T::MaxPositions>::default();
-			let mut fees = T::Balance::zero();
-			let maximum_fee = Self::partial_liquidation_penalty().try_mul(&margin)?;
-			let close_ratio = Self::partial_liquidation_close_ratio();
-			let maximum_close_value = close_ratio.try_mul(&base_asset_value)?;
-			// Sort positions from greatest to lowest margin requirement
-			positions_summary.sort_by_key(|(_, _, info)| info.margin_requirement_partial.neg());
-			for (mut market, mut position, info) in positions_summary {
-				if margin < margin_requirement {
-					Self::settle_funding(&mut position, &market, &mut collateral)?;
-
-					let base_value_to_close = close_ratio.try_mul(&info.base_asset_value)?;
-					let (_, entry_value, exit_value) = Self::decrease_position(
-						&mut position,
-						&mut market,
-						info.direction.opposite(),
-						&base_value_to_close,
-						Zero::zero(), /* No slippage control is necessary since it was already
-						               * taken into account when computing `base_asset_value` */
-					)?;
-					Markets::<T>::insert(&position.market_id, market);
-
-					let closed_share = base_value_to_close.try_div(&maximum_close_value)?;
-					let fee_decimal = closed_share.try_mul(&maximum_fee)?;
-					let requirement_freed =
-						closed_share.try_mul(&info.margin_requirement_partial)?;
-					let realized_pnl = exit_value.try_sub(&entry_value)?;
-
-					fees.try_add_mut(&fee_decimal.into_balance()?)?;
-					collateral =
-						Self::updated_balance(&collateral, &realized_pnl.try_sub(&fee_decimal)?)?;
-					margin.try_sub_mut(&fee_decimal)?;
-					margin_requirement.try_sub_mut(&requirement_freed)?;
-				}
-
-				// No positions are fully closed, so we push all.
-				// AccountSummary::positions_summary isn't constrained to be shorter than the
-				// maximum number of positions, so we keep the error checking here.
-				positions.try_push(position).map_err(|_| Error::<T>::MaxPositionsExceeded)?;
-			}
-
-			// Charge fees
-			let liquidator_fee =
-				Self::partial_liquidation_penalty_liquidator_share().saturating_mul_int(fees);
-			let insurance_fee = fees.try_sub(&liquidator_fee)?;
-
-			Positions::<T>::insert(user_id, positions);
-			Collateral::<T>::insert(user_id, collateral);
-
-			Ok((liquidator_fee, insurance_fee))
-		}
-
-		fn settle_funding(
-			position: &mut Position<T>,
-			market: &Market<T>,
-			margin: &mut T::Balance,
-		) -> Result<(), DispatchError> {
-			if let Some(direction) = position.direction() {
-				let payment = <Self as Instruments>::unrealized_funding(market, position)?;
-				*margin = Self::updated_balance(margin, &payment)?;
-				position.last_cum_funding = market.cum_funding_rate(direction);
-			}
-			Ok(())
-		}
-
-		fn settle_funding_and_outstanding_profits(
-			account_id: &T::AccountId,
-			position: &mut Position<T>,
-			collateral: &mut T::Balance,
-		) -> Result<(), DispatchError> {
-			let mut market = Self::try_get_market(&position.market_id)?;
-
-			if let Some(direction) = position.direction() {
-				let payment = <Self as Instruments>::unrealized_funding(&market, position)?;
-				*collateral = Self::updated_balance(collateral, &payment)?;
-				position.last_cum_funding = market.cum_funding_rate(direction);
-			}
-
-			if !market.available_profits.is_zero() {
-				let mut outstanding_profits =
-					Self::outstanding_profits(account_id, &position.market_id)
-						.unwrap_or_else(Zero::zero);
-				let realizable_profits = cmp::min(outstanding_profits, market.available_profits);
-				collateral.try_add_mut(&realizable_profits)?;
-				outstanding_profits.try_sub_mut(&realizable_profits)?;
-				market.available_profits.try_sub_mut(&realizable_profits)?;
-				OutstandingProfits::<T>::insert(
-					account_id,
-					&position.market_id,
-					outstanding_profits,
-				);
-			}
-
-			Markets::<T>::insert(&position.market_id, market);
-
-			Ok(())
-		}
-	}
-
 	// Helper functions - validity checks
 	impl<T: Config> Pallet<T> {
 		fn check_oracle_guard_rails(
@@ -2246,6 +1914,341 @@ pub mod pallet {
 				.into_balance()?
 				.try_mul(&market.taker_fee)?
 				.try_div(&BASIS_POINT_DENOMINATOR.into())
+		}
+	}
+
+	// Funding helpers
+	impl<T: Config> Pallet<T> {
+		fn try_update_funding(
+			market_id: &T::MarketId,
+			market: &mut Market<T>,
+		) -> Result<(), DispatchError> {
+			let now = T::UnixTime::now().as_secs();
+			if Self::is_funding_update_time(market, now)? {
+				Self::do_update_funding(market_id, market, now)?;
+			}
+			Ok(())
+		}
+
+		fn do_update_funding(
+			market_id: &T::MarketId,
+			market: &mut Market<T>,
+			now: DurationSeconds,
+		) -> Result<(), DispatchError> {
+			// Pay funding
+			// net position sign | funding rate sign | transfer
+			// --------------------------------------------------------------
+			//                -1 |                -1 | Collateral -> Fee Pool
+			//                -1 |                 1 | Fee Pool -> Collateral
+			//                 1 |                -1 | Fee Pool -> Collateral
+			//                 1 |                 1 | Collateral -> Fee Pool
+			//                 - |                 0 | n/a
+			//                 0 |                 - | n/a
+			let net_base_asset_amount =
+				market.base_asset_amount_long.try_add(&market.base_asset_amount_short)?;
+			let funding_rate = <Self as Instruments>::funding_rate(market)?;
+			let mut funding_rate_long = funding_rate;
+			let mut funding_rate_short = funding_rate;
+
+			if !(funding_rate.is_zero() | net_base_asset_amount.is_zero()) {
+				let uncapped_funding = funding_rate.try_mul(&net_base_asset_amount)?;
+				let collateral_account = Self::get_collateral_account();
+				let fee_pool_account = Self::get_fee_pool_account(market_id.clone());
+				let collateral_asset_id = Self::get_collateral_asset_id()?;
+
+				if uncapped_funding.is_positive() {
+					// Fee Pool receives funding
+					T::Assets::transfer(
+						collateral_asset_id,
+						&collateral_account,
+						&fee_pool_account,
+						uncapped_funding.into_balance()?,
+						false,
+					)?;
+				} else {
+					// Fee Pool pays funding
+					// TODO(0xangelo): set limits for
+					// - total Fee Pool usage (reserve some funds for other operations)
+					// - Fee Pool usage for funding payments per call to `update_funding`
+					let usable_fees: T::Decimal =
+						-T::Assets::balance(collateral_asset_id, &fee_pool_account)
+							.into_decimal()?;
+					let mut capped_funding = sp_std::cmp::max(uncapped_funding, usable_fees);
+
+					// Since we're dealing with negatives, we check if the uncapped funding is
+					// *smaller* (greater in absolute terms) than the capped one
+					if capped_funding > uncapped_funding {
+						// Total funding paid to one side is the sum of the funding paid by the
+						// opposite side plus the complement from the Fee Pool
+						let excess;
+						if net_base_asset_amount.is_positive() {
+							let counterparty_funding = usable_fees
+								.try_sub(&funding_rate.try_mul(&market.base_asset_amount_short)?)?;
+							(funding_rate_long, excess) =
+								counterparty_funding.try_div_rem(&market.base_asset_amount_long)?;
+						} else {
+							let counterparty_funding = funding_rate
+								.try_mul(&market.base_asset_amount_long)?
+								.try_sub(&usable_fees)?;
+							(funding_rate_short, excess) = counterparty_funding
+								.try_div_rem(&market.base_asset_amount_short)?;
+						}
+						capped_funding.try_sub_mut(&excess)?;
+					}
+
+					T::Assets::transfer(
+						collateral_asset_id,
+						&fee_pool_account,
+						&collateral_account,
+						capped_funding.into_balance()?,
+						false,
+					)?;
+				};
+			}
+
+			// Update market state
+			market.cum_funding_rate_long.try_add_mut(&funding_rate_long)?;
+			market.cum_funding_rate_short.try_add_mut(&funding_rate_short)?;
+			market.funding_rate_ts = now;
+
+			Self::deposit_event(Event::FundingUpdated { market: market_id.clone(), time: now });
+			Ok(())
+		}
+
+		fn settle_funding(
+			position: &mut Position<T>,
+			market: &Market<T>,
+			margin: &mut T::Balance,
+		) -> Result<(), DispatchError> {
+			if let Some(direction) = position.direction() {
+				let payment = <Self as Instruments>::unrealized_funding(market, position)?;
+				*margin = Self::updated_balance(margin, &payment)?;
+				position.last_cum_funding = market.cum_funding_rate(direction);
+			}
+			Ok(())
+		}
+
+		fn settle_funding_and_outstanding_profits(
+			account_id: &T::AccountId,
+			position: &mut Position<T>,
+			collateral: &mut T::Balance,
+		) -> Result<(), DispatchError> {
+			let mut market = Self::try_get_market(&position.market_id)?;
+
+			if let Some(direction) = position.direction() {
+				let payment = <Self as Instruments>::unrealized_funding(&market, position)?;
+				*collateral = Self::updated_balance(collateral, &payment)?;
+				position.last_cum_funding = market.cum_funding_rate(direction);
+			}
+
+			if !market.available_profits.is_zero() {
+				let mut outstanding_profits =
+					Self::outstanding_profits(account_id, &position.market_id)
+						.unwrap_or_else(Zero::zero);
+				let realizable_profits = cmp::min(outstanding_profits, market.available_profits);
+				collateral.try_add_mut(&realizable_profits)?;
+				outstanding_profits.try_sub_mut(&realizable_profits)?;
+				market.available_profits.try_sub_mut(&realizable_profits)?;
+				OutstandingProfits::<T>::insert(
+					account_id,
+					&position.market_id,
+					outstanding_profits,
+				);
+			}
+
+			Markets::<T>::insert(&position.market_id, market);
+
+			Ok(())
+		}
+	}
+
+	// Liquidation helpers
+	impl<T: Config> Pallet<T> {
+		fn summarize_account_state(
+			account_id: &T::AccountId,
+			positions: BoundedVec<Position<T>, T::MaxPositions>,
+		) -> Result<AccountSummary<T>, DispatchError> {
+			let collateral = Self::get_collateral(account_id).unwrap_or_else(Zero::zero);
+
+			let mut summary = AccountSummary::<T>::new(collateral)?;
+			for position in positions {
+				let market = Self::try_get_market(&position.market_id)?;
+				if let Some(direction) = position.direction() {
+					// should always succeed
+					let (base_asset_value, unrealized_pnl) =
+						Self::abs_position_notional_and_pnl(&market, &position, direction)?;
+
+					let info = PositionInfo::<T> {
+						direction,
+						margin_requirement_maintenance: base_asset_value
+							.try_mul(&market.margin_ratio_maintenance)?,
+						margin_requirement_partial: base_asset_value
+							.try_mul(&market.margin_ratio_partial)?,
+						base_asset_value,
+						unrealized_pnl,
+						unrealized_funding: <Self as Instruments>::unrealized_funding(
+							&market, &position,
+						)?,
+					};
+
+					summary.update(market, position, info)?;
+				}
+			}
+
+			Ok(summary)
+		}
+
+		/// Fully liquidates the user's positions until its account is brought above the MMR.
+		///
+		/// This function does **not** check if the account is below the MMR beforehand.
+		///
+		/// ## Storage modifications
+		///
+		/// - Updates the [`markets`](Markets) of closed positions (according to changes in
+		///   [`Self::close_position_in_market`])
+		/// - Removes closed [`positions`](Positions)
+		/// - Updates the user's account [`collateral`](Collateral)
+		///
+		/// ## Returns
+		///
+		/// The fees for the liquidator and insurance fund
+		fn fully_liquidate_account(
+			user_id: &T::AccountId,
+			summary: AccountSummary<T>,
+		) -> Result<(T::Balance, T::Balance), DispatchError> {
+			let AccountSummary::<T> {
+				mut collateral,
+				mut margin,
+				margin_requirement_maintenance: mut margin_requirement,
+				base_asset_value,
+				mut positions_summary,
+				..
+			} = summary;
+
+			let mut positions = BoundedVec::<Position<T>, T::MaxPositions>::default();
+			let maximum_fee = Self::full_liquidation_penalty().try_mul(&margin)?;
+			let mut fees = T::Balance::zero();
+			// Sort positions from greatest to lowest margin requirement
+			positions_summary.sort_by_key(|(_, _, info)| info.margin_requirement_maintenance.neg());
+			for (mut market, position, info) in positions_summary {
+				if margin < margin_requirement {
+					Self::close_position_in_market(
+						&position,
+						info.direction,
+						&mut market,
+						info.base_asset_value.into_balance()?,
+					)?;
+					Markets::<T>::insert(&position.market_id, market);
+
+					let base_asset_value_share =
+						info.base_asset_value.try_div(&base_asset_value)?;
+					let fee_decimal = base_asset_value_share.try_mul(&maximum_fee)?;
+					margin.try_sub_mut(&fee_decimal)?;
+					margin_requirement.try_sub_mut(&info.margin_requirement_maintenance)?;
+					fees.try_add_mut(&fee_decimal.into_balance()?)?;
+					collateral = Self::updated_balance(
+						&collateral,
+						&info
+							.unrealized_pnl
+							.try_add(&info.unrealized_funding)?
+							.try_sub(&fee_decimal)?,
+					)?;
+				} else {
+					// AccountSummary::positions_summary isn't constrained to be shorter than the
+					// maximum number of positions, so we keep the error checking here.
+					positions.try_push(position).map_err(|_| Error::<T>::MaxPositionsExceeded)?;
+				}
+			}
+
+			// Charge fees
+			let liquidator_fee =
+				Self::full_liquidation_penalty_liquidator_share().saturating_mul_int(fees);
+			let insurance_fee = fees.try_sub(&liquidator_fee)?;
+
+			Positions::<T>::insert(user_id, positions);
+			Collateral::<T>::insert(user_id, collateral);
+
+			Ok((liquidator_fee, insurance_fee))
+		}
+
+		/// Partially liquidates the user's positions until its account is brought above the PMR.
+		///
+		/// This function does **not** check if the account is below the PMR beforehand.
+		///
+		/// ## Storage modifications
+		///
+		/// - Updates the [`markets`](Markets) of decreased positions (according to changes made by
+		///   [`Self::decrease_position`])
+		/// - Updates reduced [`positions`](Positions) (according to changes made by
+		///   [`Self::decrease_position`])
+		/// - Updates the user's account [`collateral`](Collateral)
+		///
+		/// ## Returns
+		///
+		/// The fees for the liquidator and insurance fund
+		fn partially_liquidate_account(
+			user_id: &T::AccountId,
+			summary: AccountSummary<T>,
+		) -> Result<(T::Balance, T::Balance), DispatchError> {
+			let AccountSummary::<T> {
+				mut collateral,
+				mut margin,
+				margin_requirement_partial: mut margin_requirement,
+				base_asset_value,
+				mut positions_summary,
+				..
+			} = summary;
+
+			let mut positions = BoundedVec::<Position<T>, T::MaxPositions>::default();
+			let mut fees = T::Balance::zero();
+			let maximum_fee = Self::partial_liquidation_penalty().try_mul(&margin)?;
+			let close_ratio = Self::partial_liquidation_close_ratio();
+			let maximum_close_value = close_ratio.try_mul(&base_asset_value)?;
+			// Sort positions from greatest to lowest margin requirement
+			positions_summary.sort_by_key(|(_, _, info)| info.margin_requirement_partial.neg());
+			for (mut market, mut position, info) in positions_summary {
+				if margin < margin_requirement {
+					Self::settle_funding(&mut position, &market, &mut collateral)?;
+
+					let base_value_to_close = close_ratio.try_mul(&info.base_asset_value)?;
+					let (_, entry_value, exit_value) = Self::decrease_position(
+						&mut position,
+						&mut market,
+						info.direction.opposite(),
+						&base_value_to_close,
+						Zero::zero(), /* No slippage control is necessary since it was already
+						               * taken into account when computing `base_asset_value` */
+					)?;
+					Markets::<T>::insert(&position.market_id, market);
+
+					let closed_share = base_value_to_close.try_div(&maximum_close_value)?;
+					let fee_decimal = closed_share.try_mul(&maximum_fee)?;
+					let requirement_freed =
+						closed_share.try_mul(&info.margin_requirement_partial)?;
+					let realized_pnl = exit_value.try_sub(&entry_value)?;
+
+					fees.try_add_mut(&fee_decimal.into_balance()?)?;
+					collateral =
+						Self::updated_balance(&collateral, &realized_pnl.try_sub(&fee_decimal)?)?;
+					margin.try_sub_mut(&fee_decimal)?;
+					margin_requirement.try_sub_mut(&requirement_freed)?;
+				}
+
+				// No positions are fully closed, so we push all.
+				// AccountSummary::positions_summary isn't constrained to be shorter than the
+				// maximum number of positions, so we keep the error checking here.
+				positions.try_push(position).map_err(|_| Error::<T>::MaxPositionsExceeded)?;
+			}
+
+			// Charge fees
+			let liquidator_fee =
+				Self::partial_liquidation_penalty_liquidator_share().saturating_mul_int(fees);
+			let insurance_fee = fees.try_sub(&liquidator_fee)?;
+
+			Positions::<T>::insert(user_id, positions);
+			Collateral::<T>::insert(user_id, collateral);
+
+			Ok((liquidator_fee, insurance_fee))
 		}
 	}
 

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -505,7 +505,7 @@ pub mod pallet {
 		/// Attempted to create a new market but either the initial margin ratio is outside (0, 1]
 		/// or the maintenance margin ratio is outside (0, 1).
 		InvalidMarginRatioRequirement,
-		/// Raised when the price returned by the Oracle is zero.
+		/// Raised when the price returned by the Oracle is nonpositive.
 		InvalidOracleReading,
 		/// Raised when querying a market with an invalid or nonexistent market Id.
 		MarketIdNotFound,

--- a/frame/clearing-house/src/lib.rs
+++ b/frame/clearing-house/src/lib.rs
@@ -1147,6 +1147,8 @@ pub mod pallet {
 				);
 			}
 
+			// TODO(0xangelo): attempt funding rate update at end
+
 			// Update storage
 			Collateral::<T>::insert(account_id, collateral);
 			OutstandingProfits::<T>::insert(account_id, market_id, outstanding_profits);

--- a/frame/clearing-house/src/mock/runtime.rs
+++ b/frame/clearing-house/src/mock/runtime.rs
@@ -266,6 +266,7 @@ pub struct ExtBuilder {
 	pub oracle_asset_support: Option<bool>,
 	pub oracle_price: Option<Balance>,
 	pub oracle_twap: Option<Balance>,
+	pub max_price_divergence: Decimal,
 }
 
 impl ExtBuilder {
@@ -282,13 +283,20 @@ impl ExtBuilder {
 			.assimilate_storage(&mut storage)
 			.unwrap();
 
-		clearing_house::GenesisConfig::<Runtime> { collateral_type: self.collateral_type }
-			.assimilate_storage(&mut storage)
-			.unwrap();
+		clearing_house::GenesisConfig::<Runtime> {
+			collateral_type: self.collateral_type,
+			max_price_divergence: self.max_price_divergence,
+		}
+		.assimilate_storage(&mut storage)
+		.unwrap();
 
-		mock_vamm::GenesisConfig::<Runtime> { vamm_id: self.vamm_id, twap: self.vamm_twap }
-			.assimilate_storage(&mut storage)
-			.unwrap();
+		mock_vamm::GenesisConfig::<Runtime> {
+			vamm_id: self.vamm_id,
+			twap: self.vamm_twap,
+			..Default::default()
+		}
+		.assimilate_storage(&mut storage)
+		.unwrap();
 
 		let oracle_genesis = mock_oracle::GenesisConfig {
 			price: self.oracle_price,

--- a/frame/clearing-house/src/mock/vamm.rs
+++ b/frame/clearing-house/src/mock/vamm.rs
@@ -71,12 +71,13 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
 		pub vamm_id: Option<T::VammId>,
+		pub price: Option<T::Decimal>,
 		pub twap: Option<T::Decimal>,
 	}
 
 	impl<T: Config> Default for GenesisConfig<T> {
 		fn default() -> Self {
-			Self { vamm_id: None, twap: Some(T::Decimal::zero()) }
+			Self { vamm_id: None, price: Some(T::Decimal::one()), twap: Some(T::Decimal::one()) }
 		}
 	}
 
@@ -84,6 +85,7 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			NextVammId::<T>::set(self.vamm_id);
+			Price::<T>::set(self.price);
 			Twap::<T>::set(self.twap);
 		}
 	}

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -117,6 +117,8 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_pnl() {
 	});
 }
 
+// TODO(0xangelo): can_partially_liquidate_if_below_partial_margin_ratio_by_funding
+
 #[test]
 fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
 	let config = MarketConfig {

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -11,8 +11,8 @@ use crate::{
 		accounts::{ALICE, BOB},
 		assets::USDC,
 		runtime::{
-			Assets as AssetsPallet, Balance, Oracle as OraclePallet, Origin, Runtime,
-			System as SystemPallet, TestPallet, Vamm as VammPallet,
+			Assets as AssetsPallet, Balance, Origin, Runtime, System as SystemPallet, TestPallet,
+			Vamm as VammPallet,
 		},
 	},
 	tests::set_oracle_twap,

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -117,7 +117,50 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_pnl() {
 	});
 }
 
-// TODO(0xangelo): can_partially_liquidate_if_below_partial_margin_ratio_by_funding
+#[test]
+fn can_partially_liquidate_if_below_partial_margin_ratio_by_funding() {
+	let config = MarketConfig {
+		funding_frequency: 60,
+		funding_period: 60,
+		margin_ratio_initial: (1, 2).into(),       // 2x max leverage
+		margin_ratio_maintenance: (5, 100).into(), // 5% MMR
+		margin_ratio_partial: (7, 100).into(),     // 7% PMR
+		..Default::default()
+	};
+
+	let margins = vec![(ALICE, as_balance(50)), (BOB, 0)];
+	traders_in_one_market_context(config, margins, |market_id| {
+		set_partial_liquidation_close((25, 100).into());
+		set_partial_liquidation_penalty((25, 1000).into());
+		set_liquidator_share_partial((50, 100).into());
+
+		set_oracle_twap(&market_id, 1.into());
+		VammPallet::set_twap(Some(1.into()));
+
+		// Alice opens a position
+		VammPallet::set_price(Some(1.into()));
+		assert_ok!(<TestPallet as ClearingHouse>::open_position(
+			&ALICE,
+			&market_id,
+			Direction::Short,
+			as_balance(100),
+			as_balance(100),
+		));
+
+		run_for_seconds(60);
+		// Time passes and funding rates are updated
+		VammPallet::set_twap(Some(1.into()));
+		// Index price moves against Alice's position
+		set_oracle_twap(&market_id, (145, 100).into());
+		assert_ok!(<TestPallet as ClearingHouse>::update_funding(&market_id));
+		// Alice should now owe 0.44 * 100 = 44 in funding, bringing her account's
+		// margin ratio to slightly below the PMR
+		// - margin requirement = 7
+		// - margin = 50 - 44 = 6
+
+		assert_ok!(TestPallet::liquidate(Origin::signed(BOB), ALICE));
+	});
+}
 
 #[test]
 fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
@@ -161,6 +204,64 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
 		// - margin requirement = 7
 		// - margin = 50 - 43 = 7
 
+		assert_noop!(
+			TestPallet::liquidate(Origin::signed(BOB), ALICE),
+			Error::<Runtime>::SufficientCollateral
+		);
+	});
+}
+
+#[test]
+fn cant_liquidate_if_above_partial_margin_ratio_by_funding_2() {
+	let config = MarketConfig {
+		funding_frequency: 60,
+		funding_period: 60,
+		margin_ratio_initial: (10, 100).into(),     // 10x leverage
+		margin_ratio_maintenance: (4, 100).into(),  // 25x leverage
+		margin_ratio_partial: (625, 10_000).into(), // 16x leverage
+		..Default::default()
+	};
+
+	let margins = vec![(ALICE, as_balance(50)), (BOB, 0)];
+	traders_in_one_market_context(config.clone(), margins, |market_id| {
+		set_partial_liquidation_close((25, 100).into());
+		set_partial_liquidation_penalty((25, 1000).into());
+		set_liquidator_share_partial((50, 100).into());
+
+		set_oracle_twap(&market_id, 100.into());
+		VammPallet::set_twap(Some(100.into()));
+
+		// Alice opens a position
+		VammPallet::set_price(Some(100.into()));
+		assert_ok!(<TestPallet as ClearingHouse>::open_position(
+			&ALICE,
+			&market_id,
+			Direction::Long,
+			as_balance(500),
+			as_balance(5)
+		));
+
+		// Price moves so that Alice's account is below the PMR
+		VammPallet::set_price(Some(95.into()));
+		// 100 -> 95
+		// - margin requirement (partial) = 29.688
+		// - margin requirement (full) = 19
+		// - PnL = 475 - 500 = -25
+		// - margin = 50 - 25 = 25
+
+		// Time passes and funding rates are updated
+		// Index price moves in favor of Alice's position
+		// Alice now has +5 in unrealized funding
+		// funding = -(95 - 96) * 5 = 5
+		// margin = 50 - 25 + 5 = 30
+		run_for_seconds(config.funding_frequency);
+		VammPallet::set_twap(Some(95.into()));
+		set_oracle_twap(&market_id, 96.into());
+		// HACK: pretend the market's Fee Pool has enough funds
+		set_fee_pool_depth(&market_id, as_balance(1_000_000));
+		assert_ok!(<TestPallet as ClearingHouse>::update_funding(&market_id));
+
+		// Bob cannot liquidate Alice's account because she is above the PMR
 		assert_noop!(
 			TestPallet::liquidate(Origin::signed(BOB), ALICE),
 			Error::<Runtime>::SufficientCollateral

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -130,6 +130,7 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
 
 	let margins = vec![(ALICE, as_balance(50)), (BOB, 0)];
 	traders_in_one_market_context(config, margins, |market_id| {
+		set_oracle_twap(&market_id, 1.into());
 		VammPallet::set_price(Some(1.into()));
 
 		// Alice opens a position
@@ -151,7 +152,7 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
 		// Time passes and funding rates are updated
 		VammPallet::set_twap(Some(1.into()));
 		// Index price moves against Alice's position
-		OraclePallet::set_twap(Some(143)); // 100 -> 143 cents
+		set_oracle_twap(&market_id, (143, 100).into());
 		assert_ok!(<TestPallet as ClearingHouse>::update_funding(&market_id));
 		// Alice should now owe 0.43 * 100 = 43 in funding, bringing her account's
 		// margin ratio to exactly the MMR

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -200,7 +200,7 @@ fn cant_liquidate_if_above_partial_margin_ratio_by_funding() {
 		set_oracle_twap(&market_id, (143, 100).into());
 		assert_ok!(<TestPallet as ClearingHouse>::update_funding(&market_id));
 		// Alice should now owe 0.43 * 100 = 43 in funding, bringing her account's
-		// margin ratio to exactly the MMR
+		// margin ratio to exactly the PMR
 		// - margin requirement = 7
 		// - margin = 50 - 43 = 7
 

--- a/frame/clearing-house/src/tests/liquidate.rs
+++ b/frame/clearing-house/src/tests/liquidate.rs
@@ -151,7 +151,7 @@ fn can_partially_liquidate_if_below_partial_margin_ratio_by_funding() {
 		// Time passes and funding rates are updated
 		VammPallet::set_twap(Some(1.into()));
 		// Index price moves against Alice's position
-		set_oracle_twap(&market_id, (145, 100).into());
+		set_oracle_twap(&market_id, (144, 100).into());
 		assert_ok!(<TestPallet as ClearingHouse>::update_funding(&market_id));
 		// Alice should now owe 0.44 * 100 = 44 in funding, bringing her account's
 		// margin ratio to slightly below the PMR

--- a/frame/clearing-house/src/tests/mod.rs
+++ b/frame/clearing-house/src/tests/mod.rs
@@ -14,7 +14,7 @@ use crate::{
 		vamm::VammConfig,
 	},
 	Direction, Market as MarketGeneric, MarketConfig as MarketConfigGeneric, Markets,
-	MaxPriceDivergence,
+	MaxPriceDivergence, MaxTwapDivergence,
 };
 use composable_traits::{
 	clearing_house::{ClearingHouse, Instruments},
@@ -65,6 +65,7 @@ impl Default for ExtBuilder {
 			oracle_asset_support: Some(true),
 			oracle_price: Some(10_000),
 			oracle_twap: Some(10_000),
+			max_price_divergence: FixedI128::from_inner(i128::MAX),
 		}
 	}
 }
@@ -153,6 +154,10 @@ fn set_fee_pool_depth(market_id: &MarketId, depth: Balance) {
 
 fn set_maximum_oracle_mark_divergence(fraction: FixedI128) {
 	MaxPriceDivergence::<Runtime>::set(fraction);
+}
+
+fn set_maximum_twap_divergence(fraction: FixedI128) {
+	MaxTwapDivergence::<Runtime>::set(Some(fraction));
 }
 
 fn set_oracle_price(_market_id: &MarketId, price: FixedU128) {

--- a/frame/clearing-house/src/tests/mod.rs
+++ b/frame/clearing-house/src/tests/mod.rs
@@ -155,9 +155,17 @@ fn set_maximum_oracle_mark_divergence(fraction: FixedI128) {
 	MaxPriceDivergence::<Runtime>::set(fraction);
 }
 
+fn set_oracle_price(_market_id: &MarketId, price: FixedU128) {
+	// let market = get_market(market_id);
+	OraclePallet::set_price(Some(price.saturating_mul_int(100)));
+}
+
 fn set_oracle_twap(market_id: &MarketId, twap: FixedI128) {
+	// Prepare everything so that even if the TWAP is updated via an EMA, it stays the same
+	OraclePallet::set_price(Some(twap.saturating_mul_int(100)));
 	Markets::<Runtime>::try_mutate(market_id, |m| {
 		if let Some(m) = m {
+			m.last_oracle_price = twap;
 			m.last_oracle_twap = twap;
 			Ok(())
 		} else {

--- a/frame/clearing-house/src/tests/update_funding.rs
+++ b/frame/clearing-house/src/tests/update_funding.rs
@@ -8,10 +8,11 @@ use crate::{
 		},
 	},
 	tests::{
-		any_balance, any_price, get_market, get_market_fee_pool, run_for_seconds, run_to_time,
-		set_fee_pool_depth, set_maximum_oracle_mark_divergence, set_maximum_twap_divergence,
-		set_oracle_price, set_oracle_twap, traders_in_one_market_context, with_market_context,
-		with_trading_context, Balance, Market, MarketConfig, Position,
+		any_balance, any_price, as_balance, get_market, get_market_fee_pool, run_for_seconds,
+		run_to_time, set_fee_pool_depth, set_maximum_oracle_mark_divergence,
+		set_maximum_twap_divergence, set_oracle_price, set_oracle_twap,
+		traders_in_one_market_context, with_market_context, with_trading_context, Balance, Market,
+		MarketConfig, Position,
 	},
 	Direction, Error, Event,
 };
@@ -23,8 +24,6 @@ use composable_traits::{
 use frame_support::{assert_noop, assert_ok};
 use proptest::prelude::*;
 use sp_runtime::{FixedI128, FixedU128};
-
-use super::as_balance;
 
 // -------------------------------------------------------------------------------------------------
 //                                             Helpers


### PR DESCRIPTION
## Issue
[CU-225wvg7](https://app.clickup.com/t/225wvg7)

## Description
This PR completes the subtasks of the main ClickUp one, linked above, related to additional validity checks. It includes:
- chore(CH): update TWAPs before funding rate update
- chore(CH): add update_funding price spread guards
- test(CH): adapt to new TWAP update rules
- test(CH): expect TWAP updates in update_funding
- test(CH): try liquidate with unrealized funding
- fix(CH): use proper upper bound when clipping oracle
- fix(CH): set TWAP to current price if needed when updating Oracle TWAP
- fix(CH): clip current oracle price to withing 33% of last TWAP
- refactor(CH): group helpers by main functionality
