### PR TITLE
fix(nix-build): fixes subxt URL

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -14878,7 +14878,7 @@ dependencies = [
 [[package]]
 name = "subxt-codegen"
 version = "0.23.0"
-source = "git+https://github.com/paritytech//subxt?rev=2fe9a1446d32b93a10804db3304ccaac65f764b8#2fe9a1446d32b93a10804db3304ccaac65f764b8"
+source = "git+https://github.com/paritytech/subxt?rev=2fe9a1446d32b93a10804db3304ccaac65f764b8#2fe9a1446d32b93a10804db3304ccaac65f764b8"
 dependencies = [
  "darling",
  "frame-metadata",
@@ -14941,7 +14941,7 @@ dependencies = [
 [[package]]
 name = "subxt-metadata"
 version = "0.23.0"
-source = "git+https://github.com/paritytech//subxt?rev=2fe9a1446d32b93a10804db3304ccaac65f764b8#2fe9a1446d32b93a10804db3304ccaac65f764b8"
+source = "git+https://github.com/paritytech/subxt?rev=2fe9a1446d32b93a10804db3304ccaac65f764b8#2fe9a1446d32b93a10804db3304ccaac65f764b8"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -70,7 +70,7 @@ sp-runtime = { git = "https://github.com/ComposableFi/substrate", rev = "f709a3d
 wasmi-validation = { git = "https://github.com/ComposableFi/wasmi", rev = "cd8c0c775a1d197a35ff3d5c7d6cded3d476411b" }
 
 [patch."https://github.com/paritytech/subxt"]
-subxt-codegen = { git = "https://github.com/paritytech//subxt", rev = "2fe9a1446d32b93a10804db3304ccaac65f764b8" }
+subxt-codegen = { git = "https://github.com/paritytech/subxt", rev = "2fe9a1446d32b93a10804db3304ccaac65f764b8" }
 
 [patch."https://github.com/paritytech/cumulus"]
 cumulus-client-cli = { git = "https://github.com/ComposableFi/cumulus", rev = "f730e6747be173e2d4609381edc7929c8671f4d8" }


### PR DESCRIPTION
## Description

I am using `nix (Nix) 2.6.1` and was getting the following error `error: 'https://github.com/paritytech//subxt' is not a valid URL` when running `nix build ".#composable-node"`.

This commit fixes the issue on my side.