### PR TITLE
convert_and_multiply_by_rational vault pallet refactor

### DIFF
--- a/frame/composable-traits/src/vesting.rs
+++ b/frame/composable-traits/src/vesting.rs
@@ -105,7 +105,7 @@ pub struct VestingSchedule<VestingScheduleId, BlockNumber, Moment, Balance: HasC
 	/// Amount of tokens to release per vest
 	#[codec(compact)]
 	pub per_period: Balance,
-	/// Amout already claimed
+	/// Amount already claimed
 	pub already_claimed: Balance,
 }
 

--- a/frame/staking-rewards/src/test/mod.rs
+++ b/frame/staking-rewards/src/test/mod.rs
@@ -572,8 +572,8 @@ fn test_split_postion() {
 		);
 		assert_last_event::<Test, _>(|e| {
 			matches!(&e.event,
-            Event::StakingRewards(crate::Event::SplitPosition { positions })
-            if positions == &vec![1_u128.into(), 2_u128.into()])
+			Event::StakingRewards(crate::Event::SplitPosition { positions })
+			if positions == &vec![(1_u128.into(), stake1.stake), (2_u128.into(), stake2.stake)])
 		});
 	});
 }

--- a/frame/vault/src/tests.rs
+++ b/frame/vault/src/tests.rs
@@ -430,7 +430,7 @@ proptest! {
 		ExtBuilder::default().build().execute_with(|| {
 			let (vault_id, vault) = create_vault(strategy_account_id, asset_id);
 			prop_assert_eq!(Tokens::balance(vault.lp_token_id, &ALICE), 0);
-			assert_noop!(Vaults::withdraw(Origin::signed(ALICE), vault_id, amount), ArithmeticError::Overflow);
+			assert_noop!(Vaults::withdraw(Origin::signed(ALICE), vault_id, amount), Error::<Test>::InsufficientLpTokens);
 			Ok(())
 		})?;
 	}

--- a/frame/vesting/src/lib.rs
+++ b/frame/vesting/src/lib.rs
@@ -567,61 +567,54 @@ impl<T: Config> Pallet<T> {
 		(BalanceOf<T>, BoundedBTreeMap<T::VestingScheduleId, BalanceOf<T>, T::MaxVestingSchedules>),
 		DispatchError,
 	> {
-		let mut claims_per_schedule: BoundedBTreeMap<
-			T::VestingScheduleId,
-			BalanceOf<T>,
-			T::MaxVestingSchedules,
-		> = BoundedBTreeMap::new();
-
 		<VestingSchedules<T>>::try_mutate_exists(who, asset, |maybe_schedules| {
-			let mut total_balance_to_claim: BalanceOf<T> = Zero::zero();
-			match maybe_schedules {
-				Some(schedules) => {
-					vesting_schedule_ids
-						.into_all_ids(schedules)
-						.iter()
-						.map(|id_to_claim| {
-							let schedule = schedules
-								.get_mut(id_to_claim)
-								.ok_or(Error::<T>::VestingScheduleNotFound)?;
+			let schedules = maybe_schedules.as_mut().ok_or(Error::<T>::VestingScheduleNotFound)?;
+			vesting_schedule_ids.into_all_ids(schedules).iter().try_fold(
+				(
+					BalanceOf::<T>::zero(),
+					BoundedBTreeMap::<
+						T::VestingScheduleId,
+						BalanceOf<T>,
+						T::MaxVestingSchedules,
+					>::new(),
+				),
+				|(mut total_balance_to_claim, mut claims_per_schedule), id_to_claim| {
+					let schedule = schedules
+						.get_mut(id_to_claim)
+						.ok_or(Error::<T>::VestingScheduleNotFound)?;
 
-							// Total amount for vesting schedule
-							let total_amount = ensure_valid_vesting_schedule::<T>(schedule)?;
-							// Currently locked amount
-							let locked_amount = schedule.locked_amount(
-								frame_system::Pallet::<T>::current_block_number(),
-								T::Time::now(),
-							);
-							// All balance that is not locked, including both claimed and unclaimed
-							let unlocked_amount = total_amount.safe_sub(&locked_amount)?;
-							// Balance that is not locked and has not been claimed yet
-							let available_amount =
-								unlocked_amount.safe_sub(&schedule.already_claimed)?;
+					// Total amount for vesting schedule
+					let total_amount = ensure_valid_vesting_schedule::<T>(schedule)?;
+					// Currently locked amount
+					let locked_amount = schedule.locked_amount(
+						frame_system::Pallet::<T>::current_block_number(),
+						T::Time::now(),
+					);
+					// All balance that is not locked, including both claimed and unclaimed
+					let unlocked_amount = total_amount.safe_sub(&locked_amount)?;
+					// Balance that is not locked and has not been claimed yet
+					let available_amount =
+						unlocked_amount.safe_sub(&schedule.already_claimed)?;
 
-							// Update claimed amount for specified schedules
-							schedule.already_claimed =
-								schedule.already_claimed.safe_add(&available_amount)?;
+					// Update claimed amount for specified schedules
+					schedule.already_claimed =
+						schedule.already_claimed.safe_add(&available_amount)?;
 
-							total_balance_to_claim =
-								total_balance_to_claim.safe_add(&available_amount)?;
+					total_balance_to_claim =
+						total_balance_to_claim.safe_add(&available_amount)?;
 
-							claims_per_schedule
-								.try_insert(*id_to_claim, available_amount)
-								.expect("Max vesting schedules exceeded");
+					claims_per_schedule
+						.try_insert(*id_to_claim, available_amount)
+						.expect("Max vesting schedules exceeded");
 
-							if locked_amount.is_zero() {
-								// remove fully claimed schedules
-								schedules.remove(id_to_claim);
-							}
-
-							Ok(())
-						})
-						.collect::<Result<Vec<_>, DispatchError>>()?;
+					if locked_amount.is_zero() {
+						// Remove fully claimed schedules
+						schedules.remove(id_to_claim);
+					};
 
 					Ok((total_balance_to_claim, claims_per_schedule))
 				},
-				None => Err(Error::<T>::VestingScheduleNotFound.into()),
-			}
+			)
 		})
 	}
 


### PR DESCRIPTION
## Issue
The new `multiply_by_rational_with_rounding` function introduced in polkadot 0.9.27 returns `None` when the divisor is 0 or when an `Overflow` occurs. I have modified the `convert_and_multiply_by_rational` to reproduce the old `multiply_by_rational` behavior, adding a fourth parameter to decide which type of `Rounding` to apply. 

## Description
I have chosen to do an `Rounding::Up` for the functions `do_calculate_lp_tokens_to_mint` because more `lp_tokens` would provide a (slightly) better representation of the collateral deposited. For the functions `do_amount_of_lp_token_for_added_liquidity` and `do_lp_share_value`, since they are one the inverse of the other, I have opted for opposite roundings, giving the `Down` rounding to the `do_lp_share_value` since it's usually used before burning `lp_tokens` (same point of the `do_calculate_lp_tokens_to_mint` function).

I have also reverted the check on the test `vault_withdraw_with_zero_lp_issued_fails_to_burn` from `Overflow` to `InsufficientLpTokens`

## Checklist

- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_
- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_