### PR TITLE
[CU-33e4tdu] Crowdloan Rewards - Lock Reward Asset When Configured

### DIFF
--- a/code/parachain/frame/assets/src/lib.rs
+++ b/code/parachain/frame/assets/src/lib.rs
@@ -566,10 +566,14 @@ pub mod pallet {
 	mod fungible {
 		use super::*;
 
-		use frame_support::traits::tokens::{
-			fungible::{Inspect, InspectHold, Mutate, MutateHold, Transfer, Unbalanced},
-			DepositConsequence, WithdrawConsequence,
+		use frame_support::traits::{
+			tokens::{
+				fungible::{Inspect, InspectHold, Mutate, MutateHold, Transfer, Unbalanced},
+				DepositConsequence, WithdrawConsequence,
+			},
+			LockableCurrency, WithdrawReasons,
 		};
+		use orml_traits::LockIdentifier;
 
 		impl<T: Config> MutateHold<T::AccountId> for Pallet<T>
 		where
@@ -688,6 +692,40 @@ pub mod pallet {
 				keep_alive: bool,
 			) -> Result<Self::Balance, DispatchError> {
 				<<T as Config>::NativeCurrency>::transfer(source, dest, amount, keep_alive)
+			}
+		}
+
+		impl<T: Config> LockableCurrency<T::AccountId> for Pallet<T>
+		where
+			<T as Config>::NativeCurrency: LockableCurrency<T::AccountId, Balance = T::Balance>,
+		{
+			type Moment = <T::NativeCurrency as LockableCurrency<T::AccountId>>::Moment;
+			type MaxLocks = <T::NativeCurrency as LockableCurrency<T::AccountId>>::MaxLocks;
+
+			fn set_lock(
+				id: LockIdentifier,
+				who: &T::AccountId,
+				amount: T::Balance,
+				reasons: WithdrawReasons,
+			) {
+				<T::NativeCurrency as LockableCurrency<T::AccountId>>::set_lock(
+					id, who, amount, reasons,
+				);
+			}
+
+			fn extend_lock(
+				id: LockIdentifier,
+				who: &T::AccountId,
+				amount: T::Balance,
+				reasons: WithdrawReasons,
+			) {
+				<T::NativeCurrency as LockableCurrency<T::AccountId>>::extend_lock(
+					id, who, amount, reasons,
+				);
+			}
+
+			fn remove_lock(id: LockIdentifier, who: &T::AccountId) {
+				<T::NativeCurrency as LockableCurrency<T::AccountId>>::remove_lock(id, who);
 			}
 		}
 

--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -517,7 +517,7 @@ pub mod pallet {
 			})
 		}
 
