### PR TITLE
fix(vamm): Handle `output_amount_limit` correctly when removing asset

### DIFF
--- a/frame/vamm/src/helpers/checks.rs
+++ b/frame/vamm/src/helpers/checks.rs
@@ -64,8 +64,8 @@ impl<T: Config> Pallet<T> {
 	/// * Quote assets was not completely drained.
 	///
 	/// # Errors
-	// TODO(Cardosaum): Update list of errors
 	/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
+	/// * [`Error::<T>::SwappedAmountMoreThanMaximumLimit`]
 	/// * [`Error::<T>::BaseAssetReservesWouldBeCompletelyDrained`]
 	/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
 	pub fn sanity_check_after_swap(

--- a/frame/vamm/src/helpers/checks.rs
+++ b/frame/vamm/src/helpers/checks.rs
@@ -64,7 +64,7 @@ impl<T: Config> Pallet<T> {
 	/// * Quote assets was not completely drained.
 	///
 	/// # Errors
-	///
+	// TODO(Cardosaum): Update list of errors
 	/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
 	/// * [`Error::<T>::BaseAssetReservesWouldBeCompletelyDrained`]
 	/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
@@ -75,7 +75,16 @@ impl<T: Config> Pallet<T> {
 	) -> Result<(), DispatchError> {
 		// Ensure swapped amount is valid.
 		if let Some(limit) = config.output_amount_limit {
-			ensure!(amount_swapped.output >= limit, Error::<T>::SwappedAmountLessThanMinimumLimit);
+			match config.direction {
+				Direction::Add => ensure!(
+					amount_swapped.output >= limit,
+					Error::<T>::SwappedAmountLessThanMinimumLimit
+				),
+				Direction::Remove => ensure!(
+					amount_swapped.output <= limit,
+					Error::<T>::SwappedAmountMoreThanMaximumLimit
+				),
+			}
 		}
 
 		// Ensure both quote and base assets weren't completely drained from vamm.

--- a/frame/vamm/src/helpers/swap.rs
+++ b/frame/vamm/src/helpers/swap.rs
@@ -42,6 +42,7 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::<T>::InsufficientFundsForTrade`]
 	/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
 	/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
+	/// * [`Error::<T>::SwappedAmountMoreThanMaximumLimit`]
 	/// * [`Error::<T>::TradeExtrapolatesMaximumSupportedAmount`]
 	/// * [`ArithmeticError`](sp_runtime::ArithmeticError)
 	#[transactional]
@@ -86,6 +87,7 @@ impl<T: Config> Pallet<T> {
 	/// * [`Error::<T>::InsufficientFundsForTrade`]
 	/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
 	/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
+	/// * [`Error::<T>::SwappedAmountMoreThanMaximumLimit`]
 	/// * [`Error::<T>::TradeExtrapolatesMaximumSupportedAmount`]
 	/// * [`ArithmeticError`](sp_runtime::ArithmeticError)
 	pub fn compute_swap(

--- a/frame/vamm/src/lib.rs
+++ b/frame/vamm/src/lib.rs
@@ -446,19 +446,6 @@ pub mod pallet {
 		/// * [`Pallet::sanity_check_before_swap`]
 		/// * [`Pallet::sanity_check_before_update_twap`]
 		VammIsClosed,
-		// TODO(Cardosaum): consertar descricao
-		// TODO(Cardosaum): Adicionar nova lista de errors pra essa variante
-		/// Tried to swap assets but the amount returned was less than the minimum expected.
-		///
-		/// ## Occurrences
-		///
-		/// * [`Pallet::swap`]
-		/// * [`Pallet::swap_simulation`]
-		/// * [`Pallet::do_swap`]
-		/// * [`Pallet::compute_swap`]
-		/// * [`Pallet::sanity_check_after_swap`]
-		SwappedAmountMoreThanMaximumLimit,
-		// TODO(Cardosaum): consertar descricao
 		/// Tried to swap assets but the amount returned was less than the minimum expected.
 		///
 		/// ## Occurrences
@@ -469,6 +456,16 @@ pub mod pallet {
 		/// * [`Pallet::compute_swap`]
 		/// * [`Pallet::sanity_check_after_swap`]
 		SwappedAmountLessThanMinimumLimit,
+		/// Tried to swap assets but the amount returned was more than the maximum expected.
+		///
+		/// ## Occurrences
+		///
+		/// * [`Pallet::swap`]
+		/// * [`Pallet::swap_simulation`]
+		/// * [`Pallet::do_swap`]
+		/// * [`Pallet::compute_swap`]
+		/// * [`Pallet::sanity_check_after_swap`]
+		SwappedAmountMoreThanMaximumLimit,
 		/// Tried to derive invariant from [`base`](VammState::base_asset_reserves) and
 		/// [`quote`](VammState::quote_asset_reserves) asset, but the
 		/// computation was not successful.
@@ -917,6 +914,7 @@ pub mod pallet {
 		/// * [`Error::<T>::BaseAssetReservesWouldBeCompletelyDrained`]
 		/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
 		/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
+		/// * [`Error::<T>::SwappedAmountMoreThanMaximumLimit`]
 		/// * [`ArithmeticError::Overflow`](sp_runtime::ArithmeticError)
 		/// * [`ArithmeticError::Underflow`](sp_runtime::ArithmeticError)
 		/// * [`ArithmeticError::DivisionByZero`](sp_runtime::ArithmeticError)
@@ -988,6 +986,7 @@ pub mod pallet {
 		/// * [`Error::<T>::QuoteAssetReservesWouldBeCompletelyDrained`]
 		/// * [`Error::<T>::TradeExtrapolatesMaximumSupportedAmount`]
 		/// * [`Error::<T>::SwappedAmountLessThanMinimumLimit`]
+		/// * [`Error::<T>::SwappedAmountMoreThanMaximumLimit`]
 		/// * [`ArithmeticError::Overflow`](sp_runtime::ArithmeticError)
 		/// * [`ArithmeticError::Underflow`](sp_runtime::ArithmeticError)
 		/// * [`ArithmeticError::DivisionByZero`](sp_runtime::ArithmeticError)

--- a/frame/vamm/src/lib.rs
+++ b/frame/vamm/src/lib.rs
@@ -446,6 +446,19 @@ pub mod pallet {
 		/// * [`Pallet::sanity_check_before_swap`]
 		/// * [`Pallet::sanity_check_before_update_twap`]
 		VammIsClosed,
+		// TODO(Cardosaum): consertar descricao
+		// TODO(Cardosaum): Adicionar nova lista de errors pra essa variante
+		/// Tried to swap assets but the amount returned was less than the minimum expected.
+		///
+		/// ## Occurrences
+		///
+		/// * [`Pallet::swap`]
+		/// * [`Pallet::swap_simulation`]
+		/// * [`Pallet::do_swap`]
+		/// * [`Pallet::compute_swap`]
+		/// * [`Pallet::sanity_check_after_swap`]
+		SwappedAmountMoreThanMaximumLimit,
+		// TODO(Cardosaum): consertar descricao
 		/// Tried to swap assets but the amount returned was less than the minimum expected.
 		///
 		/// ## Occurrences

--- a/frame/vamm/src/tests/constants.rs
+++ b/frame/vamm/src/tests/constants.rs
@@ -48,3 +48,9 @@ pub const DEFAULT_BASE_RETURNED_AFTER_ADDING_QUOTE: Balance = 39215686274509804;
 /// The value we expect to give in return of a swap removing quote with an
 /// amount equal to `DEFAULT_INPUT_AMOUNT`.
 pub const DEFAULT_BASE_REQUIRED_FOR_REMOVING_QUOTE: Balance = 40816326530612244; // 0.0040 units
+/// The value expected to return as output when adding one unit to the existing
+/// vamm.
+pub const DEFAULT_OUTPUT_ADDING_BASE: Balance = 16666666666666666667;
+/// The value expected to return as output when removing one unit to the existing
+/// vamm.
+pub const DEFAULT_OUTPUT_REMOVING_BASE: Balance = 50000000000000000000;

--- a/frame/vamm/src/tests/create_vamm.rs
+++ b/frame/vamm/src/tests/create_vamm.rs
@@ -1,62 +1,15 @@
-use std::ops::RangeInclusive;
-
 use crate::{
 	mock::{Event, ExtBuilder, MockRuntime, System, TestPallet},
 	pallet::{self, Error, VammMap},
 	tests::{
 		constants::RUN_CASES,
-		helpers::any_sane_asset_amount,
-		helpers_propcompose::{loop_times, valid_twap_period},
-		types::{Balance, Decimal, TestVammConfig, Timestamp},
+		helpers_propcompose::{any_valid_vammconfig, loop_times},
+		types::{Balance, TestVammConfig, Timestamp},
 	},
 };
 use composable_traits::vamm::{Vamm as VammTrait, VammConfig, MINIMUM_TWAP_PERIOD};
 use frame_support::{assert_noop, assert_ok};
 use proptest::prelude::*;
-use sp_runtime::FixedPointNumber;
-
-// ----------------------------------------------------------------------------------------------------
-//                                               Helpers
-// ----------------------------------------------------------------------------------------------------
-
-fn one_up_to_(x: Balance) -> RangeInclusive<Balance> {
-	1..=x
-}
-
-// ----------------------------------------------------------------------------------------------------
-//                                           Prop Compose
-// ----------------------------------------------------------------------------------------------------
-
-prop_compose! {
-	fn limited_quote_peg() (
-		x in 1..=(Balance::MAX/Decimal::DIV),
-	) (
-		y in one_up_to_(x),
-		x in Just(x),
-		first_is_quote in any::<bool>()
-	) -> (Balance, Balance) {
-		if first_is_quote {
-			(x, y)
-		} else {
-			(y, x)
-		}
-	}
-}
-
-prop_compose! {
-	fn any_valid_vammconfig() (
-		(quote_asset_reserves, peg_multiplier) in limited_quote_peg(),
-		base_asset_reserves in any_sane_asset_amount(),
-		twap_period in  valid_twap_period()
-	) -> VammConfig<Balance, Timestamp> {
-		VammConfig {
-			base_asset_reserves,
-			quote_asset_reserves,
-			peg_multiplier,
-			twap_period
-		}
-	}
-}
 
 // -------------------------------------------------------------------------------------------------
 //                                            Unit Tests

--- a/frame/vamm/src/tests/swap_simulation.rs
+++ b/frame/vamm/src/tests/swap_simulation.rs
@@ -8,7 +8,7 @@ use crate::{
 			RUN_CASES,
 		},
 		helpers::{run_for_seconds, with_swap_context},
-		helpers_propcompose::{any_swap_config, any_vamm_state},
+		helpers_propcompose::any_swap_config,
 		types::{TestSwapConfig, TestVammConfig},
 	},
 };
@@ -167,11 +167,8 @@ proptest! {
 	#![proptest_config(ProptestConfig::with_cases(RUN_CASES))]
 	#[test]
 	fn should_not_update_runtime_storage(
-		mut vamm_state in any_vamm_state(),
 		mut swap_config in any_swap_config()
 	) {
-		// Ensure vamm is always open.
-		vamm_state.closed = None;
 		// Ensure we always perform operation on an existing vamm.
 		swap_config.vamm_id = Zero::zero();
 

--- a/frame/vamm/src/tests/types.rs
+++ b/frame/vamm/src/tests/types.rs
@@ -20,7 +20,7 @@ pub struct TestSwapConfig<VammId, Balance> {
 	pub asset: AssetType,
 	pub input_amount: Balance,
 	pub direction: Direction,
-	pub output_amount_limit: Balance,
+	pub output_amount_limit: Option<Balance>,
 }
 
 impl Default for TestSwapConfig<VammId, Balance> {
@@ -30,7 +30,7 @@ impl Default for TestSwapConfig<VammId, Balance> {
 			asset: AssetType::Base,
 			input_amount: DEFAULT_INPUT_AMOUNT,
 			direction: Direction::Add,
-			output_amount_limit: Zero::zero(),
+			output_amount_limit: None,
 		}
 	}
 }
@@ -42,12 +42,12 @@ impl From<TestSwapConfig<VammId, Balance>> for SwapConfig<VammId, Balance> {
 			asset: v.asset,
 			input_amount: v.input_amount,
 			direction: v.direction,
-			output_amount_limit: Some(v.output_amount_limit),
+			output_amount_limit: v.output_amount_limit,
 		}
 	}
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct TestVammConfig<Balance, Moment> {
 	pub base_asset_reserves: Balance,
 	pub quote_asset_reserves: Balance,


### PR DESCRIPTION
## Issue
[CU-2rha0dh](https://app.clickup.com/t/2rha0dh)

## Description
There was a misunderstanding while implementing the limit output for cases where the swap *removes* some amount from the Vamm. The checks were updated to take into account this difference.
