### PR TITLE
Remove T::RewardPoolID from Staking Rewards 

### DIFF
--- a/frame/dex-router/src/mock.rs
+++ b/frame/dex-router/src/mock.rs
@@ -19,7 +19,6 @@ pub type Amount = i128;
 pub type PoolId = u128;
 pub type BlockNumber = u64;
 pub type AccountId = u128;
-pub type RewardPoolId = u128;
 pub type PositionId = u128;
 pub type CurrencyId = u128;
 
@@ -176,7 +175,6 @@ parameter_types! {
 impl pallet_staking_rewards::Config for Test {
 	type Event = Event;
 	type Balance = Balance;
-	type RewardPoolId = RewardPoolId;
 	type PositionId = PositionId;
 	type AssetId = AssetId;
 	type Assets = Tokens;
@@ -219,7 +217,6 @@ impl pallet_pablo::Config for Test {
 	type Time = Timestamp;
 	type TWAPInterval = TWAPInterval;
 	type WeightInfo = ();
-	type RewardPoolId = RewardPoolId;
 	type MaxStakingRewardPools = MaxStakingRewardPools;
 	type MaxRewardConfigsPerPool = MaxRewardConfigsPerPool;
 	type MaxStakingDurationPresets = MaxStakingDurationPresets;

--- a/frame/pablo/src/lib.rs
+++ b/frame/pablo/src/lib.rs
@@ -351,20 +351,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type TWAPInterval: Get<MomentOf<Self>>;
 
-		type RewardPoolId: FullCodec
-			+ MaxEncodedLen
-			+ Default
-			+ Debug
-			+ TypeInfo
-			+ Eq
-			+ PartialEq
-			+ Ord
-			+ Copy
-			+ Zero
-			+ One
-			+ SafeArithmetic
-			+ From<u128>;
-
 		type MaxStakingRewardPools: Get<u32>;
 
 		type MaxRewardConfigsPerPool: Get<u32>;
@@ -378,14 +364,14 @@ pub mod pallet {
 			Balance = Self::Balance,
 			RewardConfigsLimit = Self::MaxRewardConfigsPerPool,
 			StakingDurationPresetsLimit = Self::MaxStakingDurationPresets,
-			RewardPoolId = Self::RewardPoolId,
+			RewardPoolId = Self::AssetId,
 		>;
 
 		type ProtocolStaking: ProtocolStaking<
 			AccountId = AccountIdOf<Self>,
 			AssetId = <Self as Config>::AssetId,
 			Balance = Self::Balance,
-			RewardPoolId = Self::RewardPoolId,
+			RewardPoolId = Self::AssetId,
 		>;
 
 		type WeightInfo: WeightInfo;
@@ -823,7 +809,7 @@ pub mod pallet {
 			if !fees.protocol_fee.is_zero() {
 				T::ProtocolStaking::transfer_reward(
 					who,
-					&T::RewardPoolId::from(T::PbloAssetId::get().into()),
+					&T::PbloAssetId::get(),
 					fees.asset_id,
 					fees.protocol_fee,
 				)?;

--- a/frame/pablo/src/mock.rs
+++ b/frame/pablo/src/mock.rs
@@ -103,7 +103,6 @@ pub type Balance = u128;
 pub type AssetId = u128;
 pub type Amount = i128;
 pub type PoolId = u128;
-pub type RewardPoolId = u128;
 pub type PositionId = u128;
 
 parameter_type_with_key! {
@@ -161,7 +160,6 @@ parameter_types! {
 impl pallet_staking_rewards::Config for Test {
 	type Event = Event;
 	type Balance = Balance;
-	type RewardPoolId = RewardPoolId;
 	type PositionId = PositionId;
 	type AssetId = CurrencyId;
 	type Assets = Tokens;
@@ -211,7 +209,6 @@ impl pablo::Config for Test {
 	type Time = Timestamp;
 	type TWAPInterval = TWAPInterval;
 	type WeightInfo = ();
-	type RewardPoolId = RewardPoolId;
 	type MaxStakingRewardPools = MaxStakingRewardPools;
 	type MaxRewardConfigsPerPool = MaxRewardConfigsPerPool;
 	type MaxStakingDurationPresets = MaxStakingDurationPresets;

--- a/frame/staking-rewards/src/benchmarking.rs
+++ b/frame/staking-rewards/src/benchmarking.rs
@@ -89,14 +89,13 @@ benchmarks! {
 			T::BlockNumber: From<u32>,
 			T::Balance: From<u128>,
 			T::AssetId: From<u128>,
-			T::RewardPoolId: From<u16>,
 			T::PositionId: From<u128>,
 	}
 
 	create_reward_pool {
 		let r in 1 .. T::MaxRewardConfigsPerPool::get();
 		let owner: T::AccountId = account("owner", 0, 0);
-		let pool_id = 100_u16.into();
+		let pool_id = 100_u128.into();
 		let end_block = 5_u128.saturated_into();
 		let asset_id = 100.into();
 	}: _(RawOrigin::Root, get_reward_pool::<T>(owner.clone(), r))
@@ -107,7 +106,7 @@ benchmarks! {
 	stake {
 		let r in 1 .. T::MaxRewardConfigsPerPool::get();
 		let asset_id = 100.into();
-		let pool_id = 100_u16.into();
+		let pool_id = 100_u128.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
 		let position_id = 1_u128.into();
@@ -124,7 +123,7 @@ benchmarks! {
 	extend {
 		let r in 1 .. T::MaxRewardConfigsPerPool::get();
 		let asset_id = 100.into();
-		let pool_id = 100_u16.into();
+		let pool_id = 100_u128.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
 		let position_id = 1_u128.into();
@@ -142,7 +141,7 @@ benchmarks! {
 	unstake {
 		let r in 1 .. T::MaxRewardConfigsPerPool::get();
 		let asset_id = 100.into();
-		let pool_id = 100_u16.into();
+		let pool_id = 100_u128.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
 		let position_id = 1_u128.into();
@@ -163,9 +162,9 @@ benchmarks! {
 		let user: T::AccountId = account("user", 0, 0);
 		let _res = Pallet::<T>::create_reward_pool(RawOrigin::Root.into(), get_reward_pool::<T>(user.clone(), r));
 		let _res = StakeCount::<T>::increment();
-		let new_stake = Stake::<T::AccountId, T::RewardPoolId, T::Balance, Reductions<T::AssetId, T::Balance, T::MaxRewardConfigsPerPool>> {
+		let new_stake = Stake::<T::AccountId, T::AssetId, T::Balance, Reductions<T::AssetId, T::Balance, T::MaxRewardConfigsPerPool>> {
 			owner: user.clone(),
-			reward_pool_id: 1_u16.into(),
+			reward_pool_id: 1_u128.into(),
 			stake: 1_000_000_000_000_000_u128.into(),
 			share: 1_000_000_000_000_000_u128.into(),
 			reductions: Reductions::<_,_,_>::new(),
@@ -238,7 +237,7 @@ benchmarks! {
 	claim {
 		let r in 1 .. T::MaxRewardConfigsPerPool::get();
 		let asset_id = 100.into();
-		let pool_id = 100_u16.into();
+		let pool_id = 100_u128.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
 		let position_id = 1_u128.into();

--- a/frame/staking-rewards/src/lib.rs
+++ b/frame/staking-rewards/src/lib.rs
@@ -352,8 +352,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	#[pallet::getter(fn pools)]
-	pub type RewardPools<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::AssetId, RewardPoolOf<T>>;
+	pub type RewardPools<T: Config> = StorageMap<_, Blake2_128Concat, T::AssetId, RewardPoolOf<T>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn stake_count)]

--- a/frame/staking-rewards/src/lib.rs
+++ b/frame/staking-rewards/src/lib.rs
@@ -591,7 +591,7 @@ pub mod pallet {
 						Error::<T>::EndBlockMustBeInTheFuture
 					);
 
-					let pool_id = T::AssetId::from(asset_id.into());
+					let pool_id = asset_id;
 					ensure!(
 						!RewardPools::<T>::contains_key(pool_id),
 						Error::<T>::RewardsPoolAlreadyExists

--- a/frame/staking-rewards/src/lib.rs
+++ b/frame/staking-rewards/src/lib.rs
@@ -107,10 +107,10 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub fn deposit_event)]
 	pub enum Event<T: Config> {
-		/// Pool with specified id `T::RewardPoolId` was created successfully by `T::AccountId`.
+		/// Pool with specified id `T::AssetId` was created successfully by `T::AccountId`.
 		RewardPoolCreated {
 			/// Id of newly created pool.
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			/// Owner of the pool.
 			owner: T::AccountId,
 			/// End block
@@ -120,7 +120,7 @@ pub mod pallet {
 		},
 		Staked {
 			/// Id of newly created stake.
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			/// Owner of the stake.
 			owner: T::AccountId,
 			amount: T::Balance,
@@ -154,25 +154,25 @@ pub mod pallet {
 		/// Reward transfer event.
 		RewardTransferred {
 			from: T::AccountId,
-			pool: T::RewardPoolId,
+			pool_id: T::AssetId,
 			reward_currency: T::AssetId,
 			/// amount of reward currency transferred.
 			reward_increment: T::Balance,
 		},
 		RewardAccumulationHookError {
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			asset_id: T::AssetId,
 			error: RewardAccumulationHookError,
 		},
 		MaxRewardsAccumulated {
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			asset_id: T::AssetId,
 		},
 		RewardPoolUpdated {
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 		},
 		RewardsPotIncreased {
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			asset_id: T::AssetId,
 			amount: T::Balance,
 		},
@@ -236,22 +236,6 @@ pub mod pallet {
 			+ Into<u128>
 			+ Zero;
 
-		/// The reward pool ID type.
-		/// Type representing the unique ID of a pool.
-		type RewardPoolId: FullCodec
-			+ MaxEncodedLen
-			+ Default
-			+ Debug
-			+ TypeInfo
-			+ Eq
-			+ PartialEq
-			+ Ord
-			+ Copy
-			+ Zero
-			+ One
-			+ SafeArithmetic
-			+ From<u128>;
-
 		/// The position id type.
 		type PositionId: Parameter + Member + Clone + FullCodec + Copy + Zero + One + SafeArithmetic;
 
@@ -280,7 +264,7 @@ pub mod pallet {
 			+ nonfungibles::Create<AccountIdOf<Self>>
 			+ FinancialNft<AccountIdOf<Self>>;
 
-		/// Is used to create staked asset per `Self::RewardPoolId`
+		/// Is used to create staked asset per reward pool
 		type CurrencyFactory: CurrencyFactory<Self::AssetId, Self::Balance>;
 
 		/// Dependency allowing this pallet to transfer funds from one account to another.
@@ -352,7 +336,7 @@ pub mod pallet {
 	/// Abstraction over Stake type
 	pub(crate) type StakeOf<T> = Stake<
 		<T as frame_system::Config>::AccountId,
-		<T as Config>::RewardPoolId,
+		<T as Config>::AssetId,
 		<T as Config>::Balance,
 		Reductions<
 			<T as Config>::AssetId,
@@ -369,7 +353,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn pools)]
 	pub type RewardPools<T: Config> =
-		StorageMap<_, Blake2_128Concat, T::RewardPoolId, RewardPoolOf<T>>;
+		StorageMap<_, Blake2_128Concat, T::AssetId, RewardPoolOf<T>>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn stake_count)]
@@ -385,7 +369,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[allow(clippy::disallowed_types)]
 	pub(super) type RewardsPotIsEmpty<T: Config> =
-		StorageDoubleMap<_, Blake2_128Concat, T::RewardPoolId, Blake2_128Concat, T::AssetId, ()>;
+		StorageDoubleMap<_, Blake2_128Concat, T::AssetId, Blake2_128Concat, T::AssetId, ()>;
 
 	#[pallet::genesis_config]
 	pub struct GenesisConfig<T: Config> {
@@ -423,7 +407,7 @@ pub mod pallet {
 				},
 			};
 			RewardPools::<T>::insert(
-				T::RewardPoolId::from(T::PicaAssetId::get().into()),
+				T::AssetId::from(T::PicaAssetId::get().into()),
 				pica_staking_pool,
 			);
 			// PBLO staking pool
@@ -446,7 +430,7 @@ pub mod pallet {
 				},
 			};
 			RewardPools::<T>::insert(
-				T::RewardPoolId::from(T::PbloAssetId::get().into()),
+				T::AssetId::from(T::PbloAssetId::get().into()),
 				pblo_staking_pool,
 			);
 		}
@@ -482,7 +466,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::stake(T::MaxRewardConfigsPerPool::get()))]
 		pub fn stake(
 			origin: OriginFor<T>,
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			amount: T::Balance,
 			duration_preset: DurationSeconds,
 		) -> DispatchResult {
@@ -538,7 +522,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::update_rewards_pool(reward_updates.len() as u32))]
 		pub fn update_rewards_pool(
 			origin: OriginFor<T>,
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			reward_updates: BoundedBTreeMap<
 				AssetIdOf<T>,
 				RewardUpdate<BalanceOf<T>>,
@@ -566,7 +550,7 @@ pub mod pallet {
 		#[pallet::weight(T::WeightInfo::add_to_rewards_pot())]
 		pub fn add_to_rewards_pot(
 			origin: OriginFor<T>,
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			asset_id: T::AssetId,
 			amount: T::Balance,
 			keep_alive: bool,
@@ -583,7 +567,7 @@ pub mod pallet {
 		type Balance = T::Balance;
 		type RewardConfigsLimit = T::MaxRewardConfigsPerPool;
 		type StakingDurationPresetsLimit = T::MaxStakingDurationPresets;
-		type RewardPoolId = T::RewardPoolId;
+		type RewardPoolId = T::AssetId;
 
 		#[transactional]
 		fn create_staking_pool(
@@ -608,7 +592,7 @@ pub mod pallet {
 						Error::<T>::EndBlockMustBeInTheFuture
 					);
 
-					let pool_id = T::RewardPoolId::from(asset_id.into());
+					let pool_id = T::AssetId::from(asset_id.into());
 					ensure!(
 						!RewardPools::<T>::contains_key(pool_id),
 						Error::<T>::RewardsPoolAlreadyExists
@@ -675,7 +659,7 @@ pub mod pallet {
 
 	impl<T: Config> Staking for Pallet<T> {
 		type AccountId = T::AccountId;
-		type RewardPoolId = T::RewardPoolId;
+		type RewardPoolId = T::AssetId;
 		type Balance = T::Balance;
 		type PositionId = T::PositionId;
 
@@ -982,7 +966,7 @@ pub mod pallet {
 			Ok((rewards_pool.clone(), stake.clone()))
 		}
 
-		pub(crate) fn pool_account_id(pool_id: &T::RewardPoolId) -> T::AccountId {
+		pub(crate) fn pool_account_id(pool_id: &T::AssetId) -> T::AccountId {
 			T::PalletId::get().into_sub_account_truncating(pool_id)
 		}
 
@@ -1038,7 +1022,7 @@ pub mod pallet {
 		}
 
 		pub(crate) fn reward_accumulation_hook_reward_update_calculation(
-			pool_id: T::RewardPoolId,
+			pool_id: T::AssetId,
 			reward: &mut Reward<T::AssetId, T::Balance>,
 			now_seconds: u64,
 		) {
@@ -1111,7 +1095,7 @@ pub mod pallet {
 	impl<T: Config> ProtocolStaking for Pallet<T> {
 		type AssetId = T::AssetId;
 		type AccountId = T::AccountId;
-		type RewardPoolId = T::RewardPoolId;
+		type RewardPoolId = T::AssetId;
 		type Balance = T::Balance;
 
 		fn accumulate_reward(
@@ -1187,7 +1171,7 @@ pub mod pallet {
 						}
 						Self::deposit_event(Event::RewardTransferred {
 							from: from.clone(),
-							pool: *pool,
+							pool_id: *pool,
 							reward_currency,
 							reward_increment,
 						});
@@ -1203,7 +1187,7 @@ pub mod pallet {
 #[transactional]
 fn add_to_rewards_pot<T: Config>(
 	who: T::AccountId,
-	pool_id: T::RewardPoolId,
+	pool_id: T::AssetId,
 	asset_id: T::AssetId,
 	amount: T::Balance,
 	keep_alive: bool,
@@ -1228,7 +1212,7 @@ fn add_to_rewards_pot<T: Config>(
 
 #[transactional]
 fn update_rewards_pool<T: Config>(
-	pool_id: T::RewardPoolId,
+	pool_id: T::AssetId,
 	reward_updates: BoundedBTreeMap<
 		AssetIdOf<T>,
 		RewardUpdate<BalanceOf<T>>,

--- a/frame/staking-rewards/src/test/mod.rs
+++ b/frame/staking-rewards/src/test/mod.rs
@@ -498,7 +498,7 @@ fn test_split_postion() {
 		let reduction = 10_000_000_000_000_u128;
 		let stake = Stake::<
 			<Test as frame_system::Config>::AccountId,
-			RewardPoolId,
+			<Test as Config>::AssetId,
 			Balance,
 			Reductions<CurrencyId, Balance, MaxRewardConfigsPerPool>,
 		> {

--- a/frame/staking-rewards/src/test/prelude.rs
+++ b/frame/staking-rewards/src/test/prelude.rs
@@ -30,7 +30,7 @@ pub(crate) const ONE_YEAR_OF_BLOCKS: u64 = 60 * 60 * 24 * 365 / (block_seconds(1
 
 pub(crate) fn add_to_rewards_pot_and_assert(
 	who: <Test as frame_system::Config>::AccountId,
-	pool_id: <Test as crate::Config>::RewardPoolId,
+	pool_id: <Test as crate::Config>::AssetId,
 	asset_id: <Test as crate::Config>::AssetId,
 	amount: <Test as crate::Config>::Balance,
 ) {
@@ -42,7 +42,7 @@ pub(crate) fn add_to_rewards_pot_and_assert(
 
 pub(crate) fn create_rewards_pool_and_assert(
 	reward_config: RewardPoolConfigurationOf<Test>,
-) -> <Test as crate::Config>::RewardPoolId {
+) -> <Test as crate::Config>::AssetId {
 	assert_ok!(StakingRewards::create_reward_pool(Origin::root(), reward_config.clone()));
 
 	match System::events().last().expect("no events present").event {

--- a/frame/staking-rewards/src/test/runtime.rs
+++ b/frame/staking-rewards/src/test/runtime.rs
@@ -236,7 +236,6 @@ parameter_types! {
 impl pallet_staking_rewards::Config for Test {
 	type Event = Event;
 	type Balance = Balance;
-	type RewardPoolId = RewardPoolId;
 	type PositionId = PositionId;
 	type AssetId = CurrencyId;
 	type FinancialNftInstanceId = FinancialNftInstanceId;

--- a/frame/staking-rewards/src/test/runtime.rs
+++ b/frame/staking-rewards/src/test/runtime.rs
@@ -26,7 +26,6 @@ pub type Balance = u128;
 pub type Amount = i128;
 pub type BlockNumber = u64;
 pub type FinancialNftInstanceId = u64;
-pub type RewardPoolId = u128;
 pub type PositionId = u128;
 
 pub static ALICE: Public =

--- a/runtime/common/src/lib.rs
+++ b/runtime/common/src/lib.rs
@@ -102,8 +102,6 @@ mod types {
 
 	pub type NftInstanceId = u128;
 
-	pub type RewardPoolId = u128;
-
 	pub type PositionId = u128;
 }
 

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -850,7 +850,6 @@ parameter_types! {
 impl pallet_staking_rewards::Config for Runtime {
 	type Event = Event;
 	type Balance = Balance;
-	type RewardPoolId = RewardPoolId;
 	type PositionId = PositionId;
 	type AssetId = CurrencyId;
 	type Assets = Assets;
@@ -1045,7 +1044,6 @@ impl pablo::Config for Runtime {
 	type TWAPInterval = TWAPInterval;
 	type Time = Timestamp;
 	type WeightInfo = weights::pablo::WeightInfo<Runtime>;
-	type RewardPoolId = RewardPoolId;
 	type MaxStakingRewardPools = MaxStakingRewardPools;
 	type MaxRewardConfigsPerPool = MaxRewardConfigsPerPool;
 	type MaxStakingDurationPresets = MaxStakingDurationPresets;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -42,7 +42,7 @@ use common::{
 	multi_existential_deposits, AccountId, AccountIndex, Address, Amount, AuraId, Balance,
 	BlockNumber, BondOfferId, FinancialNftInstanceId, Hash, MaxStringSize, Moment,
 	MosaicRemoteAssetId, NativeExistentialDeposit, PoolId, PositionId, PriceConverter,
-	RewardPoolId, Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT,
+	Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT,
 	MILLISECS_PER_BLOCK, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use composable_support::rpc_helpers::SafeRpcWrapper;

--- a/runtime/dali/src/lib.rs
+++ b/runtime/dali/src/lib.rs
@@ -41,9 +41,9 @@ use common::{
 	impls::DealWithFees,
 	multi_existential_deposits, AccountId, AccountIndex, Address, Amount, AuraId, Balance,
 	BlockNumber, BondOfferId, FinancialNftInstanceId, Hash, MaxStringSize, Moment,
-	MosaicRemoteAssetId, NativeExistentialDeposit, PoolId, PositionId, PriceConverter,
-	Signature, AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT,
-	MILLISECS_PER_BLOCK, NORMAL_DISPATCH_RATIO, SLOT_DURATION,
+	MosaicRemoteAssetId, NativeExistentialDeposit, PoolId, PositionId, PriceConverter, Signature,
+	AVERAGE_ON_INITIALIZE_RATIO, DAYS, HOURS, MAXIMUM_BLOCK_WEIGHT, MILLISECS_PER_BLOCK,
+	NORMAL_DISPATCH_RATIO, SLOT_DURATION,
 };
 use composable_support::rpc_helpers::SafeRpcWrapper;
 use composable_traits::{


### PR DESCRIPTION
Remove T::RewardPoolID from Staking Rewards to keep things simpler