### PR TITLE
allow nix and leads to approve Cargo updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,6 +33,9 @@ subsquid/ @ComposableFi/parachain-finance @ComposableFi/blockchain-integrations
 code/parachain/frame/*/rpc/ @ComposableFi/parachain-rpc
 code/parachain/frame/*/runtime-api @ComposableFi/parachain-rpc
 
+code/Cargo.lock @ComposableFi/parachain-leads @ComposableFi/core @ComposableFi/nix
+code/Cargo.toml @ComposableFi/parachain-leads @ComposableFi/core @ComposableFi/nix
+
 ## Public Gitbook
 
 book/ @ComposableFi/technical-writers


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
- cannot merge adding new `utils` crate

## Description
* when tried to add new utils crate it updated toml and lock and got no review from core for a week. 
* tool is blocker to automate open channels for sudo owners