-		/// Sets `RemoveRewardLocks`, removes `RewardAsset` locks on provided accounts, emmits
+		/// Sets `RemoveRewardLocks`, removes `RewardAsset` locks on provided accounts, emits
 		/// `RewardsUnlocked`.
 		fn do_unlock(reward_accounts: Vec<T::AccountId>) {
 			RemoveRewardLocks::<T>::put(());

--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -80,7 +80,8 @@ pub mod pallet {
 		pallet_prelude::*,
 		traits::{
 			fungible::{Inspect, Mutate, Transfer},
-			Time,
+			tokens::WithdrawReasons,
+			LockIdentifier, LockableCurrency, Time,
 		},
 		transactional, PalletId,
 	};
@@ -156,7 +157,8 @@ pub mod pallet {
 		/// The RewardAsset used to transfer the rewards.
 		type RewardAsset: Inspect<Self::AccountId, Balance = Self::Balance>
 			+ Transfer<Self::AccountId, Balance = Self::Balance>
-			+ Mutate<Self::AccountId>;
+			+ Mutate<Self::AccountId>
+			+ LockableCurrency<Self::AccountId, Balance = Self::Balance>;
 
 		/// Type used to express timestamps.
 		type Moment: AtLeast32Bit + Parameter + Default + Copy + MaxEncodedLen + FullCodec;
@@ -199,6 +201,10 @@ pub mod pallet {
 		/// The unique identifier of this pallet.
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
+
+		/// The unique identifier for locks maintained by this pallet.
+		#[pallet::constant]
+		type LockId: Get<LockIdentifier>;
 	}
 
 	#[pallet::storage]

--- a/code/parachain/frame/crowdloan-rewards/src/mocks.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/mocks.rs
@@ -5,7 +5,10 @@ use crate::{
 use codec::Encode;
 use composable_support::types::{EcdsaSignature, EthereumAddress};
 use frame_support::{
-	construct_runtime, dispatch::DispatchResultWithPostInfo, parameter_types, traits::Everything,
+	construct_runtime,
+	dispatch::DispatchResultWithPostInfo,
+	parameter_types,
+	traits::{Everything, LockIdentifier},
 	PalletId,
 };
 use frame_system as system;
@@ -82,6 +85,7 @@ impl pallet_balances::Config for Test {
 
 parameter_types! {
 	pub const CrowdloanRewardsPalletId: PalletId = PalletId(*b"pal_crow");
+	pub const CrowdloanRewardsLockId: LockIdentifier = *b"crs_lock";
 	pub const InitialPayment: Perbill = INITIAL_PAYMENT;
 	pub const OverFundedThreshold: Perbill = OVER_FUNDED_THRESHOLD;
 	pub const VestingStep: Moment = VESTING_STEP;
@@ -103,6 +107,7 @@ impl pallet_crowdloan_rewards::Config for Test {
 	type PalletId = CrowdloanRewardsPalletId;
 	type Moment = Moment;
 	type Time = Timestamp;
+	type LockId = CrowdloanRewardsLockId;
 }
 
 parameter_types! {

--- a/code/parachain/frame/crowdloan-rewards/src/mocks.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/mocks.rs
@@ -90,6 +90,7 @@ parameter_types! {
 	pub const OverFundedThreshold: Perbill = OVER_FUNDED_THRESHOLD;
 	pub const VestingStep: Moment = VESTING_STEP;
 	pub const Prefix: &'static [u8] = PROOF_PREFIX;
+	pub const LockCrowdloanRewards: bool = true;
 }
 
 impl pallet_crowdloan_rewards::Config for Test {
@@ -108,6 +109,7 @@ impl pallet_crowdloan_rewards::Config for Test {
 	type Moment = Moment;
 	type Time = Timestamp;
 	type LockId = CrowdloanRewardsLockId;
+	type LockByDefault = LockCrowdloanRewards;
 }
 
 parameter_types! {

--- a/code/parachain/frame/crowdloan-rewards/src/weights.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/weights.rs
@@ -14,6 +14,7 @@ pub trait WeightInfo {
 	fn initialize(x: u32) -> Weight;
 	fn associate(x: u32) -> Weight;
 	fn claim(x: u32) -> Weight;
+	fn unlock_rewards_for(x: u32) -> Weight;
 }
 
 impl WeightInfo for () {
@@ -61,5 +62,9 @@ impl WeightInfo for () {
 			.saturating_add((31_000 as Weight).saturating_mul(x as Weight))
 			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(3 as Weight))
+	}
+
+	fn unlock_rewards_for(x: u32) -> Weight {
+		x as _
 	}
 }

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -718,6 +718,7 @@ impl democracy::Config<democracy::Instance1> for Runtime {
 
 parameter_types! {
 	  pub const CrowdloanRewardsId: PalletId = PalletId(*b"pal_crow");
+	  pub const CrowdloanRewardsLockId: LockIdentifier = *b"clr_lock";
 	  pub const InitialPayment: Perbill = Perbill::from_percent(25);
 	  pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	  pub const VestingStep: Moment = (7 * DAYS as Moment) * (MILLISECS_PER_BLOCK as Moment);
@@ -739,6 +740,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type PalletId = CrowdloanRewardsId;
 	type Moment = Moment;
 	type Time = Timestamp;
+	type LockId = CrowdloanRewardsLockId;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -723,6 +723,7 @@ parameter_types! {
 	  pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	  pub const VestingStep: Moment = (7 * DAYS as Moment) * (MILLISECS_PER_BLOCK as Moment);
 	  pub const Prefix: &'static [u8] = b"composable-";
+	  pub const LockCrowdloanRewards: bool = false;
 }
 
 impl crowdloan_rewards::Config for Runtime {
@@ -741,6 +742,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type Moment = Moment;
 	type Time = Timestamp;
 	type LockId = CrowdloanRewardsLockId;
+	type LockByDefault = LockCrowdloanRewards;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -835,6 +835,7 @@ impl assets::Config for Runtime {
 
 parameter_types! {
 	  pub const CrowdloanRewardsId: PalletId = PalletId(*b"pal_crow");
+	  pub const CrowdloanRewardsLockId: LockIdentifier = *b"clr_lock";
 	  pub const InitialPayment: Perbill = Perbill::from_percent(25);
 	  pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	  pub const VestingStep: Moment = 1;
@@ -856,6 +857,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type PalletId = CrowdloanRewardsId;
 	type Moment = Moment;
 	type Time = Timestamp;
+	type LockId = CrowdloanRewardsLockId;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -840,6 +840,7 @@ parameter_types! {
 	  pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	  pub const VestingStep: Moment = 1;
 	  pub const Prefix: &'static [u8] = b"picasso-";
+	  pub const LockCrowdloanRewards: bool = true;
 }
 
 impl crowdloan_rewards::Config for Runtime {
@@ -858,6 +859,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type Moment = Moment;
 	type Time = Timestamp;
 	type LockId = CrowdloanRewardsLockId;
+	type LockByDefault = LockCrowdloanRewards;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/dali/src/weights/crowdloan_rewards.rs
+++ b/code/parachain/runtime/dali/src/weights/crowdloan_rewards.rs
@@ -72,4 +72,8 @@ impl<T: frame_system::Config> crowdloan_rewards::weights::WeightInfo for WeightI
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
+	
+	fn unlock_rewards_for(x: u32) -> Weight {
+		x as _
+	}
 }

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -660,6 +660,7 @@ parameter_types! {
 	pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	pub const VestingStep: Moment = (7 * DAYS as Moment) * (MILLISECS_PER_BLOCK as Moment);
 	pub const Prefix: &'static [u8] = b"picasso-";
+	pub const LockCrowdloanRewards: bool = true;
 }
 
 impl crowdloan_rewards::Config for Runtime {
@@ -678,6 +679,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type Moment = Moment;
 	type Time = Timestamp;
 	type LockId = CrowdloanRewardsLockId;
+	type LockByDefault = LockCrowdloanRewards;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -131,7 +131,7 @@ pub fn native_version() -> NativeVersion {
 	NativeVersion { runtime_version: VERSION, can_author_with: Default::default() }
 }
 
-use orml_traits::parameter_type_with_key;
+use orml_traits::{parameter_type_with_key, LockIdentifier};
 parameter_type_with_key! {
 	// Minimum amount an account has to hold to stay in state
 	pub MultiExistentialDeposits: |currency_id: CurrencyId| -> Balance {
@@ -655,6 +655,7 @@ impl currency_factory::Config for Runtime {
 
 parameter_types! {
 	pub const CrowdloanRewardsId: PalletId = PalletId(*b"pal_crow");
+	pub const CrowdloanRewardsLockId: LockIdentifier = *b"clr_lock";
 	pub const InitialPayment: Perbill = Perbill::from_percent(25);
 	pub const OverFundedThreshold: Perbill = Perbill::from_percent(1);
 	pub const VestingStep: Moment = (7 * DAYS as Moment) * (MILLISECS_PER_BLOCK as Moment);
@@ -676,6 +677,7 @@ impl crowdloan_rewards::Config for Runtime {
 	type PalletId = CrowdloanRewardsId;
 	type Moment = Moment;
 	type Time = Timestamp;
+	type LockId = CrowdloanRewardsLockId;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/picasso/src/weights/crowdloan_rewards.rs
+++ b/code/parachain/runtime/picasso/src/weights/crowdloan_rewards.rs
@@ -72,4 +72,8 @@ impl<T: frame_system::Config> crowdloan_rewards::weights::WeightInfo for WeightI
 			.saturating_add(T::DbWeight::get().reads(5 as Weight))
 			.saturating_add(T::DbWeight::get().writes(3 as Weight))
 	}
+	
+	fn unlock_rewards_for(x: u32) -> Weight {
+		x as _
+	}
 }


### PR DESCRIPTION
## Issue
[[CU-33e4tdu]](https://app.clickup.com/t/33e4tdu)

## Description
Depending on the runtime configuration, Crowdloan Rewards will lock the reward asset on claiming. This is configured by the `LockByDefault` value.

Once the time comes to remove locks, locks can be removed by the new `unlock_rewards_for` provided the accounts that need unlocking.
To ensure we're able to fit transactions in blocks. This is provided a Vector of accounts and can be called multiple times to eventually unlock all accounts.

> Do we really need this flag? Given that there is also RemoveRewardLocks which can be set/reset at genesis?

Changing the crowdloans genesis config was not an option