### PR TITLE
Extend Query with Program

### DIFF
--- a/xcvm/SPEC.md
+++ b/xcvm/SPEC.md
@@ -221,8 +221,6 @@ sequenceDiagram
     XCVM Interpreter->>Opaque Contract: Call
     XCVM Interpreter->>Gateway: Spawn
     XCVM Interpreter->>Gateway: Query
-    XCVM Interpreter->>XCVM Interpreter: Commit
-    XCVM Interpreter->>XCVM Interpreter: Abort
 ```
 
 ##### Call Instruction and Late Bindings


### PR DESCRIPTION
## Description
Extends the Query instruction with a return Program, to be executed on the origin chain once the Query is fulfilled.

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_