### PR TITLE
[Merged by Bors] - fix(CodeSpace): Fixed `cmake` not installed.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends clang libclang-dev gcc libc6-dev musl-tools openssl libssl-dev pkg-config
+    && apt-get -y install --no-install-recommends clang libclang-dev gcc libc6-dev musl-tools openssl libssl-dev pkg-config cmake
 
 # Configure rust with corect channels and targets. 
 RUN rustup update stable && \


### PR DESCRIPTION
## Issue
`cmake` wasn't installed in the CodeSpace, causing builds to fail.

## Description
~~*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*~~

## Checklist

~~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~~
~~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~~