### PR TITLE
Set allow_inplace_checks to false

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,5 +1,6 @@
 queue_rules:
  - name: default
+   allow_inplace_checks: false
    conditions: []
 
 pull_request_rules:


### PR DESCRIPTION
With this change, a dedicated staging branch will be used by mergify, instead of using the PR to test the merging.