### PR TITLE
fix(cosmwasm): crypto host functions

### DIFF
--- a/.nix/arion-xcvm.nix
+++ b/.nix/arion-xcvm.nix
@@ -11,13 +11,9 @@ pkgs.arion.build {
           port = 1337;
         };
         juno-db-name = "juno";
-        juno-db = default-db // {
-          name = juno-db-name;
-        };
+        juno-db = default-db // { name = juno-db-name; };
         squid-db-name = "squid";
-        squid-db = default-db // {
-          name = squid-db-name;
-        };
+        squid-db = default-db // { name = squid-db-name; };
       in {
         config.project.name = "Composable Finance XCVM devnet";
         config.services = {
@@ -50,9 +46,7 @@ pkgs.arion.build {
             inherit packages;
           };
           subsquid-indexer =
-            import ./services/subsquid-indexer.nix {
-              database = squid-db;
-            };
+            import ./services/subsquid-indexer.nix { database = squid-db; };
           subsquid-indexer-gateway =
             import ./services/subsquid-indexer-gateway.nix {
               database = squid-db;

--- a/frame/cosmwasm/src/runtimes/wasmi.rs
+++ b/frame/cosmwasm/src/runtimes/wasmi.rs
@@ -24,6 +24,8 @@ use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 use wasmi::CanResume;
 use wasmi_validation::{validate_module, PlainValidator};
 
+const SUBSTRATE_ECDSA_SIGNATURE_LEN: usize = 65;
+
 #[derive(Debug)]
 pub enum CosmwasmVMError<T: Config> {
 	Interpreter(wasmi::Error),
@@ -312,16 +314,29 @@ impl<'a, T: Config> VMBase for CosmwasmVM<'a, T> {
 		&mut self,
 		message_hash: &[u8],
 		signature: &[u8],
-		_recovery_param: u8,
+		recovery_param: u8,
 	) -> Result<Result<Vec<u8>, ()>, Self::Error> {
-		let signature: [u8; 65] = match signature.try_into() {
-			Ok(signature) => signature,
+		// `recovery_param` must be 0 or 1. Other values are not supported from CosmWasm.
+		if recovery_param > 2 {
+			return Ok(Err(()))
+		}
+
+		if signature.len() != SUBSTRATE_ECDSA_SIGNATURE_LEN - 1 {
+			return Ok(Err(()))
+		}
+
+		// Try into a [u8; 32]
+		let message_hash = match message_hash.try_into() {
+			Ok(message_hash) => message_hash,
 			Err(_) => return Ok(Err(())),
 		};
 
-		let message_hash: [u8; 32] = match message_hash.try_into() {
-			Ok(message_hash) => message_hash,
-			Err(_) => return Ok(Err(())),
+		let signature = {
+			// Since we fill `signature_inner` with `recovery_param`, when 64 bytes are written
+			// the final byte will be the `recovery_param`.
+			let mut signature_inner = [recovery_param; SUBSTRATE_ECDSA_SIGNATURE_LEN];
+			signature_inner[..SUBSTRATE_ECDSA_SIGNATURE_LEN - 1].copy_from_slice(signature);
+			signature_inner
 		};
 
 		// We used `compressed` function here because the api states that this function
@@ -338,18 +353,26 @@ impl<'a, T: Config> VMBase for CosmwasmVM<'a, T> {
 		signature: &[u8],
 		public_key: &[u8],
 	) -> Result<bool, Self::Error> {
-		let signature: ecdsa::Signature = match signature.try_into() {
-			Ok(signature) => signature,
-			Err(_) => return Ok(false),
-		};
+		if signature.len() != SUBSTRATE_ECDSA_SIGNATURE_LEN {
+			return Ok(false)
+		}
 
-		let public_key: ecdsa::Public = match public_key.try_into() {
-			Ok(public_key) => public_key,
-			Err(_) => return Ok(false),
-		};
-
-		let message_hash: [u8; 32] = match message_hash.try_into() {
+		// Try into a [u8; 32]
+		let message_hash = match message_hash.try_into() {
 			Ok(message_hash) => message_hash,
+			Err(_) => return Ok(false),
+		};
+
+		// We are expecting 64 bytes long public keys but the substrate function use an
+		// additional byte for recovery id. So we insert a dummy byte.
+		let signature = {
+			let mut signature_inner = [0_u8; SUBSTRATE_ECDSA_SIGNATURE_LEN];
+			signature_inner[..SUBSTRATE_ECDSA_SIGNATURE_LEN - 1].copy_from_slice(signature);
+			ecdsa::Signature(signature_inner)
+		};
+
+		let public_key = match ecdsa::Public::try_from(public_key) {
+			Ok(public_key) => public_key,
 			Err(_) => return Ok(false),
 		};
 

--- a/frontend/apps/pablo/store/hooks/useAddLiquidityForm.ts
+++ b/frontend/apps/pablo/store/hooks/useAddLiquidityForm.ts
@@ -122,21 +122,19 @@ export const useAddLiquidityForm = () => {
       const bnQuote = toChainUnits(isReverse ? assetOneAmount : assetTwoAmount);
 
       if (bnBase.gte(0) && bnQuote.gte(0)) {
-        let b = isReverse
-          ? pool.pair.quote.toString()
-          : pool.pair.base.toString();
-        let q = isReverse
-          ? pool.pair.base.toString()
-          : pool.pair.quote.toString();
+        
+        let b = isReverse ? pool.pair.quote.toString() : pool.pair.base.toString();
+        let q = isReverse ? pool.pair.base.toString() : pool.pair.quote.toString();
 
+        // @ts-ignore
         parachainApi.rpc.pablo
           .simulateAddLiquidity(
             parachainApi.createType("AccountId32", selectedAccount.address),
             parachainApi.createType("PalletPabloPoolId", pool.poolId),
-            parachainApi.createType("BTreeMap<SafeRpcWrapper, SafeRpcWrapper>",{
+            {
               [b]: bnBase.toString(),
-              [q]: bnQuote.toString(),
-            })
+              [q]: bnQuote.toString()
+            }
           )
           .then((expectedLP: any) => {
             setLpReceiveAmount(fromChainUnits(expectedLP.toString()));
@@ -146,15 +144,7 @@ export const useAddLiquidityForm = () => {
           });
       }
     }
-  }, [
-    parachainApi,
-    assetOneAmount,
-    assetTwoAmount,
-    assetOne,
-    assetTwo,
-    pool,
-    selectedAccount,
-  ]);
+  }, [parachainApi, assetOneAmount, assetTwoAmount, assetOne, assetTwo, pool, selectedAccount]);
 
   return {
     assetOne: _assetOne,
@@ -177,6 +167,6 @@ export const useAddLiquidityForm = () => {
     invalidTokenPair,
     canSupply,
     findPoolManually,
-    pool,
+    pool
   };
 };


### PR DESCRIPTION
Signed-off-by: aeryz <abdullaheryz@protonmail.com>

## Description
It turns out that substrate's crypto functions and cosmwasm's crypto function are expecting signatures with different formats. The main difference is cosmwasm expects recovery param (recovery id in substrate) and the actual signature separately in `ecdsa(secp256k1)`. But substrate expects recovery param to be added to the end of the signature.

## Checklist

- [X] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_