### PR TITLE
[Merged by Bors] - Chainspec runtime

### DIFF
--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,6 +1,7 @@
 use common::{AccountId, AuraId};
 use cumulus_primitives_core::ParaId;
 use once_cell::sync::Lazy;
+use primitives::currency::CurrencyId;
 use sc_chain_spec::{ChainSpecExtension, ChainSpecGroup, Properties};
 use sc_service::ChainType;
 use serde::{Deserialize, Serialize};
@@ -96,8 +97,8 @@ pub fn composable() -> composable::ChainSpec {
 pub fn picasso_dev() -> picasso::ChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "PICA".into());
-	properties.insert("tokenDecimals".into(), 12.into());
-	properties.insert("ss58Format".into(), 49.into());
+	properties.insert("tokenDecimals".into(), CurrencyId::decimals().into());
+	properties.insert("ss58Format".into(), picasso_runtime::SS58Prefix::get().into());
 
 	picasso::ChainSpec::from_genesis(
 		"Local Picasso Testnet",
@@ -140,8 +141,8 @@ pub fn picasso_dev() -> picasso::ChainSpec {
 pub fn dali_dev() -> dali::ChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "DALI".into());
-	properties.insert("tokenDecimals".into(), 12.into());
-	properties.insert("ss58Format".into(), 49.into());
+	properties.insert("tokenDecimals".into(), CurrencyId::decimals().into());
+	properties.insert("ss58Format".into(), dali_runtime::SS58Prefix::get().into());
 
 	dali::ChainSpec::from_genesis(
 		"Local Dali Testnet",
@@ -184,8 +185,8 @@ pub fn dali_dev() -> dali::ChainSpec {
 pub fn composable_dev() -> composable::ChainSpec {
 	let mut properties = Properties::new();
 	properties.insert("tokenSymbol".into(), "LAYR".into());
-	properties.insert("tokenDecimals".into(), 12.into());
-	properties.insert("ss58Format".into(), 50.into());
+	properties.insert("tokenDecimals".into(), CurrencyId::decimals().into());
+	properties.insert("ss58Format".into(), composable_runtime::SS58Prefix::get().into());
 
 	composable::ChainSpec::from_genesis(
 		"Local Composable Testnet",

--- a/runtime/composable/src/lib.rs
+++ b/runtime/composable/src/lib.rs
@@ -155,7 +155,7 @@ parameter_types! {
 		.avg_block_initialization(AVERAGE_ON_INITIALIZE_RATIO)
 		.build_or_panic();
 
-	pub const SS58Prefix: u8 = 49;
+	pub const SS58Prefix: u8 = 50;
 }
 
 // Configure FRAME pallets to include in runtime.


### PR DESCRIPTION
- extract `tokenDecimals` from the runtime when building the chainspec
- extract `ss58Format` from the runtime when building the chainspec
- fix a discrepancy between `SS58Prefix` and `ss58Format` for Composable parachain