### PR TITLE
[CU-2z0k7en] Removed excess storage read/writes from do_populate

### DIFF
--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -349,9 +349,9 @@ pub mod pallet {
 		/// for the new values.
 		///
 		/// # Errors
-		/// * `AlreadyInitialized` - The crowdloan has been set to intitialize, population may no
+		/// * `AlreadyInitialized` - The crowdloan has been set to initialize, population may no
 		///   longer commence
-		/// * `ArithmaticError` - Overflow/Underflow detected while calculating totals
+		/// * `ArithmeticError` - Overflow/Underflow detected while calculating totals
 		pub(crate) fn do_populate(
 			rewards: Vec<(RemoteAccountOf<T>, RewardAmountOf<T>, VestingPeriodOf<T>)>,
 		) -> DispatchResult {

--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -360,7 +360,7 @@ pub mod pallet {
 			let mut total_rewards: T::Balance = TotalRewards::<T>::get();
 			let mut total_contributors: u32 = TotalContributors::<T>::get();
 
-			for (remote_account, total, vesting_period) in rewards.into_iter() {
+			for (remote_account, account_total, vesting_period) in rewards.into_iter() {
 				Rewards::<T>::try_mutate_exists::<_, _, DispatchError, _>(
 					remote_account,
 					|reward| match reward {
@@ -368,19 +368,22 @@ pub mod pallet {
 							total_rewards = total_rewards.checked_sub(&reward.total).expect(
 								"TotalRewards is greater than or equal to reward.total; QED",
 							);
-							total_rewards = total_rewards.safe_add(&total)?;
+							total_rewards = total_rewards.safe_add(&account_total)?;
 
-							reward.total = total;
+							reward.total = account_total;
 							reward.vesting_period = vesting_period;
 
 							Ok(())
 						},
 						None => {
 							total_contributors = total_contributors.safe_add(&1)?;
-							total_rewards = total_rewards.safe_add(&total)?;
+							total_rewards = total_rewards.safe_add(&account_total)?;
 
-							*reward =
-								Some(Reward { total, claimed: T::Balance::zero(), vesting_period });
+							*reward = Some(Reward {
+								total: account_total,
+								claimed: T::Balance::zero(),
+								vesting_period,
+							});
 
 							Ok(())
 						},

--- a/code/parachain/frame/crowdloan-rewards/src/tests.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/tests.rs
@@ -134,6 +134,29 @@ fn test_populate_ok() {
 }
 
 #[test]
+fn populate_should_overwrite_existing_rewards_with_new_values() {
+	let gen = |c, r| -> Vec<(RemoteAccountOf<Test>, RewardAmountOf<Test>, VestingPeriodOf<Test>)> {
+		generate_accounts(c)
+			.into_iter()
+			.map(|(_, account)| (account.as_remote_public(), r, DEFAULT_VESTING_PERIOD))
+			.collect()
+	};
+	ExtBuilder::default().build().execute_with(|| {
+		let expected_total_rewards = 100 * 200;
+		Balances::make_free_balance_be(&CrowdloanRewards::account_id(), expected_total_rewards);
+		assert_ok!(CrowdloanRewards::populate(Origin::root(), gen(100, 200)));
+		assert_eq!(CrowdloanRewards::total_rewards(), expected_total_rewards);
+		assert_eq!(CrowdloanRewards::claimed_rewards(), 0);
+
+		let expected_total_rewards = 100 * 100;
+		Balances::make_free_balance_be(&CrowdloanRewards::account_id(), expected_total_rewards);
+		assert_ok!(CrowdloanRewards::populate(Origin::root(), gen(100, 100)));
+		assert_eq!(CrowdloanRewards::total_rewards(), expected_total_rewards);
+		assert_eq!(CrowdloanRewards::claimed_rewards(), 0);
+	});
+}
+
+#[test]
 fn test_populate_after_initialize_ko() {
 	ExtBuilder::default().build().execute_with(|| {
 		assert_ok!(CrowdloanRewards::initialize(Origin::root()));


### PR DESCRIPTION
## Issue
[[CU-2z0k7en]](https://app.clickup.com/t/2z0k7en)

## Description
Removed unnecessary reads/writes from `do_populate` by only updating existing storage values as needed.