### PR TITLE
Fix cspell 

### DIFF
--- a/cspell.yaml
+++ b/cspell.yaml
@@ -16,3 +16,6 @@ patterns:
 ignoreRegExpList:
 - rust-code-literal
 - quoted
+
+ignorePaths:
+  - 'node/src/res'


### PR DESCRIPTION
Bandaid fix for cspell issue by ignoring the node/src/res folder entirely.