### PR TITLE
Nix commands for every PR

### DIFF
--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
-            This is commit is ${{ github.sha }}
+            This is commit is ${{ github.sha }} aka ${{GITHUB_SHA}}
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
-            This is commit is ${{ github.sha }} aka $GITHUB_SHA
+            This is commit is ${{ github.sha }}
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
-            This is commit is ${{ github.sha }} aka ${{GITHUB_SHA}}
+            This is commit is ${{ github.sha }} aka $GITHUB_SHA
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -32,8 +32,9 @@ jobs:
             ```
             
             Are you on macOS, or do you not have [Nix](https://nixos.org/) installed? No worries, you can also run these commands in Docker like this:
+            _(you only need to run the first command once on your machine)_
             ```bash
-            docker volume create nix # you only need to do this once
+            docker volume create nix
 
             docker run --privileged --rm -v nix:/nix  -v /var/run/docker.sock:/var/run/docker.sock -it nixos/nix bash -c "nix run github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-up -L --option cores 8 --extra-experimental-features nix-command --extra-experimental-features flakes"
             ```

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -1,0 +1,19 @@
+name: Nix Commands PR comment.
+
+on: pull_request
+branches: 
+
+jobs:
+  example_comment_pr:
+    runs-on: ubuntu-latest
+    name: An example job to comment a PR
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+                        
+      - name: Comment PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            Hello world ! :wave:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -1,7 +1,6 @@
 name: Nix Commands PR comment.
 
 on: pull_request
-branches: 
 
 jobs:
   example_comment_pr:

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,6 +15,20 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
+            Spin up a devnet:
+            ```
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-up"
+            ```
+
+            Spin up a XCVM devnet
+            ```
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-xcvm-up"
+            ```
+
+            Build our node:
+            ```
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#composable-node"
+            ```
             This is commit is ${{ github.event.pull_request.head.sha }}
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -14,5 +14,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            Hello world ! :wave:
+            This is commit is {{ github.sha }}
+          comment_includes: 'Nix Commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,20 +15,29 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
+
             Spin up a devnet:
-            ```
-            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-up"
+            ```bash
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-up" -L
             ```
 
             Spin up a XCVM devnet
-            ```
-            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-xcvm-up"
+            ```bash
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-xcvm-up" -L
             ```
 
             Build our node:
+            ```bash
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#composable-node" -L
             ```
-            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#composable-node"
+            
+            Are you on macOS, or do you not have [Nix](https://nixos.org/) installed? No worries, you can also run these commands in Docker like this:
+            ```bash
+            docker volume create nix # you only need to do this once
+
+            docker run --privileged --rm -v nix:/nix  -v /var/run/docker.sock:/var/run/docker.sock -it nixos/nix bash -c "nix run github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-up -L --option cores 8 --extra-experimental-features nix-command --extra-experimental-features flakes"
             ```
-            This is commit is ${{ github.event.pull_request.head.sha }}
+                
+            Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
+            **Nix commands for this PR**
             This is commit is ${{ github.sha }}
-          comment_includes: 'Nix Commands for this PR'
+          comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -14,6 +14,6 @@ jobs:
         uses: thollander/actions-comment-pull-request@v1
         with:
           message: |
-            This is commit is {{ github.sha }}
+            This is commit is ${{ github.sha }}
           comment_includes: 'Nix Commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nix-command-pr-comments.yaml
+++ b/.github/workflows/nix-command-pr-comments.yaml
@@ -15,6 +15,6 @@ jobs:
         with:
           message: |
             **Nix commands for this PR**
-            This is commit is ${{ github.sha }}
+            This is commit is ${{ github.event.pull_request.head.sha }}
           comment_includes: 'Nix commands for this PR'
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR introduces a comment bot that automatically posts preformatted, copy-pastable `nix` commands for every PR. It makes it very easy to spin up a devnet for every possible commit, just by copy and pasting a command in your terminal.