### PR TITLE
Instrumental pallet: tests helpers

### DIFF
--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -53,6 +53,7 @@ std = [
     "log/std",
     "orml-tokens/std",
     "orml-traits/std",
+    "pallet-balances/std",
     "primitives/std",
     "scale-info/std",
     "serde/std",

--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -54,6 +54,7 @@ std = [
     "orml-tokens/std",
     "orml-traits/std",
     "pallet-balances/std",
+    "pallet-pablo/std",
     "pallet-vault/std",
     "primitives/std",
     "scale-info/std",

--- a/frame/instrumental-strategy-pablo/Cargo.toml
+++ b/frame/instrumental-strategy-pablo/Cargo.toml
@@ -54,6 +54,7 @@ std = [
     "orml-tokens/std",
     "orml-traits/std",
     "pallet-balances/std",
+    "pallet-vault/std",
     "primitives/std",
     "scale-info/std",
     "serde/std",

--- a/frame/instrumental-strategy-pablo/src/lib.rs
+++ b/frame/instrumental-strategy-pablo/src/lib.rs
@@ -366,14 +366,14 @@ pub mod pallet {
 		) -> DispatchResult {
 			let lp_token_amount = T::Pablo::amount_of_lp_token_for_added_liquidity(
 				pool_id,
-				T::Balance::zero(),
 				balance,
+				T::Balance::zero(),
 			)?;
 			T::Pablo::add_liquidity(
 				&vault_account,
 				pool_id,
-				T::Balance::zero(),
 				balance,
+				T::Balance::zero(),
 				lp_token_amount,
 				true,
 			)

--- a/frame/instrumental-strategy-pablo/src/mock/account_id.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/account_id.rs
@@ -1,29 +1,23 @@
 use hex_literal::hex;
+use proptest::strategy::Just;
 use sp_core::sr25519::{Public, Signature};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
-pub static ADMIN: Public =
+pub const ADMIN: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000000"));
-pub static ALICE: Public =
+pub const ALICE: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000001"));
-pub static BOB: Public =
+pub const BOB: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000002"));
-pub static CHARLIE: Public =
+pub const CHARLIE: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000003"));
-pub static DAVE: Public =
+pub const DAVE: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000004"));
-pub static EVEN: Public =
+pub const EVEN: AccountId =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000005"));
 
-use proptest::{
-	prop_oneof,
-	strategy::{Just, Strategy},
-};
-
-// TODO(saruman9): will be used in the future
-#[allow(dead_code)]
-pub fn pick_account() -> impl Strategy<Value = AccountId> {
-	prop_oneof![Just(ALICE), Just(BOB), Just(CHARLIE), Just(DAVE), Just(EVEN),]
+pub const fn accounts() -> [Just<AccountId>; 5] {
+	[Just(ALICE), Just(BOB), Just(CHARLIE), Just(DAVE), Just(EVEN)]
 }

--- a/frame/instrumental-strategy-pablo/src/mock/helpers.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/helpers.rs
@@ -14,18 +14,21 @@ use crate::mock::{
 	runtime::{Balance, BlockNumber, Pablo, PoolId, Tokens},
 };
 
-pub fn create_pool<A, B, P>(
-	base_asset: A,
-	base_amount: B,
-	quote_asset: A,
-	quote_amount: B,
-	fee: P,
-	base_weight: P,
+pub fn create_pool<BAS, BAM, QAS, QAM, F, BW>(
+	base_asset: BAS,
+	base_amount: BAM,
+	quote_asset: QAS,
+	quote_amount: QAM,
+	fee: F,
+	base_weight: BW,
 ) -> PoolId
 where
-	A: Into<Option<CurrencyId>>,
-	B: Into<Option<Balance>>,
-	P: Into<Option<Permill>>,
+	BAS: Into<Option<CurrencyId>>,
+	QAS: Into<Option<CurrencyId>>,
+	BAM: Into<Option<Balance>>,
+	QAM: Into<Option<Balance>>,
+	F: Into<Option<Permill>>,
+	BW: Into<Option<Permill>>,
 {
 	let base_asset = base_asset.into().unwrap_or(CurrencyId::LAYR);
 	let base_amount = base_amount.into().unwrap_or(1_000_000_000);

--- a/frame/instrumental-strategy-pablo/src/mock/helpers.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/helpers.rs
@@ -35,7 +35,7 @@ where
 	let base_amount = base_amount.into().unwrap_or(default_amount);
 	let quote_asset = quote_asset.into().unwrap_or(CurrencyId::CROWD_LOAN);
 	let quote_amount = quote_amount.into().unwrap_or(default_amount);
-	let fee = fee.into().unwrap_or_else(|| Permill::zero());
+	let fee = fee.into().unwrap_or_else(Permill::zero);
 	let base_weight = base_weight.into().unwrap_or_else(|| Permill::from_percent(50));
 
 	assert_ok!(Tokens::mint_into(base_asset, &ALICE, base_amount));
@@ -77,7 +77,7 @@ where
 	P: Into<Option<Perquintill>>,
 {
 	let asset_id = asset_id.into().unwrap_or(CurrencyId::LAYR);
-	let percent_deployable = percent_deployable.into().unwrap_or(Perquintill::zero());
+	let percent_deployable = percent_deployable.into().unwrap_or_else(Perquintill::zero);
 	let config = InstrumentalVaultConfig { asset_id, percent_deployable };
 	let vault_id = <Instrumental as InstrumentalTrait>::create(config);
 	assert_ok!(vault_id);

--- a/frame/instrumental-strategy-pablo/src/mock/helpers.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/helpers.rs
@@ -72,8 +72,8 @@ where
 	A: Into<Option<CurrencyId>>,
 	P: Into<Option<Perquintill>>,
 {
-	let asset_id = asset_id.into().unwrap_or_default();
-	let percent_deployable = percent_deployable.into().unwrap_or_default();
+	let asset_id = asset_id.into().unwrap_or(CurrencyId::LAYR);
+	let percent_deployable = percent_deployable.into().unwrap_or(Perquintill::zero());
 	let config = InstrumentalVaultConfig { asset_id, percent_deployable };
 	let vault_id = <Instrumental as InstrumentalTrait>::create(config);
 	assert_ok!(vault_id);

--- a/frame/instrumental-strategy-pablo/src/mock/helpers.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/helpers.rs
@@ -1,9 +1,14 @@
-use composable_traits::{defi::CurrencyPair, dex::Amm};
+use composable_traits::{
+	defi::CurrencyPair,
+	dex::Amm,
+	instrumental::{Instrumental as InstrumentalTrait, InstrumentalVaultConfig},
+};
 use frame_support::{assert_ok, traits::fungibles::Mutate};
 use pallet_pablo::PoolInitConfiguration;
 use primitives::currency::CurrencyId;
-use sp_runtime::Permill;
+use sp_runtime::{Permill, Perquintill};
 
+use super::runtime::{Instrumental, VaultId};
 use crate::mock::{
 	account_id::{AccountId, ALICE, BOB},
 	runtime::{Balance, BlockNumber, Pablo, PoolId, Tokens},
@@ -40,4 +45,17 @@ fn create_pool(
 	));
 	assert_ok!(<Pablo as Amm>::add_liquidity(&BOB, pool_id, amounts[0], amounts[1], 0_u128, true));
 	pool_id
+}
+
+pub fn create_vault<A, P>(asset_id: A, percent_deployable: P) -> VaultId
+where
+	A: Into<Option<CurrencyId>>,
+	P: Into<Option<Perquintill>>,
+{
+	let asset_id = asset_id.into().unwrap_or_default();
+	let percent_deployable = percent_deployable.into().unwrap_or_default();
+	let config = InstrumentalVaultConfig { asset_id, percent_deployable };
+	let vault_id = <Instrumental as InstrumentalTrait>::create(config);
+	assert_ok!(vault_id);
+	vault_id.unwrap()
 }

--- a/frame/instrumental-strategy-pablo/src/mock/helpers.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/helpers.rs
@@ -30,10 +30,11 @@ where
 	F: Into<Option<Permill>>,
 	BW: Into<Option<Permill>>,
 {
+	let default_amount = 1_000_000_000 * CurrencyId::unit::<Balance>();
 	let base_asset = base_asset.into().unwrap_or(CurrencyId::LAYR);
-	let base_amount = base_amount.into().unwrap_or(1_000_000_000);
+	let base_amount = base_amount.into().unwrap_or(default_amount);
 	let quote_asset = quote_asset.into().unwrap_or(CurrencyId::CROWD_LOAN);
-	let quote_amount = quote_amount.into().unwrap_or(1_000_000_000);
+	let quote_amount = quote_amount.into().unwrap_or(default_amount);
 	let fee = fee.into().unwrap_or_else(|| Permill::zero());
 	let base_weight = base_weight.into().unwrap_or_else(|| Permill::from_percent(50));
 

--- a/frame/instrumental-strategy-pablo/src/mock/runtime.rs
+++ b/frame/instrumental-strategy-pablo/src/mock/runtime.rs
@@ -1,4 +1,8 @@
-use frame_support::{parameter_types, traits::Everything, PalletId};
+use frame_support::{
+	parameter_types,
+	traits::{Everything, GenesisBuild},
+	PalletId,
+};
 use frame_system::{EnsureRoot, EnsureSigned};
 use orml_traits::parameter_type_with_key;
 use primitives::currency::CurrencyId;
@@ -21,6 +25,7 @@ pub type VaultId = u64;
 
 pub const MILLISECS_PER_BLOCK: u64 = 12000;
 pub const MAX_ASSOCIATED_VAULTS: u32 = 10;
+const NATIVE_ASSET: CurrencyId = CurrencyId::PICA;
 
 // -------------------------------------------------------------------------------------------------
 //                                              Config
@@ -187,7 +192,7 @@ impl pallet_governance_registry::Config for MockRuntime {
 // -------------------------------------------------------------------------------------------------
 
 parameter_types! {
-	pub const NativeAssetId: CurrencyId = CurrencyId::PICA;
+	pub const NativeAssetId: CurrencyId = NATIVE_ASSET;
 }
 
 impl pallet_assets::Config for MockRuntime {
@@ -327,12 +332,38 @@ frame_support::construct_runtime!(
 // -------------------------------------------------------------------------------------------------
 
 #[derive(Default)]
-pub struct ExtBuilder {}
+pub struct ExtBuilder {
+	native_balances: Vec<(AccountId, Balance)>,
+	balances: Vec<(AccountId, CurrencyId, Balance)>,
+}
 
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
-		let t = frame_system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
+		let mut storage =
+			frame_system::GenesisConfig::default().build_storage::<MockRuntime>().unwrap();
 
-		t.into()
+		pallet_balances::GenesisConfig::<MockRuntime> { balances: self.native_balances }
+			.assimilate_storage(&mut storage)
+			.unwrap();
+
+		orml_tokens::GenesisConfig::<MockRuntime> { balances: self.balances }
+			.assimilate_storage(&mut storage)
+			.unwrap();
+
+		storage.into()
+	}
+
+	pub fn initialize_balance(
+		mut self,
+		user: AccountId,
+		asset: CurrencyId,
+		balance: Balance,
+	) -> ExtBuilder {
+		if asset == NATIVE_ASSET {
+			self.native_balances.push((user, balance));
+		} else {
+			self.balances.push((user, asset, balance));
+		}
+		self
 	}
 }

--- a/frame/instrumental-strategy-pablo/src/tests.rs
+++ b/frame/instrumental-strategy-pablo/src/tests.rs
@@ -20,75 +20,85 @@ use crate::{pallet, pallet::Error};
 //                                          Associate Vault
 // -------------------------------------------------------------------------------------------------
 
-#[test]
-fn add_an_associated_vault() {
-	ExtBuilder::default().build().execute_with(|| {
-		let vault_id: VaultId = 1;
+#[cfg(test)]
+mod associate_vault {
+	use super::*;
 
-		assert_ok!(PabloStrategy::associate_vault(&vault_id));
-	});
-}
+	#[test]
+	fn add_an_associated_vault() {
+		ExtBuilder::default().build().execute_with(|| {
+			let vault_id: VaultId = 1;
 
-#[test]
-fn adding_an_associated_vault_twice_throws_an_error() {
-	ExtBuilder::default().build().execute_with(|| {
-		let vault_id: VaultId = 1;
+			assert_ok!(PabloStrategy::associate_vault(&vault_id));
+		});
+	}
 
-		assert_ok!(PabloStrategy::associate_vault(&vault_id));
-		assert_noop!(
-			PabloStrategy::associate_vault(&vault_id),
-			Error::<MockRuntime>::VaultAlreadyAssociated
-		);
-	});
-}
+	#[test]
+	fn adding_an_associated_vault_twice_throws_an_error() {
+		ExtBuilder::default().build().execute_with(|| {
+			let vault_id: VaultId = 1;
 
-#[test]
-fn associating_too_many_vaults_throws_an_error() {
-	ExtBuilder::default().build().execute_with(|| {
-		for vault_id in 0..MAX_ASSOCIATED_VAULTS {
-			assert_ok!(PabloStrategy::associate_vault(&(vault_id as VaultId)));
-		}
+			assert_ok!(PabloStrategy::associate_vault(&vault_id));
+			assert_noop!(
+				PabloStrategy::associate_vault(&vault_id),
+				Error::<MockRuntime>::VaultAlreadyAssociated
+			);
+		});
+	}
 
-		let vault_id = MAX_ASSOCIATED_VAULTS as VaultId;
-		assert_noop!(
-			PabloStrategy::associate_vault(&vault_id),
-			Error::<MockRuntime>::TooManyAssociatedStrategies
-		);
-	});
+	#[test]
+	fn associating_too_many_vaults_throws_an_error() {
+		ExtBuilder::default().build().execute_with(|| {
+			for vault_id in 0..MAX_ASSOCIATED_VAULTS {
+				assert_ok!(PabloStrategy::associate_vault(&(vault_id as VaultId)));
+			}
+
+			let vault_id = MAX_ASSOCIATED_VAULTS as VaultId;
+			assert_noop!(
+				PabloStrategy::associate_vault(&vault_id),
+				Error::<MockRuntime>::TooManyAssociatedStrategies
+			);
+		});
+	}
 }
 
 // -------------------------------------------------------------------------------------------------
 //                                             Rebalance
 // -------------------------------------------------------------------------------------------------
 
-#[test]
-fn rebalance_emits_event() {
-	ExtBuilder::default().build().execute_with(|| {
-		System::set_block_number(1);
+#[cfg(test)]
+mod rebalance {
+	use super::*;
 
-		let base_asset = CurrencyId::LAYR;
-		let quote_asset = CurrencyId::CROWD_LOAN;
-		let amount = 1_000_000_000 * CurrencyId::unit::<Balance>();
-		let amounts = vec![amount; 2];
+	#[test]
+	fn rebalance_emits_event() {
+		ExtBuilder::default().build().execute_with(|| {
+			System::set_block_number(1);
 
-		// Create Vault (LAYR)
-		let vault_id = create_vault(base_asset, None);
+			let base_asset = CurrencyId::LAYR;
+			let quote_asset = CurrencyId::CROWD_LOAN;
+			let amount = 1_000_000_000 * CurrencyId::unit::<Balance>();
+			let amounts = vec![amount; 2];
 
-		// Create Pool (LAYR/CROWD_LOAN)
-		let pool_id = create_pool_with(CurrencyPair::new(base_asset, quote_asset), amounts);
-		pallet::AdminAccountIds::<MockRuntime>::insert(ADMIN, AccessRights::Full);
-		assert_ok!(PabloStrategy::set_pool_id_for_asset(
-			Origin::signed(ADMIN),
-			base_asset,
-			pool_id
-		));
+			// Create Vault (LAYR)
+			let vault_id = create_vault(base_asset, None);
 
-		assert_ok!(PabloStrategy::associate_vault(&vault_id));
+			// Create Pool (LAYR/CROWD_LOAN)
+			let pool_id = create_pool_with(CurrencyPair::new(base_asset, quote_asset), amounts);
+			pallet::AdminAccountIds::<MockRuntime>::insert(ADMIN, AccessRights::Full);
+			assert_ok!(PabloStrategy::set_pool_id_for_asset(
+				Origin::signed(ADMIN),
+				base_asset,
+				pool_id
+			));
 
-		assert_ok!(PabloStrategy::rebalance());
+			assert_ok!(PabloStrategy::associate_vault(&vault_id));
 
-		System::assert_last_event(Event::PabloStrategy(pallet::Event::RebalancedVault {
-			vault_id,
-		}));
-	});
+			assert_ok!(PabloStrategy::rebalance());
+
+			System::assert_last_event(Event::PabloStrategy(pallet::Event::RebalancedVault {
+				vault_id,
+			}));
+		});
+	}
 }

--- a/frame/instrumental-strategy-pablo/src/tests.rs
+++ b/frame/instrumental-strategy-pablo/src/tests.rs
@@ -1,13 +1,10 @@
-use composable_traits::{
-	defi::CurrencyPair,
-	instrumental::{AccessRights, InstrumentalProtocolStrategy},
-};
+use composable_traits::instrumental::{AccessRights, InstrumentalProtocolStrategy};
 use frame_support::{assert_noop, assert_ok};
 use primitives::currency::CurrencyId;
 
 use crate::mock::{
 	account_id::ADMIN,
-	helpers::{create_pool_with, create_vault},
+	helpers::{create_pool, create_vault},
 	runtime::{
 		Balance, Event, ExtBuilder, MockRuntime, Origin, PabloStrategy, System, VaultId,
 		MAX_ASSOCIATED_VAULTS,
@@ -74,17 +71,15 @@ mod rebalance {
 	fn rebalance_emits_event() {
 		ExtBuilder::default().build().execute_with(|| {
 			System::set_block_number(1);
-
 			let base_asset = CurrencyId::LAYR;
 			let quote_asset = CurrencyId::CROWD_LOAN;
 			let amount = 1_000_000_000 * CurrencyId::unit::<Balance>();
-			let amounts = vec![amount; 2];
 
 			// Create Vault (LAYR)
 			let vault_id = create_vault(base_asset, None);
 
 			// Create Pool (LAYR/CROWD_LOAN)
-			let pool_id = create_pool_with(CurrencyPair::new(base_asset, quote_asset), amounts);
+			let pool_id = create_pool(base_asset, amount, quote_asset, amount, None, None);
 			pallet::AdminAccountIds::<MockRuntime>::insert(ADMIN, AccessRights::Full);
 			assert_ok!(PabloStrategy::set_pool_id_for_asset(
 				Origin::signed(ADMIN),

--- a/frame/instrumental-strategy-pablo/src/tests.rs
+++ b/frame/instrumental-strategy-pablo/src/tests.rs
@@ -1,20 +1,16 @@
 use composable_traits::{
 	defi::CurrencyPair,
-	instrumental::{
-		AccessRights, Instrumental as InstrumentalTrait, InstrumentalProtocolStrategy,
-		InstrumentalVaultConfig,
-	},
+	instrumental::{AccessRights, InstrumentalProtocolStrategy},
 };
 use frame_support::{assert_noop, assert_ok};
 use primitives::currency::CurrencyId;
-use sp_runtime::Perquintill;
 
 use crate::mock::{
 	account_id::ADMIN,
-	helpers::create_pool_with,
+	helpers::{create_pool_with, create_vault},
 	runtime::{
-		Balance, Event, ExtBuilder, Instrumental, MockRuntime, Origin, PabloStrategy, System,
-		VaultId, MAX_ASSOCIATED_VAULTS,
+		Balance, Event, ExtBuilder, MockRuntime, Origin, PabloStrategy, System, VaultId,
+		MAX_ASSOCIATED_VAULTS,
 	},
 };
 #[allow(unused_imports)]
@@ -76,13 +72,7 @@ fn rebalance_emits_event() {
 		let amounts = vec![amount; 2];
 
 		// Create Vault (LAYR)
-		let config = InstrumentalVaultConfig {
-			asset_id: base_asset,
-			percent_deployable: Perquintill::zero(),
-		};
-		let vault_id = <Instrumental as InstrumentalTrait>::create(config);
-		assert_ok!(vault_id);
-		let vault_id = vault_id.unwrap() as VaultId;
+		let vault_id = create_vault(base_asset, None);
 
 		// Create Pool (LAYR/CROWD_LOAN)
 		let pool_id = create_pool_with(CurrencyPair::new(base_asset, quote_asset), amounts);

--- a/frame/instrumental/src/mock/account_id.rs
+++ b/frame/instrumental/src/mock/account_id.rs
@@ -1,27 +1,23 @@
 use hex_literal::hex;
+use proptest::strategy::Just;
 use sp_core::sr25519::{Public, Signature};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 pub type AccountId = <<Signature as Verify>::Signer as IdentifyAccount>::AccountId;
 
-pub static ADMIN: Public =
+pub const ADMIN: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000000"));
-pub static ALICE: Public =
+pub const ALICE: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000001"));
-pub static BOB: Public =
+pub const BOB: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000002"));
-pub static CHARLIE: Public =
+pub const CHARLIE: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000003"));
-pub static DAVE: Public =
+pub const DAVE: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000004"));
-pub static EVEN: Public =
+pub const EVEN: Public =
 	Public(hex!("0000000000000000000000000000000000000000000000000000000000000005"));
 
-use proptest::{
-	prop_oneof,
-	strategy::{Just, Strategy},
-};
-
-pub fn pick_account() -> impl Strategy<Value = AccountId> {
-	prop_oneof![Just(ALICE), Just(BOB), Just(CHARLIE), Just(DAVE), Just(EVEN),]
+pub const fn accounts() -> [Just<AccountId>; 5] {
+	[Just(ALICE), Just(BOB), Just(CHARLIE), Just(DAVE), Just(EVEN)]
 }

--- a/frame/instrumental/src/tests.rs
+++ b/frame/instrumental/src/tests.rs
@@ -23,7 +23,7 @@ use crate::{
 const MINIMUM_RESERVE: Balance = 1_000;
 const MAXIMUM_RESERVE: Balance = 1_000_000_000;
 
-const NUMBER_OF_PROPTEST_CASES: u32 = 3_u32 * assets().len() as u32 * accounts().len() as u32;
+const NUMBER_OF_PROPTEST_CASES: u32 = (3 * assets().len() * accounts().len()) as u32;
 
 const fn assets() -> [Just<CurrencyId>; 5] {
 	[
@@ -39,7 +39,7 @@ prop_compose! {
 	fn generate_assets()(
 		assets in prop::collection::vec(
 			(0..assets().len()).prop_flat_map(|i| assets()[i]),
-			1..=assets().len()),
+			assets().len()),
 	) -> Vec<CurrencyId>{
 		assets
    }
@@ -47,7 +47,7 @@ prop_compose! {
 
 prop_compose! {
 	fn generate_balances()(
-		balances in prop::collection::vec(MINIMUM_RESERVE..MAXIMUM_RESERVE, 1..=assets().len()),
+		balances in prop::collection::vec(MINIMUM_RESERVE..MAXIMUM_RESERVE, assets().len()),
 	) -> Vec<Balance>{
 		balances
    }
@@ -57,7 +57,7 @@ prop_compose! {
 	fn generate_accounts()(
 		accounts in prop::collection::vec(
 			(0..accounts().len()).prop_flat_map(|i| accounts()[i]),
-			 1..=accounts().len()),
+			 accounts().len()),
 	) -> Vec<AccountId>{
 		accounts
    }

--- a/frame/instrumental/src/tests.rs
+++ b/frame/instrumental/src/tests.rs
@@ -20,25 +20,26 @@ use crate::{
 //                                           prop_compose
 // -------------------------------------------------------------------------------------------------
 
-const TOTAL_NUM_OF_ASSETS: usize = 5;
 const MINIMUM_RESERVE: Balance = 1_000;
 const MAXIMUM_RESERVE: Balance = 1_000_000_000;
 
-const NUMBER_OF_PROPTEST_CASES: u32 = 3_u32 * TOTAL_NUM_OF_ASSETS as u32 * accounts().len() as u32;
+const NUMBER_OF_PROPTEST_CASES: u32 = 3_u32 * assets().len() as u32 * accounts().len() as u32;
 
-fn pick_assets() -> impl Strategy<Value = CurrencyId> {
-	prop_oneof!(
+const fn assets() -> [Just<CurrencyId>; 5] {
+	[
 		Just(CurrencyId::LAYR),
 		Just(CurrencyId::CROWD_LOAN),
 		Just(CurrencyId::USDC),
 		Just(CurrencyId::USDT),
 		Just(CurrencyId::kUSD),
-	)
+	]
 }
 
 prop_compose! {
 	fn generate_assets()(
-		assets in prop::collection::vec(pick_assets(), 1..=TOTAL_NUM_OF_ASSETS),
+		assets in prop::collection::vec(
+			(0..assets().len()).prop_flat_map(|i| assets()[i]),
+			1..=assets().len()),
 	) -> Vec<CurrencyId>{
 		assets
    }
@@ -46,7 +47,7 @@ prop_compose! {
 
 prop_compose! {
 	fn generate_balances()(
-		balances in prop::collection::vec(MINIMUM_RESERVE..MAXIMUM_RESERVE, 1..=TOTAL_NUM_OF_ASSETS),
+		balances in prop::collection::vec(MINIMUM_RESERVE..MAXIMUM_RESERVE, 1..=assets().len()),
 	) -> Vec<Balance>{
 		balances
    }

--- a/frame/instrumental/src/tests.rs
+++ b/frame/instrumental/src/tests.rs
@@ -6,7 +6,7 @@ use proptest::prelude::*;
 
 use crate::{
 	mock::{
-		account_id::{pick_account, AccountId, ADMIN},
+		account_id::{accounts, AccountId, ADMIN},
 		helpers::*,
 		runtime::{
 			Assets, Balance, Event, ExtBuilder, Instrumental, MockRuntime, Origin, System, Vault,
@@ -17,16 +17,14 @@ use crate::{
 };
 
 // -------------------------------------------------------------------------------------------------
-//                                           Prop_compose
+//                                           prop_compose
 // -------------------------------------------------------------------------------------------------
 
 const TOTAL_NUM_OF_ASSETS: usize = 5;
 const MINIMUM_RESERVE: Balance = 1_000;
 const MAXIMUM_RESERVE: Balance = 1_000_000_000;
-const TOTAL_NUM_OF_ACCOUNTS: usize = 5;
 
-const NUMBER_OF_PROPTEST_CASES: u32 =
-	3_u32 * TOTAL_NUM_OF_ASSETS as u32 * TOTAL_NUM_OF_ACCOUNTS as u32;
+const NUMBER_OF_PROPTEST_CASES: u32 = 3_u32 * TOTAL_NUM_OF_ASSETS as u32 * accounts().len() as u32;
 
 fn pick_assets() -> impl Strategy<Value = CurrencyId> {
 	prop_oneof!(
@@ -56,7 +54,9 @@ prop_compose! {
 
 prop_compose! {
 	fn generate_accounts()(
-		accounts in prop::collection::vec(pick_account(), 1..=TOTAL_NUM_OF_ACCOUNTS),
+		accounts in prop::collection::vec(
+			(0..accounts().len()).prop_flat_map(|i| accounts()[i]),
+			 1..=accounts().len()),
 	) -> Vec<AccountId>{
 		accounts
    }


### PR DESCRIPTION
## Issue

- [CU-31zph3h](https://app.clickup.com/t/31zph3h)
- [CU-2j374gf](https://app.clickup.com/t/2j374gf)
- [CU-2j374jv](https://app.clickup.com/t/2j374jv)

## Description

I decided to divide the PR into smaller ones for ease of doing a code review. This is the first part.

@kevin-composable, for helpers, I decided to use a generic function with a trait constraint instead of builders. Let's see what happens, in any case, I can always quickly rewrite everything using builders. BTW, in other projects I have used `derive_builder` and other similar things, they slow down an already long compilation.