### PR TITLE
Pablo feat/constant product zapping additional

### DIFF
--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -100,9 +100,9 @@ pub trait Amm {
 
 	/// Update accounts deposited one asset storage.
 	/// `lp_amount` - amount of LP token to deposit/withdraw,
-	/// `action` - withdraw or deposit LP token. 
+	/// `action` - withdraw or deposit LP token.
 	fn update_accounts_deposited_one_asset_storage(
-		who: Self::AccountId, 
+		who: Self::AccountId,
 		pool_id: Self::PoolId,
 		lp_amount: Self::Balance,
 		action: SingleAssetAccountsStorageAction,
@@ -118,6 +118,19 @@ pub trait Amm {
 		quote_amount: Self::Balance,
 		min_mint_amount: Self::Balance,
 		keep_alive: bool,
+	) -> Result<(), DispatchError>;
+
+	/// Withdraw coins of ine type from the pool.
+	/// Withdrawal amount are based on current deposit ratios.
+	/// `amount` - quantity of LP tokens to burn in the withdrawal,
+	/// `min_amounts` - minimum amounts of underlying coin to receive.
+	fn remove_liquidity_single_asset(
+		who: &Self::AccountId,
+		pool_id: Self::PoolId,
+		lp_available: Self::Balance,
+		lp_amount: Self::Balance,
+		min_base_amount: Self::Balance,
+		min_quote_amount: Self::Balance,
 	) -> Result<(), DispatchError>;
 
 	/// Withdraw coins from the pool.

--- a/frame/composable-traits/src/dex.rs
+++ b/frame/composable-traits/src/dex.rs
@@ -98,6 +98,16 @@ pub trait Amm {
 		keep_alive: bool,
 	) -> Result<Self::Balance, DispatchError>;
 
+	/// Update accounts deposited one asset storage.
+	/// `lp_amount` - amount of LP token to deposit/withdraw,
+	/// `action` - withdraw or deposit LP token. 
+	fn update_accounts_deposited_one_asset_storage(
+		who: Self::AccountId, 
+		pool_id: Self::PoolId,
+		lp_amount: Self::Balance,
+		action: SingleAssetAccountsStorageAction,
+	) -> Result<(), DispatchError>;
+
 	/// Deposit coins into the pool
 	/// `amounts` - list of amounts of coins to deposit,
 	/// `min_mint_amount` - minimum amount of LP tokens to mint from the deposit.
@@ -460,6 +470,13 @@ where
 	AssetId: Ord,
 {
 	pub assets: BTreeMap<AssetId, Balance>,
+}
+
+/// Enum to check whether deposit in SingleAssetAccountsStorage or withdrawal
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, RuntimeDebug)]
+pub enum SingleAssetAccountsStorageAction {
+	Depositing,
+	Withdrawing,
 }
 
 #[cfg(test)]

--- a/frame/pablo/src/common_test_functions.rs
+++ b/frame/pablo/src/common_test_functions.rs
@@ -240,7 +240,6 @@ pub fn common_remove_lp_failure(
 		Pablo::remove_liquidity(Origin::signed(BOB), pool_id, lp + 1, 0, 0, false),
 		TokenError::NoFunds
 	);
