### PR TITLE
Added benchmarks for liquidations pallet

### DIFF
--- a/frame/dutch-auction/src/weights.rs
+++ b/frame/dutch-auction/src/weights.rs
@@ -19,7 +19,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: DutchAuction SellOrders (r:0 w:1)
 	fn ask() -> Weight {
-		(185_212_000 as Weight)
+		(19_571_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -28,7 +28,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: DutchAuction Takes (r:1 w:1)
 	fn take() -> Weight {
-		(140_074_000 as Weight)
+		(14_079_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -36,16 +36,18 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn liquidate() -> Weight {
-		(150_867_000 as Weight)
+		(18_310_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
 	// Storage: DutchAuction Takes (r:2 w:1)
+	// Storage: unknown [0x3a7472616e73616374696f6e5f6c6576656c3a] (r:1 w:1)
 	// Storage: DutchAuction SellOrders (r:1 w:1)
 	// Storage: Tokens Accounts (r:2 w:2)
+	// Storage: DutchAuction LocalOrderIdToRemote (r:1 w:1)
 	fn known_overhead_for_on_finalize() -> Weight {
-		(195_022_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(5 as Weight))
-			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+		(24_104_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(7 as Weight))
+			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}
 }

--- a/frame/dutch-auction/src/weights.rs
+++ b/frame/dutch-auction/src/weights.rs
@@ -13,13 +13,13 @@ pub trait WeightInfo {
 /// Weight functions for `dutch_auction`.
 pub struct SubstrateWeight<T>(PhantomData<T>);
 impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
-	// Storage: DutchAuction OrdersIndex (r:1 w:1)
+// Storage: DutchAuction OrdersIndex (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: DutchAuction SellOrders (r:0 w:1)
 	fn ask() -> Weight {
-		(19_571_000 as Weight)
+		(36_861_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
@@ -28,7 +28,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: DutchAuction Takes (r:1 w:1)
 	fn take() -> Weight {
-		(14_079_000 as Weight)
+		(21_573_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(4 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
@@ -36,7 +36,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	fn liquidate() -> Weight {
-		(18_310_000 as Weight)
+		(32_851_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(3 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
@@ -46,7 +46,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Tokens Accounts (r:2 w:2)
 	// Storage: DutchAuction LocalOrderIdToRemote (r:1 w:1)
 	fn known_overhead_for_on_finalize() -> Weight {
-		(24_104_000 as Weight)
+		(37_495_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(7 as Weight))
 			.saturating_add(T::DbWeight::get().writes(6 as Weight))
 	}

--- a/frame/lending/src/mocks/general.rs
+++ b/frame/lending/src/mocks/general.rs
@@ -348,7 +348,7 @@ impl pallet_liquidations::Config for Runtime {
 	type LiquidationStrategyId = LiquidationStrategyId;
 	type OrderId = OrderId;
 	type PalletId = LiquidationsPalletId;
-	type WeightInfo = ();
+	type WeightInfo = pallet_liquidations::weights::SubstrateWeight<Self>;
 	type CanModifyStrategies = EnsureRoot<Self::AccountId>;
 	type XcmSender = XcmFake;
 	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;

--- a/frame/lending/src/mocks/offchain.rs
+++ b/frame/lending/src/mocks/offchain.rs
@@ -358,7 +358,7 @@ impl pallet_liquidations::Config for Runtime {
 	type LiquidationStrategyId = LiquidationStrategyId;
 	type OrderId = OrderId;
 	type PalletId = LiquidationsPalletId;
-	type WeightInfo = ();
+	type WeightInfo = pallet_liquidations::weights::SubstrateWeight<Self>;
 	type CanModifyStrategies = EnsureRoot<Self::AccountId>;
 	type XcmSender = XcmFake;
 	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;

--- a/frame/liquidations/Cargo.toml
+++ b/frame/liquidations/Cargo.toml
@@ -19,6 +19,7 @@ package = "parity-scale-codec"
 version = "3.0.0"
 
 [dependencies]
+log = "0.4"
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 frame-system = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
@@ -28,7 +29,10 @@ sp-core = { default-features = false, git = "https://github.com/paritytech/subst
 sp-io = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
-
+pallet-assets = { default-features = false, path = "../assets" }
+orml-tokens = { default-features = false, git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "f709ed62262435b3ad80482d309e3575625d1e5b" }
+pallet-dutch-auction = { default-features = false, path = "../dutch-auction" }
+pallet-balances = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.22" }
 composable-support = { path = "../composable-support", default-features = false }
 composable-traits = { path = "../composable-traits", default-features = false }
 
@@ -69,6 +73,7 @@ std = [
   "scale-info/std",
   "xcm/std",
   "cumulus-pallet-xcm/std",
+  "frame-benchmarking/std",
 ]
 
 runtime-benchmarks = [
@@ -76,4 +81,6 @@ runtime-benchmarks = [
   "frame-benchmarking",
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
+  "pallet-assets/runtime-benchmarks",
+  "pallet-dutch-auction/runtime-benchmarks",
 ]

--- a/frame/liquidations/src/benchmarking.rs
+++ b/frame/liquidations/src/benchmarking.rs
@@ -3,47 +3,64 @@ use crate::Pallet as Liquidations;
 use codec::Decode;
 use composable_traits::{
 	defi::{CurrencyPair, DeFiComposableConfig, Ratio, Sell},
-	liquidation::Liquidation,
+	time::{LinearDecrease, TimeReleaseFunction},
 };
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::{fungibles::Mutate, Currency, Get, Hooks};
-use frame_system::{pallet_prelude::BlockNumberFor, RawOrigin};
-use sp_runtime::FixedPointNumber;
+use frame_support::traits::{fungible::Inspect, fungibles::Mutate, Currency, Get};
+use frame_system::RawOrigin;
+use sp_runtime::{
+	traits::{AccountIdConversion, Saturating},
+	FixedPointNumber,
+};
 use sp_std::prelude::*;
-
 pub type AssetIdOf<T> = <T as DeFiComposableConfig>::MayBeAssetId;
 fn assets<T>() -> CurrencyPair<AssetIdOf<T>>
 where
 	T: Config,
 {
 	let a = 1_u128.to_be_bytes();
-	let b = 2_u128.to_be_bytes();
+	let b = 129_u128.to_be_bytes();
 	CurrencyPair::new(
 		AssetIdOf::<T>::decode(&mut &a[..]).unwrap(),
 		AssetIdOf::<T>::decode(&mut &b[..]).unwrap(),
 	)
 }
 
-// meaningless sell of 1 to 1
-pub fn sell_identity<T: Config>(
-) -> Sell<<T as DeFiComposableConfig>::MayBeAssetId, <T as DeFiComposableConfig>::Balance> {
-	let one: <T as DeFiComposableConfig>::Balance = 1_u64.into();
-	let pair = assets::<T>();
-	Sell::new(pair.base, pair.quote, one, Ratio::saturating_from_integer(one))
-}
-
 benchmarks! {
+	where_clause {
+		where
+			T: pallet_assets::Config + DeFiComposableConfig + orml_tokens::Config + pallet_balances::Config + pallet_dutch_auction::Config,
+			<T as orml_tokens::Config>::CurrencyId: From<<T as DeFiComposableConfig>::MayBeAssetId>,
+			<T as pallet_dutch_auction::Config>::NativeCurrency: Currency<T::AccountId>,
+				}
+
 	add_liquidation_strategy {
-		let sell = sell_identity::<T>();
-		let account_id : T::AccountId = whitelisted_caller();
-		let caller = RawOrigin::Signed(account_id.clone());
-		let amount = 100;
-		}: {
-		<Liquidations::<T> as Liquidation>::liquidate(
-				&account_id,
-				sell,
-				vec![])
-			}
+		// Only root allowed to add new strategies.
+		let origin = RawOrigin::Root;
+		let config = LiquidationStrategyConfiguration::DutchAuction(
+				TimeReleaseFunction::LinearDecrease(LinearDecrease { total: 10 * 60 }),
+			);
+		}: _(origin, config)
+
+   sell {
+		let pair = assets::<T>();
+		let one: <T as DeFiComposableConfig>::Balance = 1u32.into();
+		let order = Sell::new(pair.base, pair.quote, one, Ratio::saturating_from_integer(one));
+		let caller: T::AccountId = whitelisted_caller();
+		let origin = RawOrigin::Signed(caller.clone());
+		let root_origin = RawOrigin::<T::AccountId>::Root;
+		let config = LiquidationStrategyConfiguration::DutchAuction(
+				TimeReleaseFunction::LinearDecrease(LinearDecrease { total: 10 * 60 }),
+		);
+		Liquidations::<T>::add_liquidation_strategy(root_origin.clone().into(), config.clone()).unwrap();
+		let native_token_amount = <<T as pallet_dutch_auction::Config>::NativeCurrency as Currency<T::AccountId>>::minimum_balance().saturating_mul(1_000_000_000u32.into());
+		<<T as pallet_dutch_auction::Config>::NativeCurrency as Currency<T::AccountId>>::make_free_balance_be(&caller, native_token_amount);
+		orml_tokens::Pallet::<T>::mint_into(order.pair.base.into(), &caller, 1_000_000u32.into()).unwrap();
+		let begin = 1000;
+		let end = begin + <T as Config>::MaxLiquidationStrategiesAmount::get() - 1;
+		let mut configurations:Vec<T::LiquidationStrategyId> = (begin..end).map(|x| x.into()).collect();
+		configurations.push(1.into());
+		   }: _(origin, order, configurations)
 }
 
 impl_benchmark_test_suite!(

--- a/frame/liquidations/src/benchmarking.rs
+++ b/frame/liquidations/src/benchmarking.rs
@@ -6,10 +6,10 @@ use composable_traits::{
 	time::{LinearDecrease, TimeReleaseFunction},
 };
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite, whitelisted_caller};
-use frame_support::traits::{fungible::Inspect, fungibles::Mutate, Currency, Get};
+use frame_support::traits::{fungibles::Mutate, Currency, Get};
 use frame_system::RawOrigin;
 use sp_runtime::{
-	traits::{AccountIdConversion, Saturating},
+	traits::Saturating,
 	FixedPointNumber,
 };
 use sp_std::prelude::*;
@@ -43,6 +43,7 @@ benchmarks! {
 		}: _(origin, config)
 
    sell {
+		let x in 1..<T as Config>::MaxLiquidationStrategiesAmount::get() - 1;
 		let pair = assets::<T>();
 		let one: <T as DeFiComposableConfig>::Balance = 1u32.into();
 		let order = Sell::new(pair.base, pair.quote, one, Ratio::saturating_from_integer(one));
@@ -57,7 +58,7 @@ benchmarks! {
 		<<T as pallet_dutch_auction::Config>::NativeCurrency as Currency<T::AccountId>>::make_free_balance_be(&caller, native_token_amount);
 		orml_tokens::Pallet::<T>::mint_into(order.pair.base.into(), &caller, 1_000_000u32.into()).unwrap();
 		let begin = 1000;
-		let end = begin + <T as Config>::MaxLiquidationStrategiesAmount::get() - 1;
+		let end = begin + x;
 		let mut configurations:Vec<T::LiquidationStrategyId> = (begin..end).map(|x| x.into()).collect();
 		configurations.push(1.into());
 		   }: _(origin, order, configurations)

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -151,7 +151,7 @@ pub mod pallet {
 			Ok(().into())
 		}
 
-		#[pallet::weight(T::WeightInfo::sell())]
+		#[pallet::weight(T::WeightInfo::sell(configuration.len() as u32))]
 		pub fn sell(
 			origin: OriginFor<T>,
 			order: Sell<T::MayBeAssetId, T::Balance>,

--- a/frame/liquidations/src/lib.rs
+++ b/frame/liquidations/src/lib.rs
@@ -38,7 +38,7 @@ mod mock;
 
 #[cfg(test)]
 mod tests;
-mod weights;
+pub mod weights;
 
 pub use crate::weights::WeightInfo;
 
@@ -100,7 +100,8 @@ pub mod pallet {
 			+ MaxEncodedLen
 			+ WrappingNext
 			+ Parameter
-			+ Copy;
+			+ Copy
+			+ From<u32>;
 
 		type OrderId: Default + FullCodec + MaxEncodedLen + sp_std::fmt::Debug;
 
@@ -266,7 +267,7 @@ pub mod pallet {
 				configuration
 					.try_push(DefaultStrategyIndex::<T>::get())
 					.map_err(|()| Error::<T>::InvalidLiquidationStrategiesVector)?;
-			};			
+			};
 			for id in configuration {
 				let configuration = Strategies::<T>::get(id);
 				if let Some(configuration) = configuration {

--- a/frame/liquidations/src/mock/runtime.rs
+++ b/frame/liquidations/src/mock/runtime.rs
@@ -1,6 +1,7 @@
 use crate::{
 	self as pallet_liquidations,
 	mock::currency::{CurrencyId, NativeAssetId},
+	weights::SubstrateWeight,
 };
 
 use composable_traits::defi::DeFiComposableConfig;
@@ -240,7 +241,7 @@ impl pallet_liquidations::Config for Runtime {
 	type Event = Event;
 	type UnixTime = Timestamp;
 	type OrderId = OrderId;
-	type WeightInfo = ();
+	type WeightInfo = SubstrateWeight<Self>;
 	type DutchAuction = DutchAuction;
 	type LiquidationStrategyId = LiquidationStrategyId;
 	type PalletId = LiquidationPalletId;

--- a/frame/liquidations/src/weights.rs
+++ b/frame/liquidations/src/weights.rs
@@ -1,17 +1,35 @@
-use frame_support::dispatch::Weight;
+#![allow(unused_parens)]
+#![allow(unused_imports)]
+#![allow(trivial_numeric_casts)]
+#![allow(clippy::unnecessary_cast)]
+
+use frame_support::{pallet_prelude::Weight, traits::Get};
+use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
-	fn liquidate() -> Weight {
-		10_000
-	}
-
-	fn add_liquidation_strategy() -> Weight {
-		10_000
-	}
-
-	fn sell() -> Weight {
-		10_000
-	}
+	fn add_liquidation_strategy() -> Weight;
+	fn sell() -> Weight;
 }
 
-impl WeightInfo for () {}
+/// Weight functions for `liquidations`.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	// Storage: Liquidations StrategyIndex (r:1 w:1)
+	// Storage: Liquidations Strategies (r:0 w:1)
+	fn add_liquidation_strategy() -> Weight {
+		(1_493_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: Liquidations Strategies (r:10 w:0)
+	// Storage: DutchAuction OrdersIndex (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: Timestamp Now (r:1 w:0)
+	// Storage: Tokens Accounts (r:1 w:1)
+	// Storage: DutchAuction SellOrders (r:0 w:1)
+	fn sell() -> Weight {
+		(33_349_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(14 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
+	}
+}

--- a/frame/liquidations/src/weights.rs
+++ b/frame/liquidations/src/weights.rs
@@ -8,7 +8,7 @@ use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
 	fn add_liquidation_strategy() -> Weight;
-	fn sell() -> Weight;
+	fn sell(vector_length: u32) -> Weight;
 }
 
 /// Weight functions for `liquidations`.
@@ -17,19 +17,22 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Liquidations StrategyIndex (r:1 w:1)
 	// Storage: Liquidations Strategies (r:0 w:1)
 	fn add_liquidation_strategy() -> Weight {
-		(1_493_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(1))
+		(3_127_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
 			.saturating_add(T::DbWeight::get().writes(2 as Weight))
 	}
-	// Storage: Liquidations Strategies (r:10 w:0)
+	// Storage: Liquidations Strategies (r:2 w:0)
 	// Storage: DutchAuction OrdersIndex (r:1 w:1)
 	// Storage: System Account (r:1 w:1)
 	// Storage: Timestamp Now (r:1 w:0)
 	// Storage: Tokens Accounts (r:1 w:1)
 	// Storage: DutchAuction SellOrders (r:0 w:1)
-	fn sell() -> Weight {
-		(33_349_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(14 as Weight))
+	fn sell(x: u32, ) -> Weight {
+		(43_980_000 as Weight)
+			// Standard Error: 27_000
+			.saturating_add((1_758_000 as Weight).saturating_mul(x as Weight))
+			.saturating_add(T::DbWeight::get().reads(5 as Weight))
+			.saturating_add(T::DbWeight::get().reads((1 as Weight).saturating_mul(x as Weight)))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 }

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -973,6 +973,7 @@ pub type OrderId = u128;
 
 parameter_types! {
 	pub const LiquidationsPalletId: PalletId = PalletId(*b"liqdatns");
+	pub const MaxLiquidationStrategiesAmount: u32 = 10;
 }
 
 impl liquidations::Config for Runtime {
@@ -985,6 +986,7 @@ impl liquidations::Config for Runtime {
 	type PalletId = LiquidationsPalletId;
 	type CanModifyStrategies = EnsureRootOrHalfCouncil;
 	type XcmSender = XcmRouter;
+	type MaxLiquidationStrategiesAmount = MaxLiquidationStrategiesAmount;
 }
 
 parameter_types! {

--- a/runtime/dali/src/weights/liquidations.rs
+++ b/runtime/dali/src/weights/liquidations.rs
@@ -30,10 +30,22 @@ use sp_std::marker::PhantomData;
 /// Weight functions for `liquidations`.
 pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> liquidations::WeightInfo for WeightInfo<T> {
-	// Storage: Liquidations DefaultStrategyIndex (r:1 w:0)
-	// Storage: Liquidations Strategies (r:1 w:0)
+	// Storage: Liquidations StrategyIndex (r:1 w:1)
+	// Storage: Liquidations Strategies (r:0 w:1)
 	fn add_liquidation_strategy() -> Weight {
-		(7_727_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(2 as Weight))
+		(1_493_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(1 as Weight))
+			.saturating_add(T::DbWeight::get().writes(2 as Weight))
+	}
+	// Storage: Liquidations Strategies (r:10 w:0)
+	// Storage: DutchAuction OrdersIndex (r:1 w:1)
+	// Storage: System Account (r:1 w:1)
+	// Storage: Timestamp Now (r:1 w:0)
+	// Storage: Tokens Accounts (r:1 w:1)
+	// Storage: DutchAuction SellOrders (r:0 w:1)
+	fn sell() -> Weight {
+		(33_349_000 as Weight)
+			.saturating_add(T::DbWeight::get().reads(14 as Weight))
+			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
 }


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/32b5019

## Description
Halborn report:

> The liquidations pallet defines a sell function responsible for creating a Dutch Auction for Liquidating a position. The weight associated with calling this extrinsic is a constant value of 10000. Such configuration is invalid, as the sell function accepts a Vector as a parameter, which length is controlled by the user. Two issues originate from this fact. The first one is that regardless of the Vector size, the extrinsic will have a constant weight and would always be perceived as filling a constant space in the block. The second one is related to fees associated with calling the extrinsic. Currently, the sell function is internally creating a Dutch Auction. Anyone can call the sell auction, similarly to the fact that anyone can create their own Dutch Auction via the dutch-auction pallet. There is a correlation between weights and fees. With the current weight configuration for the sell function, it is cheaper to create a Dutch Auction via the liquidations pallet rather than via the dutch-auction itself. The prerequisite for this is that there is already a desired configuration defined in the liquidations pallet.

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_