### PR TITLE
[Merged by Bors] - [CU-2pt779p] Add support for  environment variable to redefine PARA_ID

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1576,6 +1576,7 @@ dependencies = [
  "lending-rpc",
  "lending-runtime-api",
  "log 0.4.17",
+ "once_cell",
  "pablo-rpc",
  "pablo-runtime-api",
  "pallet-assets 0.0.1",

--- a/frame/lending/src/types.rs
+++ b/frame/lending/src/types.rs
@@ -26,7 +26,7 @@ pub type MarketId = u32;
 #[repr(transparent)]
 pub struct MarketIndex(
 	#[cfg(test)] // to allow pattern matching in tests outside of this crate
-	pub  MarketId,
+	pub MarketId,
 	#[cfg(not(test))] pub(crate) MarketId,
 );
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -13,6 +13,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 clap = "3.1.6"
 codec = { package = "parity-scale-codec", version = "3.0.0" }
 jsonrpsee = { version = "0.13.0", features = ["server", "macros"] }
+once_cell = "1.12.0"
 log = "0.4.14"
 serde = { version = "1.0.136", features = ["derive"] }
 tracing-core = "=0.1.26"                                            # https://substrate.stackexchange.com/questions/3147/node-startup-message-missing-after-upgrade-to-polkadot-v0-9-23

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,5 +1,6 @@
 use common::{AccountId, AuraId};
 use cumulus_primitives_core::ParaId;
+use once_cell::sync::Lazy;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup, Properties};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -13,8 +14,17 @@ pub mod dali;
 
 pub mod picasso;
 
+const DEFAULT_PARA_ID: u32 = 2000;
+
 // Parachin ID.
-const PARA_ID: ParaId = ParaId::new(2000);
+static PARA_ID: Lazy<ParaId> = Lazy::new(|| {
+	ParaId::new(
+		std::env::var("COMPOSABLE_PARA_ID")
+			.unwrap_or(DEFAULT_PARA_ID.to_string())
+			.parse::<u32>()
+			.unwrap_or(DEFAULT_PARA_ID),
+	)
+});
 
 /// The extensions for the [`ChainSpec`].
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ChainSpecGroup, ChainSpecExtension)]
@@ -111,7 +121,7 @@ pub fn picasso_dev() -> picasso::ChainSpec {
 					),
 				],
 				dev_accounts(),
-				PARA_ID,
+				*PARA_ID,
 				common::NativeExistentialDeposit::get(),
 				picasso_runtime::governance::TreasuryAccount::get(),
 			)
@@ -121,7 +131,7 @@ pub fn picasso_dev() -> picasso::ChainSpec {
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo_local_testnet".into(), para_id: PARA_ID.into() },
+		Extensions { relay_chain: "rococo_local_testnet".into(), para_id: u32::from(*PARA_ID) },
 	)
 }
 
@@ -155,7 +165,7 @@ pub fn dali_dev() -> dali::ChainSpec {
 					),
 				],
 				dev_accounts(),
-				PARA_ID,
+				*PARA_ID,
 				common::NativeExistentialDeposit::get(),
 				dali_runtime::TreasuryAccount::get(),
 			)
@@ -165,7 +175,7 @@ pub fn dali_dev() -> dali::ChainSpec {
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "rococo_local_testnet".into(), para_id: PARA_ID.into() },
+		Extensions { relay_chain: "rococo_local_testnet".into(), para_id: u32::from(*PARA_ID) },
 	)
 }
 
@@ -199,7 +209,7 @@ pub fn composable_dev() -> composable::ChainSpec {
 					),
 				],
 				dev_accounts(),
-				PARA_ID,
+				*PARA_ID,
 				composable_runtime::ExistentialDeposit::get(),
 				composable_runtime::TreasuryAccount::get(),
 			)
@@ -209,7 +219,7 @@ pub fn composable_dev() -> composable::ChainSpec {
 		None,
 		None,
 		Some(properties),
-		Extensions { relay_chain: "westend_local_testnet".into(), para_id: PARA_ID.into() },
+		Extensions { relay_chain: "westend_local_testnet".into(), para_id: u32::from(*PARA_ID) },
 	)
 }
 

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -20,7 +20,7 @@ const DEFAULT_PARA_ID: u32 = 2000;
 static PARA_ID: Lazy<ParaId> = Lazy::new(|| {
 	ParaId::new(
 		std::env::var("COMPOSABLE_PARA_ID")
-			.unwrap_or(DEFAULT_PARA_ID.to_string())
+			.unwrap_or_else(|_| DEFAULT_PARA_ID.to_string())
 			.parse::<u32>()
 			.unwrap_or(DEFAULT_PARA_ID),
 	)

--- a/scripts/polkadot-launch/package.json
+++ b/scripts/polkadot-launch/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "composable": "rm -rf /tmp/polkadot-launch && polkadot-launch composable.json --verbose",
-    "rococo-dali-karura": "polkadot-launch rococo-local-dali-dev-karura-dev.json"
+    "rococo-dali-karura": "COMPOSABLE_PARA_ID=2087 polkadot-launch rococo-local-dali-dev-karura-dev.json"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Issue
https://app.clickup.com/t/2pt779p


## Description
Composable parachain uses PARA_ID = 2000 (hard-coded), Acala parachain uses PARA_ID = 2000 (hard-coded).
I added support for `COMPOSABLE_PARA_ID` environment variable to redefine PARA_ID for Composable parachain, so we can run both parachains simultaneously.
