### PR TITLE
Change bors timeout to 2 hours

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -10,3 +10,4 @@ status = [
 up_to_date_approvals = true
 update_base_for_deletes = true
 use_codeowners = true
+timeout_sec = 7200


### PR DESCRIPTION
## Issue
Bors timeout is changed to 2 hours due to timing out on some PRs.

## Description
This has changed as per @KaiserKarel suggestion. 

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_