### PR TITLE
[CU-2yktqzz] Use StorageDoubleMap for Instance

### DIFF
--- a/code/parachain/frame/fnft/src/lib.rs
+++ b/code/parachain/frame/fnft/src/lib.rs
@@ -253,8 +253,6 @@ pub mod pallet {
 		}
 
 		/// Returns an iterator of the items of a `collection` in existence.
-		// REVIEW(connor): Is this still the case?
-		/// NOTE: iterating this list invokes a storage read per item.
 		fn items(collection: &Self::CollectionId) -> Box<dyn Iterator<Item = Self::ItemId>> {
 			Box::new(Instance::<T>::iter_key_prefix(collection))
 		}

--- a/code/parachain/frame/fnft/src/test/nonfungibles/mutate.rs
+++ b/code/parachain/frame/fnft/src/test/nonfungibles/mutate.rs
@@ -39,12 +39,6 @@ mod mint_into {
 			}));
 
 			assert_eq!(
-				CollectionInstances::<MockRuntime>::get(TEST_COLLECTION_ID).unwrap(),
-				BTreeSet::from([NEW_NFT_ID]),
-				"class should only have one instance"
-			);
-
-			assert_eq!(
 				OwnerInstances::<MockRuntime>::get(&ALICE).unwrap(),
 				BTreeSet::from([(TEST_COLLECTION_ID, NEW_NFT_ID)]),
 				"ALICE should only have one instance"
@@ -223,12 +217,6 @@ mod burn_from {
 			}));
 
 			assert_eq!(
-				CollectionInstances::<MockRuntime>::get(TEST_COLLECTION_ID).unwrap(),
-				BTreeSet::from(new_nft_ids),
-				"class should have all of the original NFTs except for the one burned"
-			);
-
-			assert_eq!(
 				OwnerInstances::<MockRuntime>::get(&ALICE).unwrap(),
 				to_btree(TEST_COLLECTION_ID, &new_nft_ids),
 				"ALICE should have all of the original NFTs except for the one burned"
@@ -254,12 +242,6 @@ mod burn_from {
 				collection_id: TEST_COLLECTION_ID,
 				instance_id: new_id,
 			}));
-
-			assert_eq!(
-				CollectionInstances::<MockRuntime>::get(TEST_COLLECTION_ID).unwrap(),
-				BTreeSet::new(),
-				"class should not have any instances"
-			);
 
 			assert_eq!(
 				OwnerInstances::<MockRuntime>::get(&ALICE).unwrap(),

--- a/code/parachain/frame/fnft/src/test/nonfungibles/mutate.rs
+++ b/code/parachain/frame/fnft/src/test/nonfungibles/mutate.rs
@@ -51,7 +51,7 @@ mod mint_into {
 			);
 
 			assert_eq!(
-				Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, NEW_NFT_ID)).unwrap(),
+				Instance::<MockRuntime>::get(TEST_COLLECTION_ID, NEW_NFT_ID).unwrap(),
 				(ALICE, BTreeMap::new()),
 				"owner should be ALICE, with no attributes"
 			);
@@ -148,10 +148,7 @@ mod set_attribute {
 
 			for should_not_be_mutated_nft_id in other_nft_ids {
 				assert_eq!(
-					Instance::<MockRuntime>::get(&(
-						TEST_COLLECTION_ID,
-						should_not_be_mutated_nft_id
-					)),
+					Instance::<MockRuntime>::get(TEST_COLLECTION_ID, should_not_be_mutated_nft_id),
 					Some((ALICE, BTreeMap::from([]))),
 					"instance should not have any attributes"
 				);
@@ -238,7 +235,7 @@ mod burn_from {
 			);
 
 			assert_eq!(
-				Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, nft_to_burn)),
+				Instance::<MockRuntime>::get(TEST_COLLECTION_ID, nft_to_burn),
 				None,
 				"instance should not exist"
 			);
@@ -271,7 +268,7 @@ mod burn_from {
 			);
 
 			assert_eq!(
-				Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, new_id)),
+				Instance::<MockRuntime>::get(TEST_COLLECTION_ID, new_id),
 				None,
 				"instance should not exist"
 			);

--- a/code/parachain/frame/fnft/src/test/nonfungibles/transfer.rs
+++ b/code/parachain/frame/fnft/src/test/nonfungibles/transfer.rs
@@ -54,7 +54,7 @@ fn simple() {
 		);
 
 		assert_eq!(
-			Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, created_nft_id)),
+			Instance::<MockRuntime>::get(TEST_COLLECTION_ID, created_nft_id),
 			Some((BOB, BTreeMap::from([(1_u32.encode(), 1_u32.encode())]))),
 			"owner of transferred NFT should be BOB after transfer"
 		);

