### PR TITLE
[Merged by Bors] - 394nbkw Add show/hide options to transaction settings modal.

### DIFF
--- a/frontend/apps/pablo/components/Organisms/TransactionSettings/index.tsx
+++ b/frontend/apps/pablo/components/Organisms/TransactionSettings/index.tsx
@@ -35,11 +35,15 @@ const containerProps = (theme: Theme) => ({
 });
 
 export type TransactionSettingsProps = {
+  showSlippageSelection?: boolean,
+  showTransactionDeadlineSelection?: boolean,
   applyCallback?: () => void,
   closeCallback?: () => void,
 } & Omit<ModalProps, "open">;
 
 export const TransactionSettings: React.FC<TransactionSettingsProps> = ({
+  showSlippageSelection = true,
+  showTransactionDeadlineSelection = true,
   applyCallback,
   closeCallback,
   ...modalProps
@@ -111,7 +115,7 @@ export const TransactionSettings: React.FC<TransactionSettingsProps> = ({
           <Typography variant="h6">Transaction settings</Typography>
           <CloseOutlined onClick={onCloseHandler} sx={{cursor: "pointer"}} />
         </Box>
-        <Box mt={6}>
+        {showSlippageSelection && <Box mt={6}>
           <Input
             LabelProps={{
               label: "Slippage Tolerance",
@@ -142,8 +146,8 @@ export const TransactionSettings: React.FC<TransactionSettingsProps> = ({
               </FormControl>
             }
           />
-        </Box>
-        <Box mt={4}>
+        </Box>}
+        {showTransactionDeadlineSelection && <Box mt={4}>
           <Input
             value={deadlineStringValue}
             onChange={onDeadlineChange}
@@ -152,7 +156,7 @@ export const TransactionSettings: React.FC<TransactionSettingsProps> = ({
             }}
             referenceText="minutes"
           />
-        </Box>
+        </Box>}
         <Box mt={4}>
           <Button
             variant="contained"

--- a/frontend/apps/pablo/components/Organisms/liquidity/AddForm/index.tsx
+++ b/frontend/apps/pablo/components/Organisms/liquidity/AddForm/index.tsx
@@ -296,7 +296,7 @@ export const AddLiquidityForm: React.FC<BoxProps> = ({ ...rest }) => {
         share={share}
       />
 
-      <TransactionSettings />
+      <TransactionSettings showSlippageSelection={false} />
     </Box>
   );
 };


### PR DESCRIPTION
## Issue
[Pablo - (POOL) Removing unusable options on add liquidity settings](https://app.clickup.com/t/394nbkw)
## Description
Added functionality in both modals to hide/show fields which might be handy in other places.
