### PR TITLE
[CU-2yyykk2] Added ensure for non-zero assetIds

### DIFF
--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -203,6 +203,8 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Error when creating reward configs.
 		RewardConfigProblem,
+		/// AssetId is invalid, asset IDs must be graeter than 0
+		InvalidAssetId,
 		/// Reward pool already exists
 		RewardsPoolAlreadyExists,
 		/// No duration presets configured.
@@ -267,7 +269,8 @@ pub mod pallet {
 			+ Ord
 			+ From<u128>
 			+ Into<u128>
-			+ Copy;
+			+ Copy
+			+ Zero;
 
 		// REVIEW(benluelo): Mutate::CollectionId type?
 		type FinancialNft: NonFungiblesMutate<AccountIdOf<Self>>
@@ -637,6 +640,11 @@ pub mod pallet {
 					share_asset_id,
 					financial_nft_asset_id,
 				} => {
+					// AssetIds must be greater than 0
+					ensure!(!pool_asset.is_zero(), Error::<T>::InvalidAssetId);
+					ensure!(!share_asset_id.is_zero(), Error::<T>::InvalidAssetId);
+					ensure!(!financial_nft_asset_id.is_zero(), Error::<T>::InvalidAssetId);
+
 					// now < start_block < end_block
 					ensure!(
 						// Exclusively greater than to prevent errors/attacks

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -203,7 +203,7 @@ pub mod pallet {
 	pub enum Error<T> {
 		/// Error when creating reward configs.
 		RewardConfigProblem,
-		/// AssetId is invalid, asset IDs must be graeter than 0
+		/// AssetId is invalid, asset IDs must be greater than 0
 		InvalidAssetId,
 		/// Reward pool already exists
 		RewardsPoolAlreadyExists,

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -86,6 +86,81 @@ fn test_create_reward_pool_invalid_end_block() {
 }
 
 #[test]
+fn create_staking_reward_pool_should_fail_when_pool_asset_id_is_zero() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		assert_err!(
+			StakingRewards::create_reward_pool(
+				Origin::root(),
+				RewardRateBasedIncentive {
+					owner: ALICE,
+					asset_id: 0,
+					// end block can't be before the current block
+					start_block: 2,
+					end_block: 0,
+					reward_configs: default_reward_config(),
+					lock: default_lock_config(),
+					share_asset_id: XPICA::ID,
+					financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
+				}
+			),
+			crate::Error::<Test>::InvalidAssetId,
+		);
+	});
+}
+
+#[test]
+fn create_staking_reward_pool_should_fail_when_share_asset_id_is_zero() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		assert_err!(
+			StakingRewards::create_reward_pool(
+				Origin::root(),
+				RewardRateBasedIncentive {
+					owner: ALICE,
+					asset_id: PICA::ID,
+					// end block can't be before the current block
+					start_block: 2,
+					end_block: 0,
+					reward_configs: default_reward_config(),
+					lock: default_lock_config(),
+					share_asset_id: 0,
+					financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
+				}
+			),
+			crate::Error::<Test>::InvalidAssetId
+		);
+	});
+}
+
+#[test]
+fn create_staking_reward_pool_should_fail_when_fnft_collection_asset_id_is_zero() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+
+		assert_err!(
+			StakingRewards::create_reward_pool(
+				Origin::root(),
+				RewardRateBasedIncentive {
+					owner: ALICE,
+					asset_id: PICA::ID,
+					// end block can't be before the current block
+					start_block: 2,
+					end_block: 0,
+					reward_configs: default_reward_config(),
+					lock: default_lock_config(),
+					share_asset_id: XPICA::ID,
+					financial_nft_asset_id: 0,
+				}
+			),
+			crate::Error::<Test>::InvalidAssetId
+		);
+	});
+}
+
+#[test]
 fn stake_should_fail_before_start_of_rewards_pool() {
 	new_test_ext().execute_with(|| {
 		let staker = ALICE;


### PR DESCRIPTION
## Issue
[[CU-2yyykk2]](https://app.clickup.com/t/2yyykk2)

## Description
Decided to place the check inside of `create_staking_pool` to avoid unwrapping the pool config at the `pallet::call` level.