--- a/code/parachain/frame/fnft/src/test/prelude.rs
+++ b/code/parachain/frame/fnft/src/test/prelude.rs
@@ -55,7 +55,7 @@ pub(crate) fn mint_nft_and_assert() -> FinancialNftInstanceIdOf<MockRuntime> {
 	));
 
 	assert_eq!(
-		Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, created_nft_id)).unwrap(),
+		Instance::<MockRuntime>::get(TEST_COLLECTION_ID, created_nft_id).unwrap(),
 		(ALICE, BTreeMap::from([(1_u32.encode(), 1_u32.encode())])),
 		"owner should be ALICE"
 	);
@@ -91,7 +91,7 @@ pub(crate) fn mint_into_and_assert() -> FinancialNftInstanceIdOf<MockRuntime> {
 	);
 
 	assert_eq!(
-		Instance::<MockRuntime>::get(&(TEST_COLLECTION_ID, NEW_NFT_ID)).unwrap(),
+		Instance::<MockRuntime>::get(TEST_COLLECTION_ID, NEW_NFT_ID).unwrap(),
 		(ALICE, BTreeMap::new()),
 		"owner should be ALICE, with no attributes"
 	);
@@ -170,7 +170,7 @@ pub(crate) fn add_attributes_and_assert<
 		);
 	}
 
-	let (found_owner, data) = Instance::<MockRuntime>::get(&(class, *instance)).unwrap();
+	let (found_owner, data) = Instance::<MockRuntime>::get(class, *instance).unwrap();
 
 	assert_eq!(owner, found_owner, "instance owner should be {owner}");
 

--- a/code/parachain/frame/fnft/src/test/prelude.rs
+++ b/code/parachain/frame/fnft/src/test/prelude.rs
@@ -11,7 +11,7 @@ use std::{
 };
 
 use crate::{
-	pallet::{CollectionInstances, Event as NftEvent, Instance, OwnerInstances},
+	pallet::{Event as NftEvent, Instance, OwnerInstances},
 	test::{
 		mock::{Event, MockRuntime, Nft},
 		ALICE, BOB,
@@ -34,12 +34,6 @@ pub(crate) fn mint_nft_and_assert() -> FinancialNftInstanceIdOf<MockRuntime> {
 		collection_id: TEST_COLLECTION_ID,
 		instance_id: created_nft_id,
 	}));
-
-	assert_eq!(
-		CollectionInstances::<MockRuntime>::get(TEST_COLLECTION_ID).unwrap(),
-		BTreeSet::from([created_nft_id]),
-		"class should only have one instance"
-	);
 
 	assert_eq!(
 		OwnerInstances::<MockRuntime>::get(&ALICE).unwrap(),
@@ -77,12 +71,6 @@ pub(crate) fn mint_into_and_assert() -> FinancialNftInstanceIdOf<MockRuntime> {
 		collection_id: TEST_COLLECTION_ID,
 		instance_id: NEW_NFT_ID,
 	}));
-
-	assert_eq!(
-		CollectionInstances::<MockRuntime>::get(&TEST_COLLECTION_ID).unwrap(),
-		BTreeSet::from([NEW_NFT_ID]),
-		"class should only have one instance"
-	);
 
 	assert_eq!(
 		OwnerInstances::<MockRuntime>::get(&ALICE).unwrap(),

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -234,7 +234,7 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 		assert_eq!(balance(staked_asset_id, &ALICE), AMOUNT);
 		assert_eq!(balance(staked_asset_id, &fnft_asset_account), AMOUNT);
 
-		assert!(FinancialNft::instance((1, 0)).is_some());
+		assert!(FinancialNft::instance(1, 0).is_some());
 
 		assert_last_event_with::<Test, _>(|event| match event {
 			Event::StakingRewards(crate::Event::Staked {
@@ -404,7 +404,7 @@ fn unstake_in_case_of_zero_claims_and_early_unlock_should_work() {
 		// assert_eq!(balance(staked_asset_id, &fnft_asset_account), penalty);
 
 		// Assert fNFT is removed from storage
-		assert!(FinancialNft::instance((1, 0)).is_none());
+		assert!(FinancialNft::instance(1, 0).is_none());
 	});
 }
 


### PR DESCRIPTION
## Issue
[[CU-2yktqzz]](https://app.clickup.com/t/2yktqzz)

## Description
Updated the storage of `Instance` from `StorageMap` to `StorageDoubleMap`.

Removed `CollectionInstances` as its behavior can be mimicked via `StorageDoubleMap` functions.