### PR TITLE
[Merged by Bors] - Fix eslint warning on anonymous export

### DIFF
--- a/frontend/apps/pablo/__mocks__/svgMock.js
+++ b/frontend/apps/pablo/__mocks__/svgMock.js
@@ -1,3 +1,4 @@
-import * as React from 'react'
-export default 'svg'
-export const ReactComponent = 'div'
+import * as React from "react";
+const svgMock = "svg";
+export default svgMock;
+export const ReactComponent = "div";

--- a/frontend/apps/picasso/__mocks__/svgMock.js
+++ b/frontend/apps/picasso/__mocks__/svgMock.js
@@ -1,3 +1,4 @@
 import * as React from "react";
-export default "svg";
+const svgMock = "svg";
+export default svgMock;
 export const ReactComponent = "div";


### PR DESCRIPTION
## Issue
Eslint analysis for svgMock is throwing a warning. This PR fixes that. 

## Description
This PR fixes eslint warning `[import/no-anonymous-default-export] Assign literal to a variable before exporting as module default`


## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_