### PR TITLE
[CU-2vr59uq] Add `start_block` to Rewards Pool

### DIFF
--- a/code/parachain/frame/composable-traits/src/staking/mod.rs
+++ b/code/parachain/frame/composable-traits/src/staking/mod.rs
@@ -120,6 +120,9 @@ pub struct RewardPool<
 	/// Already claimed shares by stakers by unstaking
 	pub claimed_shares: Balance,
 
+	/// Pool will start adding rewards to the pool at this block number.
+	pub start_block: BlockNumber,
+
 	/// Pool would stop adding rewards to pool at this block number.
 	pub end_block: BlockNumber,
 
@@ -176,6 +179,8 @@ pub enum RewardPoolConfiguration<
 		owner: AccountId,
 		/// The staked asset id of the reward pool.
 		asset_id: AssetId,
+		/// Pool will start adding rewards to the pool at this block number.
+		start_block: BlockNumber,
 		/// Pool would stop adding rewards to pool at this block number.
 		end_block: BlockNumber,
 		/// initial reward configuration for this pool

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -673,7 +673,8 @@ pub mod pallet {
 					.map_err(|_| Error::<T>::StakingPoolConfigError)?;
 			let lock = LockConfig { duration_presets, unlock_penalty: Perbill::from_percent(5) };
 			let five_years_block = 5 * 365 * 24 * 60 * 60 / T::MsPerBlock::get();
-			let start_block = frame_system::Pallet::<T>::current_block_number();
+			// NOTE(connor): `start_block` must greater than current block
+			let start_block = frame_system::Pallet::<T>::current_block_number() + 1_u32.into();
 			let end_block = start_block + five_years_block.into();
 
 			Ok(RewardPoolConfiguration::RewardRateBasedIncentive {

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -673,11 +673,13 @@ pub mod pallet {
 					.map_err(|_| Error::<T>::StakingPoolConfigError)?;
 			let lock = LockConfig { duration_presets, unlock_penalty: Perbill::from_percent(5) };
 			let five_years_block = 5 * 365 * 24 * 60 * 60 / T::MsPerBlock::get();
-			let end_block =
-				frame_system::Pallet::<T>::current_block_number() + five_years_block.into();
+			let start_block = frame_system::Pallet::<T>::current_block_number();
+			let end_block = start_block + five_years_block.into();
+
 			Ok(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: Self::account_id(pool_id),
 				asset_id: Self::lp_token(*pool_id)?,
+				start_block,
 				end_block,
 				reward_configs,
 				lock,

--- a/code/parachain/frame/staking-rewards/src/benchmarking.rs
+++ b/code/parachain/frame/staking-rewards/src/benchmarking.rs
@@ -31,6 +31,7 @@ fn get_reward_pool<T: Config>(
 	let pool_init_config = RewardRateBasedIncentive {
 		owner,
 		asset_id: BASE_ASSET_ID.into(),
+		start_block: 0_u128.saturated_into(),
 		end_block: 5_u128.saturated_into(),
 		reward_configs: reward_config::<T>(reward_count),
 		lock: lock_config::<T>(),
@@ -190,6 +191,7 @@ benchmarks! {
 		let pool_id = <Pallet<T> as ManageStaking>::create_staking_pool(RewardRateBasedIncentive {
 			owner: user,
 			asset_id: pool_asset_id,
+			start_block: 0_u128.saturated_into(),
 			end_block: 5_u128.saturated_into(),
 			reward_configs: [(reward_asset_id, reward_config)]
 				.into_iter()

--- a/code/parachain/frame/staking-rewards/src/benchmarking.rs
+++ b/code/parachain/frame/staking-rewards/src/benchmarking.rs
@@ -31,7 +31,7 @@ fn get_reward_pool<T: Config>(
 	let pool_init_config = RewardRateBasedIncentive {
 		owner,
 		asset_id: BASE_ASSET_ID.into(),
-		start_block: 0_u128.saturated_into(),
+		start_block: 1_u128.saturated_into(),
 		end_block: 5_u128.saturated_into(),
 		reward_configs: reward_config::<T>(reward_count),
 		lock: lock_config::<T>(),
@@ -106,6 +106,9 @@ benchmarks! {
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);
+
+		frame_system::Pallet::<T>::set_block_number(1.into());
+
 		<Pallet<T>>::create_reward_pool(RawOrigin::Root.into(), get_reward_pool::<T>(pool_owner, r))?;
 		<T::Assets as Mutate<T::AccountId>>::mint_into(asset_id, &staker, amount * 2.into())?;
 	}: _(RawOrigin::Signed(staker.clone()), asset_id, amount, duration_preset)
@@ -121,6 +124,9 @@ benchmarks! {
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);
+
+		frame_system::Pallet::<T>::set_block_number(1.into());
+
 		<Pallet<T>>::create_reward_pool(RawOrigin::Root.into(), get_reward_pool::<T>(pool_owner, r))?;
 		<T::Assets as Mutate<T::AccountId>>::mint_into(asset_id, &staker, amount * 3.into()).expect("an asset minting expected");
 		<Pallet<T>>::stake(RawOrigin::Signed(staker.clone()).into(), asset_id, amount, duration_preset)?;
@@ -137,6 +143,9 @@ benchmarks! {
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);
+
+		frame_system::Pallet::<T>::set_block_number(1.into());
+
 		<Pallet<T>>::create_reward_pool(RawOrigin::Root.into(), get_reward_pool::<T>(pool_owner, r))?;
 		<T::Assets as Mutate<T::AccountId>>::mint_into(asset_id, &staker, amount * 2.into())?;
 		<Pallet<T>>::stake(RawOrigin::Signed(staker.clone()).into(), asset_id, amount, duration_preset)?;
@@ -191,7 +200,7 @@ benchmarks! {
 		let pool_id = <Pallet<T> as ManageStaking>::create_staking_pool(RewardRateBasedIncentive {
 			owner: user,
 			asset_id: pool_asset_id,
-			start_block: 0_u128.saturated_into(),
+			start_block: 1_u128.saturated_into(),
 			end_block: 5_u128.saturated_into(),
 			reward_configs: [(reward_asset_id, reward_config)]
 				.into_iter()
@@ -239,6 +248,9 @@ benchmarks! {
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);
+
+		frame_system::Pallet::<T>::set_block_number(1.into());
+
 		<Pallet<T>>::create_reward_pool(RawOrigin::Root.into(), get_reward_pool::<T>(pool_owner, r))?;
 		<T::Assets as Mutate<T::AccountId>>::mint_into(asset_id, &staker, amount * 2.into())?;
 		<Pallet<T>>::stake(RawOrigin::Signed(staker.clone()).into(), asset_id, amount, duration_preset)?;

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -217,6 +217,8 @@ pub mod pallet {
 		UnimplementedRewardPoolConfiguration,
 		/// Rewards pool not found.
 		RewardsPoolNotFound,
+		/// Rewards pool has not started.
+		RewardsPoolHasNotStarted,
 		/// Error when creating reduction configs.
 		ReductionConfigProblem,
 		/// Not enough assets for a stake.
@@ -724,6 +726,11 @@ pub mod pallet {
 		) -> Result<Self::PositionId, DispatchError> {
 			let mut rewards_pool =
 				RewardPools::<T>::try_get(pool_id).map_err(|_| Error::<T>::RewardsPoolNotFound)?;
+
+			ensure!(
+				rewards_pool.start_block <= frame_system::Pallet::<T>::current_block_number(),
+				Error::<T>::RewardsPoolHasNotStarted
+			);
 
 			let reward_multiplier = Self::reward_multiplier(&rewards_pool, duration_preset)
 				.ok_or(Error::<T>::NoDurationPresetsConfigured)?;

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -210,7 +210,7 @@ pub mod pallet {
 		/// Too many rewarded asset types per pool violating the storage allowed.
 		TooManyRewardAssetTypes,
 		/// Invalid start block number provided for creating a pool.
-		StartBlockMustBeNowOrLater,
+		StartBlockMustBeAfterCurrentBlock,
 		/// Invalid end block number provided for creating a pool.
 		EndBlockMustBeAfterStartBlock,
 		/// Unimplemented reward pool type.
@@ -641,7 +641,7 @@ pub mod pallet {
 					ensure!(
 						// Exlusively greater than to prevent erros/attacks
 						start_block > frame_system::Pallet::<T>::current_block_number(),
-						Error::<T>::StartBlockMustBeNowOrLater
+						Error::<T>::StartBlockMustBeAfterCurrentBlock
 					);
 					ensure!(end_block > start_block, Error::<T>::EndBlockMustBeAfterStartBlock);
 

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -1243,6 +1243,11 @@ pub mod pallet {
 			let mut total_weight = unix_time_now_weight;
 
 			RewardPools::<T>::translate(|pool_id, mut reward_pool: RewardPoolOf<T>| {
+				// If reward pool has not started, do not accumulate rewards or adjust weight
+				if reward_pool.start_block > frame_system::Pallet::<T>::current_block_number() {
+					return Some(reward_pool)
+				}
+
 				for (asset_id, reward) in &mut reward_pool.rewards {
 					Self::reward_accumulation_hook_reward_update_calculation(
 						pool_id,

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -639,7 +639,7 @@ pub mod pallet {
 				} => {
 					// now < start_block < end_block
 					ensure!(
-						// Exlusively greater than to prevent erros/attacks
+						// Exclusively greater than to prevent errors/attacks
 						start_block > frame_system::Pallet::<T>::current_block_number(),
 						Error::<T>::StartBlockMustBeAfterCurrentBlock
 					);

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -1269,11 +1269,9 @@ pub mod pallet {
 					// NOTE: `StorageMap::translate` does one read and one write per item
 					T::DbWeight::get().reads(1) +
 					T::DbWeight::get().writes(1);
-
-					Some(reward_pool)
-				} else {
-					Some(reward_pool)
 				}
+
+				Some(reward_pool)
 			});
 
 			total_weight

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -66,6 +66,7 @@ fn test_create_reward_pool_invalid_end_block() {
 					owner: ALICE,
 					asset_id: PICA::ID,
 					// end block can't be before the current block
+					start_block: 0,
 					end_block: 0,
 					reward_configs: default_reward_config(),
 					lock: default_lock_config(),
@@ -73,7 +74,7 @@ fn test_create_reward_pool_invalid_end_block() {
 					financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
 				}
 			),
-			crate::Error::<Test>::EndBlockMustBeInTheFuture
+			crate::Error::<Test>::EndBlockMustBeAfterStartBlock
 		);
 	});
 }
@@ -562,6 +563,7 @@ fn test_split_position() {
 		let pool_init_config = RewardRateBasedIncentive {
 			owner: ALICE,
 			asset_id: PICA::ID,
+			start_block: 1,
 			end_block: 5,
 			reward_configs: default_reward_config(),
 			lock: default_lock_config(),
@@ -869,6 +871,7 @@ fn create_default_reward_pool() {
 			RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
+				start_block: 0,
 				end_block: 5,
 				reward_configs: default_reward_config(),
 				lock: default_lock_config(),
@@ -885,6 +888,7 @@ fn get_default_reward_pool() -> RewardPoolConfigurationOf<Test> {
 	RewardRateBasedIncentive {
 		owner: ALICE,
 		asset_id: PICA::ID,
+		start_block: 0,
 		end_block: 5,
 		reward_configs: default_reward_config(),
 		lock: default_lock_config(),

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -4,6 +4,7 @@ use crate::{
 	Config, RewardPoolConfigurationOf, RewardPools, StakeOf, Stakes,
 };
 use composable_tests_helpers::test::{
+	block::process_and_progress_blocks,
 	currency::{BTC, PICA, USDT, XPICA},
 	helper::{assert_extrinsic_event, assert_extrinsic_event_with, assert_last_event_with},
 };
@@ -66,7 +67,7 @@ fn test_create_reward_pool_invalid_end_block() {
 					owner: ALICE,
 					asset_id: PICA::ID,
 					// end block can't be before the current block
-					start_block: 1,
+					start_block: 2,
 					end_block: 0,
 					reward_configs: default_reward_config(),
 					lock: default_lock_config(),
@@ -82,7 +83,7 @@ fn test_create_reward_pool_invalid_end_block() {
 #[test]
 fn stake_in_case_of_low_balance_should_not_work() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		const AMOUNT: u128 = 100_500_u128;
 
 		create_default_reward_pool();
@@ -90,6 +91,7 @@ fn stake_in_case_of_low_balance_should_not_work() {
 		let asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		assert_eq!(balance(asset_id, &ALICE), 0);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_noop!(
 			StakingRewards::stake(Origin::signed(ALICE), PICA::ID, AMOUNT, ONE_HOUR),
 			crate::Error::<Test>::NotEnoughAssets
@@ -99,10 +101,13 @@ fn stake_in_case_of_low_balance_should_not_work() {
 	});
 }
 
+// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
+// `System::set_block_number()` because amounts being checked aren't valid.
+#[ignore]
 #[test]
 fn stake_in_case_of_zero_inflation_should_work() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 		let staker: Public = ALICE;
@@ -113,6 +118,7 @@ fn stake_in_case_of_zero_inflation_should_work() {
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		mint_assets([staker], [staked_asset_id], amount * 2);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		let fnft_instance_id = assert_extrinsic_event_with::<Test, _, _, _>(
 			StakingRewards::stake(Origin::signed(staker), PICA::ID, amount, duration_preset),
 			|event| match event {
@@ -181,6 +187,9 @@ fn stake_in_case_of_zero_inflation_should_work() {
 // this is almost the exact same as the above function
 // spot the difference!
 // maybe do a proptest with different inflation rates?
+// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
+// `System::set_block_number()` because amounts being checked aren't valid.
+#[ignore]
 #[test]
 fn stake_in_case_of_not_zero_inflation_should_work() {
 	new_test_ext().execute_with(|| {
@@ -190,7 +199,7 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 		const TOTAL_SHARES: u128 = 200;
 		let fnft_asset_account = FinancialNft::asset_account(&1, &0);
 
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
@@ -201,6 +210,7 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 			TOTAL_SHARES,
 		);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(ALICE), PICA::ID, AMOUNT, DURATION_PRESET));
 		let rewards_pool = StakingRewards::pools(PICA::ID).expect("rewards_pool expected");
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, DURATION_PRESET)
@@ -258,10 +268,13 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 	});
 }
 
+// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
+// `System::set_block_number()` because amounts being checked aren't valid.
+#[ignore]
 #[test]
 fn test_extend_stake_amount() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 		let staker = ALICE;
@@ -276,13 +289,18 @@ fn test_extend_stake_amount() {
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		mint_assets([staker], [staked_asset_id], amount * 2 + existential_deposit);
 		update_total_rewards_and_total_shares_in_rewards_pool(pool_id, total_rewards, total_shares);
+
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(staker), pool_id, amount, duration_preset));
+
 		let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, duration_preset)
 			.expect("reward_multiplier expected");
 		let boosted_amount = StakingRewards::boosted_amount(reward_multiplier, amount);
 		let inflation = boosted_amount * total_rewards / total_shares;
+
 		assert_ok!(StakingRewards::extend(Origin::signed(staker), 1, 0, extend_amount));
+
 		let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 
 		let total_rewards =	rewards_pool
@@ -347,7 +365,7 @@ fn unstake_non_existent_stake_should_not_work() {
 #[test]
 fn not_owner_of_stake_can_not_unstake() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 		let owner = ALICE;
 		let not_owner = BOB;
@@ -359,6 +377,7 @@ fn not_owner_of_stake_can_not_unstake() {
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		mint_assets([owner, not_owner], [staked_asset_id], amount * 2);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(owner), pool_id, amount, duration_preset));
 
 		assert_noop!(
@@ -371,7 +390,7 @@ fn not_owner_of_stake_can_not_unstake() {
 #[test]
 fn unstake_in_case_of_zero_claims_and_early_unlock_should_work() {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 		let staker = ALICE;
@@ -383,6 +402,7 @@ fn unstake_in_case_of_zero_claims_and_early_unlock_should_work() {
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		mint_assets([staker], [staked_asset_id], amount * 2);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(staker), pool_id, amount, duration_preset));
 		let unlock_penalty =
 			StakingRewards::stakes(1, 0).expect("stake expected").lock.unlock_penalty;
@@ -564,7 +584,7 @@ fn test_split_position() {
 		let pool_init_config = RewardRateBasedIncentive {
 			owner: ALICE,
 			asset_id: PICA::ID,
-			start_block: 1,
+			start_block: 2,
 			end_block: 5,
 			reward_configs: default_reward_config(),
 			lock: default_lock_config(),
@@ -658,11 +678,12 @@ mod claim {
 			total_rewards,
 			total_shares,
 			Some(claim),
-			|pool_id, _, _, staked_asset_id| {
+			|pool_id, _unlock_penalty, _stake_duration, staked_asset_id| {
 				let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 
 				// Ensure that the value of the staked asset has **not** changed
 				assert_eq!(balance(staked_asset_id, &staker), amount);
+				process_and_progress_blocks::<StakingRewards, Test>(1);
 				assert_ok!(StakingRewards::claim(Origin::signed(staker), 1, 0));
 				assert_eq!(balance(staked_asset_id, &staker), amount);
 
@@ -694,7 +715,7 @@ mod claim {
 			total_rewards,
 			total_shares,
 			Some(claim),
-			|pool_id, _, _, staked_asset_id| {
+			|pool_id, _unlock_penalty, _stake_duration, staked_asset_id| {
 				let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 
 				// First claim
@@ -742,14 +763,7 @@ mod claim {
 			total_rewards,
 			total_shares,
 			Some(claim),
-			|_, _, stake_duration, _| {
-				let second_in_milliseconds = 1000;
-				Timestamp::set_timestamp(
-					Timestamp::now()
-						.saturating_add(stake_duration.saturating_mul(second_in_milliseconds))
-						.saturating_add(second_in_milliseconds),
-				);
-
+			|_pool_id, _unlock_penalty, _stake_duration, _staked_asset_id| {
 				assert_ok!(StakingRewards::claim(Origin::signed(staker), 1, 0));
 
 				assert_last_event::<Test, _>(|e| {
@@ -781,14 +795,7 @@ mod claim {
 			total_rewards,
 			total_shares,
 			Some(claim),
-			|pool_id, _, stake_duration, _| {
-				let second_in_milliseconds = 1000;
-				Timestamp::set_timestamp(
-					Timestamp::now()
-						.saturating_add(stake_duration.saturating_mul(second_in_milliseconds))
-						.saturating_add(second_in_milliseconds),
-				);
-
+			|pool_id, _unlock_penalty, _stake_duration, _staked_asset_id| {
 				assert_ok!(StakingRewards::claim(Origin::signed(staker), 1, 0));
 
 				assert_last_event::<Test, _>(|e| {
@@ -817,7 +824,6 @@ mod claim {
 ///
 /// `execute` closure will provide:
 /// - `pool_id`
-/// - `stake_id`
 /// - `unlock_penalty`
 /// - `stake_duration`
 /// - `staked_asset_id`
@@ -831,7 +837,7 @@ fn with_stake<R>(
 	execute: impl FnOnce(u128, Perbill, u64, u128) -> R,
 ) -> R {
 	new_test_ext().execute_with(|| {
-		System::set_block_number(1);
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 
 		let pool_id = PICA::ID;
@@ -846,6 +852,7 @@ fn with_stake<R>(
 
 		update_total_rewards_and_total_shares_in_rewards_pool(pool_id, total_rewards, total_shares);
 
+		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(staker), pool_id, amount, duration));
 		assert_eq!(balance(staked_asset_id, &staker), amount);
 
@@ -872,7 +879,7 @@ fn create_default_reward_pool() {
 			RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
-				start_block: 1,
+				start_block: 2,
 				end_block: 5,
 				reward_configs: default_reward_config(),
 				lock: default_lock_config(),
@@ -889,7 +896,7 @@ fn get_default_reward_pool() -> RewardPoolConfigurationOf<Test> {
 	RewardRateBasedIncentive {
 		owner: ALICE,
 		asset_id: PICA::ID,
-		start_block: 1,
+		start_block: 2,
 		end_block: 5,
 		reward_configs: default_reward_config(),
 		lock: default_lock_config(),
@@ -919,14 +926,6 @@ fn default_reward_config() -> BoundedBTreeMap<u128, RewardConfig<u128>, MaxRewar
 	.into_iter()
 	.try_collect()
 	.unwrap()
-}
-
-pub fn assert_has_event<T, F>(matcher: F)
-where
-	T: Config,
-	F: Fn(&EventRecord<Event, H256>) -> bool,
-{
-	assert!(System::events().iter().any(matcher));
 }
 
 pub fn assert_last_event<T, F>(matcher: F)

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -66,7 +66,7 @@ fn test_create_reward_pool_invalid_end_block() {
 					owner: ALICE,
 					asset_id: PICA::ID,
 					// end block can't be before the current block
-					start_block: 0,
+					start_block: 1,
 					end_block: 0,
 					reward_configs: default_reward_config(),
 					lock: default_lock_config(),
@@ -347,6 +347,7 @@ fn unstake_non_existent_stake_should_not_work() {
 #[test]
 fn not_owner_of_stake_can_not_unstake() {
 	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
 		let owner = ALICE;
 		let not_owner = BOB;
@@ -871,7 +872,7 @@ fn create_default_reward_pool() {
 			RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
-				start_block: 0,
+				start_block: 1,
 				end_block: 5,
 				reward_configs: default_reward_config(),
 				lock: default_lock_config(),
@@ -888,7 +889,7 @@ fn get_default_reward_pool() -> RewardPoolConfigurationOf<Test> {
 	RewardRateBasedIncentive {
 		owner: ALICE,
 		asset_id: PICA::ID,
-		start_block: 0,
+		start_block: 1,
 		end_block: 5,
 		reward_configs: default_reward_config(),
 		lock: default_lock_config(),

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -81,6 +81,24 @@ fn test_create_reward_pool_invalid_end_block() {
 }
 
 #[test]
+fn stake_should_fail_before_start_of_rewards_pool() {
+	new_test_ext().execute_with(|| {
+		let staker = ALICE;
+		let amount = 100_500;
+		let duration = ONE_HOUR;
+		let pool_id = PICA::ID;
+
+		process_and_progress_blocks::<StakingRewards, Test>(1);
+		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
+
+		assert_noop!(
+			StakingRewards::stake(Origin::signed(staker), pool_id, amount, duration),
+			crate::Error::<Test>::RewardsPoolHasNotStarted
+		);
+	});
+}
+
+#[test]
 fn stake_in_case_of_low_balance_should_not_work() {
 	new_test_ext().execute_with(|| {
 		process_and_progress_blocks::<StakingRewards, Test>(1);
@@ -101,9 +119,6 @@ fn stake_in_case_of_low_balance_should_not_work() {
 	});
 }
 
-// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
-// `System::set_block_number()` because amounts being checked aren't valid.
-#[ignore]
 #[test]
 fn stake_in_case_of_zero_inflation_should_work() {
 	new_test_ext().execute_with(|| {
@@ -155,7 +170,7 @@ fn stake_in_case_of_zero_inflation_should_work() {
 				share: StakingRewards::boosted_amount(reward_multiplier, amount),
 				reductions,
 				lock: Lock {
-					started_at: <Test as crate::Config>::UnixTime::now(),
+					started_at: 12,
 					duration: duration_preset,
 					unlock_penalty: rewards_pool.lock.unlock_penalty,
 				},
@@ -187,9 +202,6 @@ fn stake_in_case_of_zero_inflation_should_work() {
 // this is almost the exact same as the above function
 // spot the difference!
 // maybe do a proptest with different inflation rates?
-// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
-// `System::set_block_number()` because amounts being checked aren't valid.
-#[ignore]
 #[test]
 fn stake_in_case_of_not_zero_inflation_should_work() {
 	new_test_ext().execute_with(|| {
@@ -234,7 +246,7 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 				share: StakingRewards::boosted_amount(reward_multiplier, AMOUNT),
 				reductions,
 				lock: Lock {
-					started_at: <Test as crate::Config>::UnixTime::now(),
+					started_at: 12,
 					duration: DURATION_PRESET,
 					unlock_penalty: rewards_pool.lock.unlock_penalty,
 				},
@@ -268,9 +280,6 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 	});
 }
 
-// NOTE(connor): Bad test, fails when using `process_and_progress_blocks` but passes with
-// `System::set_block_number()` because amounts being checked aren't valid.
-#[ignore]
 #[test]
 fn test_extend_stake_amount() {
 	new_test_ext().execute_with(|| {
@@ -331,7 +340,7 @@ fn test_extend_stake_amount() {
 				share: boosted_amount + extend_amount,
 				reductions,
 				lock: Lock {
-					started_at: <Test as crate::Config>::UnixTime::now(),
+					started_at: 12,
 					duration: duration_preset,
 					unlock_penalty: rewards_pool.lock.unlock_penalty,
 				},

--- a/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
@@ -40,8 +40,8 @@ fn test_reward_update_calculation() {
 		let pool_id = create_rewards_pool_and_assert(RewardRateBasedIncentive {
 			owner: ALICE,
 			asset_id: PICA::ID,
-			start_block: 1,
-			end_block: ONE_YEAR_OF_BLOCKS * 10,
+			start_block: 2,
+			end_block: ONE_YEAR_OF_BLOCKS * 10 + 1,
 			reward_configs: [(PICA::ID, reward_config)].into_iter().try_collect().unwrap(),
 			lock: default_lock_config(),
 			share_asset_id: XPICA::ID,
@@ -157,8 +157,8 @@ fn test_accumulate_rewards_pool_empty_refill() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: A::ID,
-				start_block: current_block,
-				end_block: current_block + ONE_YEAR_OF_BLOCKS,
+				start_block: current_block + 1,
+				end_block: current_block + ONE_YEAR_OF_BLOCKS + 1,
 				reward_configs: [
 					(
 						A::ID,
@@ -285,8 +285,8 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: A::ID,
-				start_block: current_block,
-				end_block: current_block + ONE_YEAR_OF_BLOCKS,
+				start_block: current_block + 1,
+				end_block: current_block + ONE_YEAR_OF_BLOCKS + 1,
 				reward_configs: [
 					(
 						A::ID,
@@ -320,8 +320,8 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: BOB,
 				asset_id: C::ID,
-				start_block: current_block,
-				end_block: current_block + ONE_YEAR_OF_BLOCKS,
+				start_block: current_block + 1,
+				end_block: current_block + ONE_YEAR_OF_BLOCKS + 1,
 				reward_configs: [
 					(
 						D::ID,
@@ -582,8 +582,8 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: CHARLIE,
 				asset_id: F::ID,
-				start_block: current_block,
-				end_block: current_block + ONE_YEAR_OF_BLOCKS,
+				start_block: current_block + 1,
+				end_block: current_block + ONE_YEAR_OF_BLOCKS + 1,
 				reward_configs: [(
 					F::ID,
 					RewardConfig {

--- a/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
@@ -40,7 +40,7 @@ fn test_reward_update_calculation() {
 		let pool_id = create_rewards_pool_and_assert(RewardRateBasedIncentive {
 			owner: ALICE,
 			asset_id: PICA::ID,
-			start_block: 0,
+			start_block: 1,
 			end_block: ONE_YEAR_OF_BLOCKS * 10,
 			reward_configs: [(PICA::ID, reward_config)].into_iter().try_collect().unwrap(),
 			lock: default_lock_config(),

--- a/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
@@ -40,6 +40,7 @@ fn test_reward_update_calculation() {
 		let pool_id = create_rewards_pool_and_assert(RewardRateBasedIncentive {
 			owner: ALICE,
 			asset_id: PICA::ID,
+			start_block: 0,
 			end_block: ONE_YEAR_OF_BLOCKS * 10,
 			reward_configs: [(PICA::ID, reward_config)].into_iter().try_collect().unwrap(),
 			lock: default_lock_config(),
@@ -156,6 +157,7 @@ fn test_accumulate_rewards_pool_empty_refill() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: A::ID,
+				start_block: current_block,
 				end_block: current_block + ONE_YEAR_OF_BLOCKS,
 				reward_configs: [
 					(
@@ -283,6 +285,7 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: A::ID,
+				start_block: current_block,
 				end_block: current_block + ONE_YEAR_OF_BLOCKS,
 				reward_configs: [
 					(
@@ -317,6 +320,7 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: BOB,
 				asset_id: C::ID,
+				start_block: current_block,
 				end_block: current_block + ONE_YEAR_OF_BLOCKS,
 				reward_configs: [
 					(
@@ -578,6 +582,7 @@ fn test_accumulate_rewards_hook() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: CHARLIE,
 				asset_id: F::ID,
+				start_block: current_block,
 				end_block: current_block + ONE_YEAR_OF_BLOCKS,
 				reward_configs: [(
 					F::ID,

--- a/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
@@ -35,6 +35,7 @@ fn test_update_reward_pool() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
+				start_block: 0,
 				end_block: ONE_YEAR_OF_BLOCKS,
 				reward_configs: [(
 					USDT::ID,

--- a/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
@@ -35,7 +35,7 @@ fn test_update_reward_pool() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
-				start_block: 0,
+				start_block: 1,
 				end_block: ONE_YEAR_OF_BLOCKS,
 				reward_configs: [(
 					USDT::ID,

--- a/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
@@ -35,8 +35,8 @@ fn test_update_reward_pool() {
 			create_rewards_pool_and_assert(RewardPoolConfiguration::RewardRateBasedIncentive {
 				owner: ALICE,
 				asset_id: PICA::ID,
-				start_block: 1,
-				end_block: ONE_YEAR_OF_BLOCKS,
+				start_block: 2,
+				end_block: ONE_YEAR_OF_BLOCKS + 1,
 				reward_configs: [(
 					USDT::ID,
 					RewardConfig {
@@ -46,7 +46,7 @@ fn test_update_reward_pool() {
 				)]
 				.into_iter()
 				.try_collect()
-				.unwrap(),
+				.expect("Rewards pool has a valid config for creation; QED"),
 				lock: default_lock_config(),
 				share_asset_id: XPICA::ID,
 				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,


### PR DESCRIPTION
## Issue
[[CU-2vr59uq]](https://app.clickup.com/t/2vr59uq)

## Description
Use the `start_block` to determine if `stake` and reward accumulation are valid.