### PR TITLE
fixed subshell call to ensure that CI waits for exit code of integration tests

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -974,10 +974,11 @@ jobs:
           echo "PATH=$(pwd):$PATH" >> $GITHUB_ENV
           cd code/integration-tests/runtime-tests
           npm install -q
-          ( export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1 &) | tee runtime-tests.log & RUNTIME_TESTS_PID=$!
+          export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
           until test -f runtime-tests.log; do sleep 1 && echo "waiting tests start"; done;
-          ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=1 "API-WS: disconnected from" > stop.log & )
-          (while : ; do if test $(wc --lines stop.log | cut --delimiter " " --fields 1) -gt 0; then kill -9 $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) & 
+          tail --follow runtime-tests.log &
+          ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )
+          ( while : ; do if test $( wc --lines stop.log | cut --delimiter " " --fields 1 ) -gt 4; then kill -9 $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) & 
           wait $RUNTIME_TESTS_PID
           exit $?
 


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>



## Description
- fixed case when integration tests failed, but CI was success
- waiting for NPM with hope it exists non zero
- cannot (... & PID=$! |  tee log &) as either PID is not set at all or set to subshell (so what ever you put $! it will not capture what is needed
- so made output to UI via tail (unfortunately errors logs are normal for now)
 - https://composablefinance.slack.com/archives/C03MJD3E8KX/p1661391802137939
 - needs @Dom-Roth help to fix or report issues of integration tests NOTE: as soon as this merged refresh to get pass https://github.com/ComposableFi/composable/pull/1586#pullrequestreview-1103924701
