### PR TITLE
ci(integration-tests): Removed `cleanup` step.

### DIFF
--- a/.github/workflows/runtime-tests.yml
+++ b/.github/workflows/runtime-tests.yml
@@ -74,8 +74,3 @@ jobs:
         run: |
           cd integration-tests/runtime-tests
           docker run --rm -v$(pwd):/build -e "ENDPOINT=composable:9988" -e "ENDPOINT_RELAYCHAIN=composable:9944" --workdir /build --network runtime-tests_default --entrypoint=/build/dockerRun.sh node:16.14
-
-      - name: Cleanup
-        run: |
-          cd integration-tests/runtime-tests
-          ./docker-compose -f docker-compose-ci.yml down --remove-orphans


### PR DESCRIPTION
## Issue
The cleanup step failed in some rare cases.

## Description
~~*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*~~

## Checklist

~~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~~
~~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~~