### PR TITLE
fix(integration-tests/crowdloan-rewards): Wrong amount of asset decimals

### DIFF
--- a/code/integration-tests/runtime-tests/test/tests/crowdloanRewards/txCrowdloanRewardsTests.ts
+++ b/code/integration-tests/runtime-tests/test/tests/crowdloanRewards/txCrowdloanRewardsTests.ts
@@ -72,7 +72,7 @@ describe("CrowdloanRewards Tests", function () {
     if (!testConfiguration.enabledTests.tx.setup.provideAssets) this.skip();
     // 2 minutes timeout
     this.timeout(60 * 2 * 1000);
-    await mintAssetsToWallet(api, sudoKey, sudoKey, [1]);
+    await mintAssetsToWallet(api, sudoKey, sudoKey, [1], 999_999_999_999_999_999_999_999_999n);
     await mintAssetsToWallet(api, contributorRewardAccount, sudoKey, [1]);
     await mintAssetsToWallet(api, contributorEthRewardAccount, sudoKey, [1]);
   });


### PR DESCRIPTION
## Issue
Wrong amount of decimals were used in crowdloan rewards integration tests.

## Description
~~*Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version"*~~

## Checklist

~~- [ ] I have updated the cargo docs to reflect changes made by this PR _(if applicable)_~~
~~- [ ] I have updated the `book/` to reflect changes made by this PR _(if applicable)_~~