### PR TITLE
feat: docker-wipe-system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -490,6 +490,15 @@
               '';
             };
 
+            docker-wipe-system =
+              pkgs.writeShellScriptBin "docker-wipe-system" ''
+                echo "Wiping all docker containers, images, and volumes";
+                docker stop $(docker ps -q)
+                docker system prune -f
+                docker rmi -f $(docker images -a -q)    
+                docker volume prune -f
+              '';
+
             composable-book = import ./book/default.nix {
               crane = crane-stable;
               inherit cargo stdenv;


### PR DESCRIPTION
I've had multiple people come to me reporting unexpected behavior with running our devnet because of docker container/image/volume caches. This PR adds a nix package that wipes your entire docker system in case any of this occurs. 