-	println!("LP token: {:?}", lp + 1);
 	// single asset
 	if is_constant_product {
 		assert_noop!(

--- a/frame/pablo/src/common_test_functions.rs
+++ b/frame/pablo/src/common_test_functions.rs
@@ -240,11 +240,12 @@ pub fn common_remove_lp_failure(
 		Pablo::remove_liquidity(Origin::signed(BOB), pool_id, lp + 1, 0, 0, false),
 		TokenError::NoFunds
 	);
+	println!("LP token: {:?}", lp + 1);
 	// single asset
 	if is_constant_product {
 		assert_noop!(
 			Pablo::remove_liquidity(Origin::signed(BOB), pool_id, lp + 1, 0, 0, true),
-			TokenError::NoFunds
+			crate::Error::<Test>::NoAvailableLPtokensForSingleAssetWithdraw
 		);
 	}
 	let min_expected_base_amount = base_amount + 1;

--- a/frame/pablo/src/uniswap_tests.rs
+++ b/frame/pablo/src/uniswap_tests.rs
@@ -921,7 +921,6 @@ proptest! {
 			prop_assert_ok!(
 				Pablo::add_liquidity(Origin::signed(BOB), pool_id, btc_value, usdt_value, 0, false)
 			);
-
 			let expected_lp_tokens = calculate_lp_for_single_deposit(
 				lp_supply, btc_value, base_weight, lp_fee, initial_btc);
 			let lp_amount = Tokens::balance(pool.lp_token, &BOB);

--- a/integration-tests/runtime-tests/test/tests/dexRouter/dexRouterTests.ts
+++ b/integration-tests/runtime-tests/test/tests/dexRouter/dexRouterTests.ts
@@ -1,0 +1,415 @@
+import { getNewConnection } from "@composable/utils/connectionHelper";
+import { mintAssetsToWallet } from "@composable/utils/mintingHelper";
+import { sendAndWaitForSuccess } from "@composable/utils/polkadotjs";
+import { getDevWallets } from "@composable/utils/walletHelper";
+import { ApiPromise } from "@polkadot/api";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { expect } from "chai";
+import { createConsProdPool } from "../dexRouter/testHandlers/dexRouterHelper";
+import BN from "bn.js";
+
+// DEX router pallet integration test
+
+// In these tests we are testing the following extrinsics:
+//  - updateRoute
+//  - addLiquidity
+//  - removeLiquidity
+//  - buy
+//  - exchange
+//  - sell
+
+describe("DexRouterPallet Tests", function () {
+  let api: ApiPromise;
+  let eth: number, usdt: number, usdc: number, dai: number;
+  let walletId1: KeyringPair, walletId2: KeyringPair, sudoKey: KeyringPair;
+  let fee: number, baseWeight: number;
+  let poolId1: number, poolId2: number, poolId3: number;
+  this.timeout(2 * 60 * 1000);
+
+  before("Initialize variables", async function () {
+    const { newClient, newKeyring } = await getNewConnection();
+    api = newClient;
+    const { devWalletAlice, devWalletEve, devWalletFerdie } = getDevWallets(newKeyring);
+    sudoKey = devWalletAlice;
+    walletId1 = devWalletEve.derive("/test/constantProductDex/walletId1");
+    walletId2 = devWalletFerdie.derive("/test/constantProductDex/walletId2");
+    eth = 5;
+    usdt = 6;
+    usdc = 7;
+    dai = 9;
+    //sets the fee to 1.00%/Type Permill
+    fee = 10000;
+    baseWeight = 500000;
+  });
+
+  before("Minting assets", async function () {
+    await mintAssetsToWallet(api, walletId1, sudoKey, [1, eth, usdc, usdt, dai]);
+    await mintAssetsToWallet(api, walletId2, sudoKey, [1, eth, usdc, usdt, dai]);
+  });
+
+  before("Creating pools", async function()  {
+    poolId1 = await createConsProdPool(api, sudoKey, walletId1, usdt, eth, fee, baseWeight);
+    poolId2 = await createConsProdPool(api, sudoKey, walletId1, usdc, usdt, fee, baseWeight);
+    poolId3 = await createConsProdPool(api, sudoKey, walletId1, dai, usdc, fee, baseWeight);
+  });
+
+  after("Closing the connection", async function () {
+    await api.disconnect();
+  });
+
+  it("[SHORT] Create route for pablo pools", async function () {
+    this.timeout(5 * 60 * 1000);
+
+    // create route for pool 1 (USDT-ETH)
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdt,
+      quote: eth
+    });
+    const route = api.createType("Vec<u128>", [api.createType("u128", poolId1)]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair, route))
+    );
+
+    // create route for pool 2 (USDC-USDT)
+    const assetPair2 = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: usdt
+    });
+    const route2 = api.createType("Vec<u128>", [api.createType("u128", poolId2)]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair2, route2))
+    );
+
+    // create route for pool 3 (DAI-USDC)
+    const assetPair3 = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: dai,
+      quote: usdc
+    });
+    const route3 = api.createType("Vec<u128>", [api.createType("u128", poolId3)]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair3, route3))
+    );
+
+    // create route for USDC-ETH pair (pool 1 <--> pool 2)
+    const assetPair4 = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: eth
+    });
+    const route4 = api.createType("Vec<u128>", [api.createType("u128", poolId1), api.createType("u128", poolId2)]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair4, route4))
+    );
+
+    // create route for DAI-USDT pair (pool 2 <--> pool3)
+    const assetPair5 = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: dai,
+      quote: usdt
+    });
+    const route5 = api.createType("Vec<u128>", [api.createType("u128", poolId2), api.createType("u128", poolId3)]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair5, route5))
+    );
+
+    // create route for DAI-ETH pair (pool 1 <--> pool 2 <--> pool3)
+    const assetPair6 = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: dai,
+      quote: eth
+    });
+    const route6 = api.createType("Vec<u128>", [
+      api.createType("u128", poolId1),
+      api.createType("u128", poolId2),
+      api.createType("u128", poolId3)
+    ]);
+    await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.sudo.Sudid.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair6, route6))
+    );
+  });
+
+  it("Add liquidity to pablo pool (USDT-ETH)", async function () {
+    this.timeout(5 * 60 * 1000);
+    const USDTAmount = 1000000000000000;
+    const ETHAmount = 1000000000000000;
+    const minimumMint = 0;
+    //set tx parameters
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdt,
+      quote: eth
+    });
+    const baseAmount = api.createType("u128", USDTAmount);
+    const quoteAmount = api.createType("u128", ETHAmount);
+    const minMintAmount = api.createType("u128", minimumMint);
+    const keepAlive = api.createType("bool", false);
+    //extrinsic call
+    const {
+      data: [, , baseAmountInTransfer, quoteAmountIntransfer, mintedLp]
+    } = await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.LiquidityAdded.is,
+      api.tx.dexRouter.addLiquidity(assetPair, baseAmount, quoteAmount, minMintAmount, keepAlive)
+    );
+    //Asertions
+    expect(baseAmountInTransfer.toString()).to.be.equal(baseAmount.toString());
+    expect(quoteAmountIntransfer.toString()).to.be.equal(quoteAmount.toString());
+    expect(new BN(mintedLp).gt(new BN(minimumMint))).to.be.true;
+  });
+
+  it("Add liquidity to pablo pool (USDC-USDT)", async function () {
+    this.timeout(5 * 60 * 1000);
+    const USDCAmount = 1000000000000000;
+    const USDTAmount = 1000000000000000;
+    const minimumMint = 0;
+    //set tx parameters
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: usdt
+    });
+    const baseAmount = api.createType("u128", USDCAmount);
+    const quoteAmount = api.createType("u128", USDTAmount);
+    const minMintAmount = api.createType("u128", minimumMint);
+    const keepAlive = api.createType("bool", false);
+    //extrinsic call
+    const {
+      data: [, , baseAmountInTransfer, quoteAmountIntransfer, mintedLp]
+    } = await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.LiquidityAdded.is,
+      api.tx.dexRouter.addLiquidity(assetPair, baseAmount, quoteAmount, minMintAmount, keepAlive)
+    );
+    //Asertions
+    expect(baseAmountInTransfer.toString()).to.be.equal(baseAmount.toString());
+    expect(quoteAmountIntransfer.toString()).to.be.equal(quoteAmount.toString());
+    expect(new BN(mintedLp).gt(new BN(minimumMint))).to.be.true;
+  });
+
+  it("Add liquidity to pablo pool (DAI-USDC)", async function () {
+    this.timeout(5 * 60 * 1000);
+    const DAIAmount = 1000000000000000;
+    const USDCAmount = 1000000000000000;
+    const minimumMint = 0;
+    //set tx parameters
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: dai,
+      quote: usdc
+    });
+    const baseAmount = api.createType("u128", DAIAmount);
+    const quoteAmount = api.createType("u128", USDCAmount);
+    const minMintAmount = api.createType("u128", minimumMint);
+    const keepAlive = api.createType("bool", false);
+    //extrinsic call
+    const {
+      data: [, , baseAmountInTransfer, quoteAmountIntransfer, mintedLp]
+    } = await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.LiquidityAdded.is,
+      api.tx.dexRouter.addLiquidity(assetPair, baseAmount, quoteAmount, minMintAmount, keepAlive)
+    );
+    //Asertions
+    expect(baseAmountInTransfer.toString()).to.be.equal(baseAmount.toString());
+    expect(quoteAmountIntransfer.toString()).to.be.equal(quoteAmount.toString());
+    expect(new BN(mintedLp).gt(new BN(minimumMint))).to.be.true;
+  });
+
+  it("update route (USDC-USDT)", async function () {
+    // Create new pool for USDC-USDT
+    const newPoolId = await createConsProdPool(api, walletId1, walletId1, usdc, usdt, fee, baseWeight);
+    // update route for pool 2 USDC-USDT
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: usdt
+    });
+    const route = api.createType("Vec<u128>", [api.createType("u128", newPoolId)]);
+    const {
+      data: [baseTokenId, quoteTokenId, , newRoute]
+    } = await sendAndWaitForSuccess(
+      api,
+      sudoKey,
+      api.events.dexRouter.RouteUpdated.is,
+      api.tx.sudo.sudo(api.tx.dexRouter.updateRoute(assetPair, route))
+    );
+    // Add liquidity to USDC-USDT pool so next test doesn't fail
+    const USDCAmount = 1000000000000000;
+    const USDTAmount = 1000000000000000;
+    const minimumMint = 0;
+    const baseAmount = api.createType("u128", USDCAmount);
+    const quoteAmount = api.createType("u128", USDTAmount);
+    const minMintAmount = api.createType("u128", minimumMint);
+    const keepAlive = api.createType("bool", false);
+    await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.LiquidityAdded.is,
+      api.tx.dexRouter.addLiquidity(assetPair, baseAmount, quoteAmount, minMintAmount, keepAlive)
+    );
+    // Asertions
+    expect(baseTokenId.toString()).eq(usdc.toString());
+    expect(quoteTokenId.toString()).eq(usdt.toString());
+    expect(newRoute[0].toString()).eq(newPoolId.toString());
+  });
+
+  it("Remove liquidity from pablo pool (USDC-USDT)", async function () {
+    this.timeout(5 * 60 * 1000);
+    const assetAmount = 10000000000000;
+    const minUSDCAmount = 1000000000000;
+    const minUSDTAmount = 1000000000000;
+    //set tx parameters
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: usdt
+    });
+    const lpAmount = api.createType("u128", assetAmount);
+    const minBaseAmount = api.createType("u128", minUSDCAmount);
+    const minQuoteAmount = api.createType("u128", minUSDTAmount);
+    //extrinsic call
+    const {
+      data: [, , baseAmountInTransfer, quoteAmountIntransfer]
+    } = await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.LiquidityRemoved.is,
+      api.tx.dexRouter.removeLiquidity(assetPair, lpAmount, minBaseAmount, minQuoteAmount)
+    );
+    //Asertions
+    expect(new BN(baseAmountInTransfer.toString()).gt(new BN(minUSDCAmount.toString()))).to.be.true;
+    expect(new BN(quoteAmountIntransfer.toString()).gt(new BN(minUSDCAmount.toString()))).to.be.true;
+  });
+
+  it("Buy ETH via route found in router (1 hop)", async function () {
+    this.timeout(5 * 60 * 1000);
+    //get initial data
+    const initialETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const initialUSDCbalance = new BN(
+      (await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString()
+    );
+    //set tx parameters
+    const ETHAmount = 1000000000000;
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: eth,
+      quote: usdc
+    });
+    const amount = api.createType("u128", ETHAmount);
+    const minReceive = api.createType("u128", 0);
+    //extrinsic call
+    await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.Swapped.is, // verify
+      api.tx.dexRouter.buy(assetPair, amount, minReceive)
+    );
+    //get final data
+    const finalETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const finalUSDCbalance = new BN((await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString());
+    //Assertions
+    expect(initialETHbalance.lt(finalETHbalance)).to.be.true;
+    expect(initialUSDCbalance.gt(finalUSDCbalance)).to.be.true;
+  });
+
+  it("Buy ETH via route found in router (2 hops)", async function () {
+    this.timeout(5 * 60 * 1000);
+    //get initial data
+    const initialETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const initialDAIbalance = new BN((await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString());
+    //set tx parameters
+    const ETHAmount = 1000000000000;
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: eth,
+      quote: dai
+    });
+    const amount = api.createType("u128", ETHAmount);
+    const minReceive = api.createType("u128", 0);
+    //extrinsic call
+    await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.Swapped.is, // verify
+      api.tx.dexRouter.buy(assetPair, amount, minReceive)
+    );
+    //get final data
+    const finalETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const finalDAIbalance = new BN((await api.rpc.assets.balanceOf(dai.toString(), walletId2.publicKey)).toString());
+    //Assertions
+    expect(initialETHbalance.lt(finalETHbalance)).to.be.true;
+    expect(initialDAIbalance.gt(finalDAIbalance)).to.be.true;
+  });
+
+  it("Exchange ETH for USDC via route found in router (1 hop)", async function () {
+    this.timeout(5 * 60 * 1000);
+    //get initial data
+    const initialETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const initialUSDCbalance = new BN(
+      (await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString()
+    );
+    //set tx parameters
+    const ETHAmount = 1000;
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: eth,
+      quote: usdc
+    });
+    const amount = api.createType("u128", ETHAmount);
+    const minReceive = api.createType("u128", 0);
+    //extrinsic call
+    await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.Swapped.is, // verify
+      api.tx.dexRouter.exchange(assetPair, amount, minReceive)
+    );
+    //get final data
+    const finalETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const finalUSDCbalance = new BN((await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString());
+    //Assertions
+    expect(initialETHbalance.lt(finalETHbalance)).to.be.true;
+    expect(initialUSDCbalance.gt(finalUSDCbalance)).to.be.true;
+  });
+
+  it("Sell ETH via route found in router (1 hop)", async function () {
+    this.timeout(5 * 60 * 1000);
+    this.timeout(5 * 60 * 1000);
+    //get initial data
+    const initialETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const initialUSDCbalance = new BN(
+      (await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString()
+    );
+    //set tx parameters
+    const ETHAmount = 1000;
+    const assetPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+      base: usdc,
+      quote: eth
+    });
+    const amount = api.createType("u128", ETHAmount);
+    const minReceive = api.createType("u128", 0);
+    //extrinsic call
+    await sendAndWaitForSuccess(
+      api,
+      walletId2,
+      api.events.pablo.Swapped.is, // verify
+      api.tx.dexRouter.sell(assetPair, amount, minReceive)
+    );
+    //get final data
+    const finalETHbalance = new BN((await api.rpc.assets.balanceOf(eth.toString(), walletId2.publicKey)).toString());
+    const finalUSDCbalance = new BN((await api.rpc.assets.balanceOf(usdc.toString(), walletId2.publicKey)).toString());
+    //Assertions
+    expect(initialETHbalance.gt(finalETHbalance)).to.be.true;
+    expect(initialUSDCbalance.lt(finalUSDCbalance)).to.be.true;
+  });
+});

