### PR TITLE
add beneficiary to NewOffer event

### DIFF
--- a/frame/bonded-finance/src/lib.rs
+++ b/frame/bonded-finance/src/lib.rs
@@ -94,7 +94,7 @@ pub mod pallet {
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
 		/// A new offer has been created.
-		NewOffer { offer_id: T::BondOfferId },
+		NewOffer { offer_id: T::BondOfferId, beneficiary: AccountIdOf<T> },
 		/// A new bond has been registered.
 		NewBond { offer_id: T::BondOfferId, who: AccountIdOf<T>, nb_of_bonds: BalanceOf<T> },
 		/// An offer has been cancelled by the `AdminOrigin`.
@@ -310,7 +310,7 @@ pub mod pallet {
 				keep_alive,
 			)?;
 			BondOffers::<T>::insert(offer_id, (from.clone(), offer));
-			Self::deposit_event(Event::<T>::NewOffer { offer_id });
+			Self::deposit_event(Event::<T>::NewOffer { offer_id, beneficiary: from.clone() });
 			Ok(offer_id)
 		}
 

--- a/frame/bonded-finance/src/tests.rs
+++ b/frame/bonded-finance/src/tests.rs
@@ -59,7 +59,7 @@ proptest! {
 					  prop_assert_ok!(offer_id);
 					  let offer_id = offer_id.expect("impossible; qed");
 
-					  System::assert_last_event(Event::BondedFinance(crate::Event::NewOffer{ offer_id }));
+					  System::assert_last_event(Event::BondedFinance(crate::Event::NewOffer{ offer_id, beneficiary: ALICE }));
 					  Ok(())
 			  })?;
 	  }


### PR DESCRIPTION
## Issue
https://github.com/ComposableFi/composable/pull/1220#discussion_r912929099

## Description
Need to get bond beneficiary from every `NewOffer` event, to be able to include it on Subsquid