### PR TITLE
xcvm: comments on protobuf is not ideal

### DIFF
--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -50,6 +50,9 @@ message Account {
 }
 
 message U128 {
+  // minimums:
+  // bytes - 1 byte type + 1 byte length + 1 byte value, but not 7 bit encoded, so always 2+ bytes (more than 65535 tokens)
+  // low + high - 2 byte types + 2 bytes values
   uint64 low = 1;
   uint64 high = 2;
 }

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -4,7 +4,9 @@ package xcvm;
 
 message Program {
   // as of now there is only linear interpreter with no fields dependencies
-  // so because of protocol specificaiton 2 can be in message because of 1
+  // so because of protocol specificaiton 2 can be in message because of 1.
+  // also specification does not guarantess field is represented only once,
+  // so it can repeat it - so please pick implementations which proven not doing it 
   Instructions instructions = 1;
   bytes tag = 2;
 }

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -2,20 +2,18 @@ syntax = "proto3";
 
 package xcvm;
 
+/// proto buf tells that
+/// - any repeated field can be intemingled with not not, e.g. `asset A, account, asset B`can happen
+/// - also can happend repeats, which are really not, exampeles `transfer, transfer` and `asset A, asset A`
+/// so proto are not enforce inter field order niether exact once by specfication,
+/// so that should be specified on XCVM compatible protocol to use proper protoc
+
 message Program {
-  // as of now there is only linear interpreter with no fields dependencies
-  // so because of protocol specificaiton 2 can be in message because of 1.
-  // also specification does not guarantess field is represented only once,
-  // so it can repeat it - so please pick implementations which proven not doing it 
-  // generally, specification of protobuf is not hash fiendly
   Instructions instructions = 1;
   bytes tag = 2;
 }
 
 message Instructions {
-  // do not add new fields into this message if there is desire to change message execution 
-  // because of possible reoreder and intermingling of repeated fields with other fields.
-  // also please pick only implementation which do not reorded repeated, as specificaion does not enforces to do that 
   repeated Instruction instructions = 1;
 }
 
@@ -48,7 +46,8 @@ message Account {
 }
 
 message U128 {
-  bytes encoded = 1;
+  uint64 low = 1;
+  uint64 high = 2;
 }
 
 message Amount {
@@ -62,6 +61,6 @@ message Fixed {
   U128 amount = 1;
 }
 
-message Ratio {
-  uint32 value = 1;
+message Ratio {  
+  uint32 numerator = 1;
 }

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 
 package xcvm;
 
-/// proto buf tells that
-/// - any repeated field can be intemingled with not not, e.g. `asset A, account, asset B`can happen
-/// - also can happend repeats, which are really not, exampeles `transfer, transfer` and `asset A, asset A`
-/// so proto are not enforce inter field order niether exact once by specfication,
+/// protobuf encoding spec tells that:
+/// - any repeated field can be intremingled with other, e.g. `asset A, account, asset B`can happen
+/// - also can happend repeats for singular fields, examples `transfer 1, transfer 1` and `asset A, asset A`
+/// so proto are not enforce inter field order neither exact once by specfication,
 /// so that should be specified on XCVM compatible protocol to use proper protoc
 
 message Program {

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -3,11 +3,16 @@ syntax = "proto3";
 package xcvm;
 
 message Program {
+  // as of now there is only linear interpreter with no fields dependencies
+  // so because of protocol specificaiton 2 can be in message because of 1
   Instructions instructions = 1;
   bytes tag = 2;
 }
 
 message Instructions {
+  // do not add new fields into this message if there is desire to change message execution 
+  // because of possible reoreder and intermingling of repeated fields with other fields.
+  // also please pick only implementation which do not reorded repeated, as specificaion does not enforces to do that 
   repeated Instruction instructions = 1;
 }
 

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -7,6 +7,7 @@ message Program {
   // so because of protocol specificaiton 2 can be in message because of 1.
   // also specification does not guarantess field is represented only once,
   // so it can repeat it - so please pick implementations which proven not doing it 
+  // generally, specification of protobuf is not hash fiendly
   Instructions instructions = 1;
   bytes tag = 2;
 }

--- a/lib/xcvm/protobuf/src/xcvm.proto
+++ b/lib/xcvm/protobuf/src/xcvm.proto
@@ -27,7 +27,11 @@ message Instruction {
 
 message Transfer {
   Account destination = 1;
-  map<uint32, Amount> assets = 2;
+  Assets assets = 2;
+}
+
+message Assets {
+  map<uint32, Amount> assets = 1;
 }
 
 message Call {
@@ -37,7 +41,7 @@ message Call {
 message Spawn {
   uint32 network = 1;
   bytes salt = 2;
-  map<uint32, Amount> assets = 3;
+  Assets assets = 3;
   Program program = 4;
 }
 


### PR DESCRIPTION
for ordered execution and hashing of programs as per spec

Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>