--- a/integration-tests/runtime-tests/test/tests/dexRouter/testHandlers/dexRouterHelper.ts
+++ b/integration-tests/runtime-tests/test/tests/dexRouter/testHandlers/dexRouterHelper.ts
@@ -1,0 +1,431 @@
+import { sendAndWaitForSuccess, sendWithBatchAndWaitForSuccess } from "@composable/utils/polkadotjs";
+import { KeyringPair } from "@polkadot/keyring/types";
+import { u128 } from "@polkadot/types-codec";
+import { AccountId32 } from "@polkadot/types/interfaces/runtime";
+import { CustomRpcCurrencyId, PalletPabloPoolId } from "@composable/types/interfaces";
+import { ApiPromise } from "@polkadot/api";
+
+/**
+ *Contains handler methods for the pabloPallet Tests.
+ * StableSwap ConstantProduct and LiquidityBootsrapping Pools
+ */
+
+let constantProductk: bigint;
+let baseAmountTotal: bigint;
+let quoteAmountTotal: bigint;
+let mintedLPTokens: bigint;
+baseAmountTotal = BigInt(0);
+quoteAmountTotal = BigInt(0);
+mintedLPTokens = BigInt(0);
+
+/**
+ * Creates Constant Product Pool
+ * @param api
+ * @param walletId
+ * @param owner
+ * @param baseAssetId
+ * @param quoteAssetId
+ * @param fee
+ * @param ownerFee
+ */
+export async function createConsProdPool(
+  api: ApiPromise,
+  walletId: KeyringPair,
+  owner: KeyringPair,
+  baseAssetId: number,
+  quoteAssetId: number,
+  fee: number,
+  baseWeight: number
+): Promise<number> {
+  const pool = api.createType("PalletPabloPoolInitConfiguration", {
+    ConstantProduct: {
+      owner: api.createType("AccountId32", owner.address),
+      pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+        base: api.createType("u128", baseAssetId),
+        quote: api.createType("u128", quoteAssetId)
+      }),
+      fee: api.createType("Permill", fee),
+      baseWeight: api.createType("Permill", baseWeight)
+    }
+  });
+  const {
+    data: [resultPoolId]
+  } = await sendAndWaitForSuccess(api, walletId, api.events.sudo.Sudid.is, api.tx.sudo.sudo(api.tx.pablo.create(pool)));
+  return resultPoolId.toNumber();
+}
+
+export async function addFundstoThePool(
+  api: ApiPromise,
+  poolId: number,
+  walletId: KeyringPair,
+  baseAmount: bigint,
+  quoteAmount: bigint
+): Promise<{
+  returnedLPTokens: u128;
+  baseAdded: u128;
+  quoteAdded: u128;
+  walletIdResult: AccountId32;
+}> {
+  const pool = api.createType("u128", poolId);
+  const baseAmountParam = api.createType("u128", baseAmount);
+  const quoteAmountParam = api.createType("u128", quoteAmount);
+  const keepAliveParam = api.createType("bool", true);
+  const minMintAmountParam = api.createType("u128", 0);
+  const {
+    data: [walletIdResult, addedPool, baseAdded, quoteAdded, returnedLPTokens]
+  } = await sendAndWaitForSuccess(
+    api,
+    walletId,
+    api.events.pablo.LiquidityAdded.is,
+    api.tx.pablo.addLiquidity(pool, baseAmountParam, quoteAmountParam, minMintAmountParam, keepAliveParam)
+  );
+  mintedLPTokens += BigInt(returnedLPTokens.toString(10));
+  baseAmountTotal += BigInt(baseAdded.toString(10));
+  quoteAmountTotal += BigInt(quoteAdded.toString(10));
+  return { walletIdResult, baseAdded, quoteAdded, returnedLPTokens };
+}
+
+export async function buyFromPool(
+  api: ApiPromise,
+  poolId: number,
+  walletId: KeyringPair,
+  assetId: number,
+  amountToBuy: bigint
+): Promise<{
+  accountId: AccountId32;
+  ownerFee: u128;
+  expectedConversion: bigint;
+  quoteAmount: u128;
+  baseAmount: u128;
+}> {
+  const poolIdParam = api.createType("u128", poolId);
+  const assetIdParam = api.createType("u128", assetId);
+  const amountParam = api.createType("u128", amountToBuy);
+  const keepAlive = api.createType("bool", true);
+  const minMintAmount = api.createType("u128", 0);
+  constantProductk = baseAmountTotal * quoteAmountTotal;
+  const expectedConversion = constantProductk / (baseAmountTotal - amountToBuy) - quoteAmountTotal;
+  const {
+    data: [retPoolId, accountId, baseArg, quoteArg, baseAmount, quoteAmount, ownerFee]
+  } = await sendAndWaitForSuccess(
+    api,
+    walletId,
+    api.events.pablo.Swapped.is,
+    api.tx.pablo.buy(poolIdParam, assetIdParam, amountParam, minMintAmount, keepAlive)
+  );
+  return { accountId, baseAmount, quoteAmount, expectedConversion, ownerFee: ownerFee.fee };
+}
+
+export async function sellToPool(
+  api: ApiPromise,
+  poolId: number,
+  walletId: KeyringPair,
+  assetId: number,
+  amount: bigint
+): Promise<AccountId32> {
+  const poolIdParam = api.createType("u128", poolId);
+  const assetIdParam = api.createType("u128", assetId);
+  const amountParam = api.createType("u128", amount);
+  const minMintAmount = api.createType("u128", 0);
+  const keepAliveParam = api.createType("bool", false);
+  const {
+    data: [result, ownerAccount, ...rest]
+  } = await sendAndWaitForSuccess(
+    api,
+    walletId,
+    api.events.pablo.Swapped.is,
+    api.tx.pablo.sell(poolIdParam, assetIdParam, amountParam, minMintAmount, keepAliveParam)
+  );
+  return ownerAccount;
+}
+
+export async function removeLiquidityFromPool(
+  api: ApiPromise,
+  poolId: number,
+  walletId: KeyringPair,
+  lpTokens: bigint
+): Promise<{ resultBase: u128; resultQuote: u128 }> {
+  const poolIdParam = api.createType("u128", poolId);
+  const lpTokenParam = api.createType("u128", lpTokens);
+  const minBaseParam = api.createType("u128", 0);
+  const minQuoteAmountParam = api.createType("u128", 0);
+  const {
+    data: [resultPoolId, resultWallet, resultBase, resultQuote, remainingLpTokens]
+  } = await sendAndWaitForSuccess(
+    api,
+    walletId,
+    api.events.pablo.LiquidityRemoved.is,
+    api.tx.pablo.removeLiquidity(poolIdParam, lpTokenParam, minBaseParam, minQuoteAmountParam)
+  );
+  return { resultBase, resultQuote };
+}
+
+export async function swapTokenPairs(
+  api: ApiPromise,
+  poolId: number,
+  wallet: KeyringPair,
+  baseAssetId: number,
+  quoteAssetId: number,
+  quoteAmount: bigint,
+  minReceiveAmount = 0
+): Promise<{ returnedBaseAmount: u128; returnedQuoteAmount: u128 }> {
+  const poolIdParam = api.createType("u128", poolId);
+  const currencyPair = api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+    base: api.createType("CurrencyId", baseAssetId),
+    quote: api.createType("CurrencyId", quoteAssetId)
+  });
+  const quoteAmountParam = api.createType("u128", quoteAmount);
+  const minReceiveParam = api.createType("u128", minReceiveAmount);
+  const keepAliveParam = api.createType("bool", true);
+  const {
+    data: [resultPoolId, resultWallet, baseAsset, quoteAsset, returnedBaseAmount, returnedQuoteAmount, feeInfo]
+  } = await sendAndWaitForSuccess(
+    api,
+    wallet,
+    api.events.pablo.Swapped.is,
+    api.tx.pablo.swap(poolIdParam, currencyPair, quoteAmountParam, minReceiveParam, keepAliveParam)
+  );
+  return { returnedBaseAmount, returnedQuoteAmount };
+}
+
+export async function createMultipleCPPools(api: ApiPromise, wallet: KeyringPair) {
+  const tx = [];
+  for (let i = 0; i < 500; i++) {
+    const owner = wallet.derive("/test/ConstantProduct/deriveWallet");
+    const pool = api.createType("PalletPabloPoolInitConfiguration", {
+      ConstantProduct: {
+        owner: api.createType("AccountId32", owner.address),
+        pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+          base: api.createType("u128", Math.floor(Math.random() * 10000)),
+          quote: api.createType("u128", Math.floor(Math.random() * 10000))
+        }),
+        fee: api.createType("Permill", Math.floor(Math.random() * 100000)),
+        baseWeight: api.createType("Permill", Math.floor(Math.random() * 100000))
+      }
+    });
+    tx.push(api.tx.pablo.create(pool));
+  }
+  await sendWithBatchAndWaitForSuccess(api, wallet, api.events.pablo.PoolCreated.is, tx, false);
+}
+
+export async function getUserTokens(api: ApiPromise, walletId: KeyringPair, assetId: number): Promise<u128> {
+  const { free } = await api.query.tokens.accounts(walletId.address, assetId);
+  return free;
+}
+
+export async function getPoolInfo(api: ApiPromise, poolType: string, poolId: number): Promise<{ weights }> {
+  const result = await api.query.pablo.pools(api.createType("u128", poolId));
+  const pool = result.unwrap();
+  const poolS = "as" + poolType;
+  const baseWeight = pool[poolS].baseWeight.toNumber();
+  const quoteWeight = pool[poolS].quoteWeight.toNumber();
+  const weights = { baseWeight, quoteWeight };
+  return { weights };
+}
+
+export async function rpcPriceFor(
+  api: ApiPromise,
+  poolId: PalletPabloPoolId,
+  baseAssetId: CustomRpcCurrencyId,
+  quoteAssetId: CustomRpcCurrencyId
+) {
+  return await api.rpc.pablo.pricesFor(
+    poolId,
+    baseAssetId,
+    quoteAssetId,
+    api.createType("CustomRpcBalance", 10000 /* unit */)
+  );
+}
+
+export async function getPoolAddress(
+  api: ApiPromise,
+  poolId: number,
+  walletId: KeyringPair,
+  baseAmount: bigint,
+  quoteAmount: bigint
+): Promise<string> {
+  const pool = api.createType("u128", poolId);
+  const baseAmountParam = api.createType("u128", baseAmount);
+  const quoteAmountParam = api.createType("u128", quoteAmount);
+  const keepAliveParam = api.createType("bool", true);
+  const minMintAmountParam = api.createType("u128", 0);
+  const {
+    data: [, AccountId]
+  } = await sendAndWaitForSuccess(
+    api,
+    walletId,
+    api.events.tokens.Endowed.is,
+    api.tx.pablo.addLiquidity(pool, baseAmountParam, quoteAmountParam, minMintAmountParam, keepAliveParam)
+  );
+  return AccountId.toString();
+}
+
+export async function getPoolBalance(api: ApiPromise, poolAddress: string, assetId: number): Promise<u128> {
+  const { free } = await api.query.tokens.accounts(poolAddress, assetId);
+  return free;
+}
+
+export async function transferTokens(
+  api: ApiPromise,
+  sender: KeyringPair,
+  receiver: KeyringPair,
+  assetId: number,
+  amount: bigint
+): Promise<string> {
+  const {
+    data: [, accountId]
+  } = await sendAndWaitForSuccess(
+    api,
+    sender,
+    api.events.tokens.Endowed.is,
+    api.tx.assets.transfer(
+      api.createType("u128", assetId),
+      api.createType("MultiAddress", {
+        id: api.createType("AccountId", receiver.address.toString())
+      }),
+      api.createType("u128", amount),
+      api.createType("bool", false)
+    )
+  );
+  return accountId.toString();
+}
+
+/***
+ * Creates LiquidityBootstrappingPool
+ * @param sender
+ * @param owner
+ * @param baseAssetId
+ * @param quoteAssetId
+ * @param start
+ * @param end
+ * @param initialWeight
+ * @param finalWeight
+ * @param fee
+ * @returns Newly Created pool Id
+ */
+export async function createLBPool(
+  api: ApiPromise,
+  sender: KeyringPair,
+  owner: KeyringPair,
+  baseAssetId: number,
+  quoteAssetId: number,
+  start: number,
+  end: number,
+  initialWeight: number,
+  finalWeight: number,
+  feeRate: number,
+  ownerFeeRate: number,
+  protocolFeeRate: number
+): Promise<{ resultPoolId: number }> {
+  const pool = api.createType("PalletPabloPoolInitConfiguration", {
+    LiquidityBootstrapping: {
+      owner: api.createType("AccountId32", owner.address),
+      pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+        base: api.createType("u128", baseAssetId),
+        quote: api.createType("u128", quoteAssetId)
+      }),
+      sale: api.createType("ComposableTraitsDexSale", {
+        start: api.createType("u32", start),
+        end: api.createType("u32", end),
+        initialWeight: api.createType("Permill", initialWeight),
+        finalWeight: api.createType("Permill", finalWeight)
+      }),
+      feeConfig: api.createType("ComposableTraitsDexFeeConfig", {
+        feeRate: api.createType("Permill", feeRate),
+        ownerFeeRate: api.createType("Permill", ownerFeeRate),
+        protocolFeeRate: api.createType("Permill", protocolFeeRate)
+      })
+    }
+  });
+  const {
+    data: [returnedPoolId]
+  } = await sendAndWaitForSuccess(api, sender, api.events.pablo.PoolCreated.is, api.tx.pablo.create(pool));
+  const resultPoolId = returnedPoolId.toNumber();
+  return { resultPoolId };
+}
+
+export async function createMultipleLBPools(api: ApiPromise, wallet: KeyringPair): Promise<void> {
+  const tx = [];
+  for (let i = 0; i < 500; i++) {
+    const owner = wallet.derive("/test/ConstantProduct/deriveWallet");
+    const pool = api.createType("PalletPabloPoolInitConfiguration", {
+      LiquidityBootstrapping: {
+        owner: api.createType("AccountId32", owner.address),
+        pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+          base: api.createType("u128", Math.floor(Math.random() * 10000)),
+          quote: api.createType("u128", Math.floor(Math.random() * 10000))
+        }),
+        sale: api.createType("ComposableTraitsDexSale", {
+          start: api.createType("u32", Math.floor(Math.random() * 50000) + 300),
+          end: api.createType("u32", Math.floor(Math.random() * 100000) + 100000),
+          initialWeight: api.createType("Permill", Math.floor(Math.random() * 800000) + 150000),
+          finalWeight: api.createType("Permill", Math.floor(Math.random() * 100000) + 50000)
+        }),
+        feeConfig: api.createType("ComposableTraitsDexFeeConfig", {
+          feeRate: api.createType("Permill", Math.floor(Math.random() * 150000)),
+          ownerFeeRate: api.createType("Permill", Math.floor(Math.random() * 150000)),
+          protocolFeeRate: api.createType("Permill", Math.floor(Math.random() * 150000))
+        })
+      }
+    });
+    tx.push(api.tx.pablo.create(pool));
+  }
+  await sendWithBatchAndWaitForSuccess(api, wallet, api.events.pablo.PoolCreated.is, tx, false);
+}
+
+/***
+ Creates stableSwapPool
+ @param sender: User sending tx- KeyringPair
+ @param owner: Owner of the pool - KeyringPair
+ @param baseAssetId: CurencyId
+ @param quoteAssetId: CurrencyId
+ @param ampCoefficient: Amplification Coefficient, for details see curve.fi stable swap dex
+ @param fee: Total fee to be charged for each transaction in the pool
+ @returns resultPoolId: the number of the created pool
+ */
+export async function createStableSwapPool(
+  api: ApiPromise,
+  sender: KeyringPair,
+  owner: KeyringPair,
+  baseAssetId: number,
+  quoteAssetId: number,
+  ampCoefficient: number,
+  fee: number
+): Promise<{ resultPoolId: number }> {
+  const pool = api.createType("PalletPabloPoolInitConfiguration", {
+    StableSwap: {
+      owner: api.createType("AccountId32", owner.address),
+      pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+        base: api.createType("u128", baseAssetId),
+        quote: api.createType("u128", quoteAssetId)
+      }),
+      amplification_coefficient: api.createType("u16", ampCoefficient),
+      fee: api.createType("Permill", fee)
+    }
+  });
+  const {
+    data: [returnedPoolId]
+  } = await sendAndWaitForSuccess(api, sender, api.events.pablo.PoolCreated.is, api.tx.pablo.create(pool));
+  const resultPoolId = returnedPoolId.toNumber() as number;
+  return { resultPoolId };
+}
+
+export async function createMultipleStableSwapPools(api: ApiPromise, wallet: KeyringPair): Promise<void> {
+  const tx = [];
+  for (let i = 0; i < 50; i++) {
+    const owner = wallet.derive("/test/ConstantProduct/deriveWallet");
+    const pool = api.createType("PalletPabloPoolInitConfiguration", {
+      StableSwap: {
+        owner: api.createType("AccountId32", owner.address),
+        pair: api.createType("ComposableTraitsDefiCurrencyPairCurrencyId", {
+          base: api.createType("u128", Math.floor(Math.random() * 10000)),
+          quote: api.createType("u128", Math.floor(Math.random() * 10000))
+        }),
+        amplification_coefficient: api.createType("u16", Math.floor(Math.random() * 20000)),
+        fee: api.createType("Permill", Math.floor(Math.random() * 990000))
+      }
+    });
+    tx.push(api.tx.pablo.create(pool));
+  }
+  await sendWithBatchAndWaitForSuccess(api, wallet, api.events.pablo.PoolCreated.is, tx, false);
+}


### PR DESCRIPTION
## Issue
[2q8zq4k](https://app.clickup.com/t/2q8zq4k)

## Description
It is necessary to keep a history of depositing, specifically, in two assets or in one deposited fund. If a user wants to withdraw funds, then we must adhere to some algorithm when burning LP tokens, otherwise a situation may arise when a user will withdraw in one asset, but there will not be enough funds in a pool.