### PR TITLE
[CU-3153c9f] Moved fNFT collection and share asset IDs into staking

### DIFF
--- a/code/parachain/frame/assets/src/mocks.rs
+++ b/code/parachain/frame/assets/src/mocks.rs
@@ -74,6 +74,10 @@ impl CurrencyFactory for CurrencyIdGenerator {
 		Ok(1)
 	}
 
+	fn expect_create(_asset_id: RangeId, _ed: Self::Balance) -> Self::AssetId {
+		1
+	}
+
 	fn protocol_asset_id_to_unique_asset_id(
 		_protocol_asset_id: u32,
 		_range_id: RangeId,
@@ -185,7 +189,7 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 }
 
 pub fn new_test_ext_multi_currency() -> sp_io::TestExternalities {
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into();
+	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
 
 	let balances: Vec<(AccountId, AssetId, Balance)> =
 		vec![(ALICE, ASSET_1, 1000), (BOB, ASSET_2, 1000)];

--- a/code/parachain/frame/composable-tests-helpers/src/test/currency.rs
+++ b/code/parachain/frame/composable-tests-helpers/src/test/currency.rs
@@ -189,7 +189,6 @@ pub mod defs {
 	use super::Currency;
 
 	pub type PICA = Currency<1, 12>;
-	pub type XPICA = Currency<2, 12>;
 	pub type BTC = Currency<2000, 12>;
 	pub type USDT = Currency<1000, 12>;
 

--- a/code/parachain/frame/composable-traits/src/currency.rs
+++ b/code/parachain/frame/composable-traits/src/currency.rs
@@ -21,9 +21,16 @@ pub trait CurrencyFactory {
 
 	/// permissionless creation of new transferable asset id
 	fn create(id: RangeId, ed: Self::Balance) -> Result<Self::AssetId, DispatchError>;
+
+	/// Permissionless creation of new transferable asset id
+	///
+	/// **Must not fail!**
+	fn expect_create(id: RangeId, ed: Self::Balance) -> Self::AssetId;
+
 	fn reserve_lp_token_id(ed: Self::Balance) -> Result<Self::AssetId, DispatchError> {
 		Self::create(RangeId::LP_TOKENS, ed)
 	}
+
 	/// Given a `u32` ID (within the range of `0` to `u32::MAX`) returns a unique `AssetId` reserved
 	/// by Currency Factory for the runtime.
 	fn protocol_asset_id_to_unique_asset_id(

--- a/code/parachain/frame/composable-traits/src/fnft.rs
+++ b/code/parachain/frame/composable-traits/src/fnft.rs
@@ -56,6 +56,7 @@ pub trait FinancialNftProtocol {
 	/// - collection: id of the financial NFT collection issued/used by the protocol.
 	/// TODO (vim): Think how to represent the difference between assets and liabilities
 	fn value_of(
+		pool_id: &Self::AssetId,
 		collection: &Self::AssetId,
 		instance: &Self::ItemId,
 	) -> Result<Vec<(Self::AssetId, Self::Balance)>, DispatchError>;

--- a/code/parachain/frame/composable-traits/src/staking/mod.rs
+++ b/code/parachain/frame/composable-traits/src/staking/mod.rs
@@ -190,12 +190,6 @@ pub enum RewardPoolConfiguration<
 		reward_configs: BoundedBTreeMap<AssetId, RewardConfig<Balance>, MaxRewardConfigs>,
 		// possible lock config for this reward
 		lock: LockConfig<MaxDurationPresets>,
-
-		// Asset ID issued as shares for staking in the pool. Eg: for PBLO -> xPBLO
-		share_asset_id: AssetId,
-
-		// Asset ID (collection ID) of the financial NFTs issued for staking positions of this pool
-		financial_nft_asset_id: AssetId,
 	},
 }
 

--- a/code/parachain/frame/currency-factory/src/lib.rs
+++ b/code/parachain/frame/currency-factory/src/lib.rs
@@ -181,7 +181,7 @@ pub mod pallet {
 
 		fn expect_create(id: RangeId, ed: Self::Balance) -> Self::AssetId {
 			let asset_id = AssetIdRanges::<T>::mutate(|range| range.increment(id))
-				.expect("Range is sufficent; QED");
+				.expect("Range is sufficient; QED");
 			AssetEd::<T>::insert(asset_id, ed);
 			asset_id
 		}

--- a/code/parachain/frame/currency-factory/src/lib.rs
+++ b/code/parachain/frame/currency-factory/src/lib.rs
@@ -179,6 +179,13 @@ pub mod pallet {
 			Ok(asset_id)
 		}
 
+		fn expect_create(id: RangeId, ed: Self::Balance) -> Self::AssetId {
+			let asset_id = AssetIdRanges::<T>::mutate(|range| range.increment(id))
+				.expect("Range is sufficent; QED");
+			AssetEd::<T>::insert(asset_id, ed);
+			asset_id
+		}
+
 		fn protocol_asset_id_to_unique_asset_id(
 			protocol_asset_id: u32,
 			range_id: RangeId,

--- a/code/parachain/frame/dex-router/src/mock.rs
+++ b/code/parachain/frame/dex-router/src/mock.rs
@@ -171,10 +171,6 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const PicaAssetId : CurrencyId = 1;
 	pub const PbloAssetId : CurrencyId = 2;
-	pub const XPicaAssetId: CurrencyId = 101;
-	pub const XPbloAssetId: CurrencyId = 102;
-	pub const PicaStakeFinancialNftCollectionId: CurrencyId = 1001;
-	pub const PbloStakeFinancialNftCollectionId: CurrencyId = 1002;
 	// TODO(benluelo): Use a better value here?
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
 }
@@ -234,10 +230,6 @@ impl pallet_pablo::Config for Test {
 	type MsPerBlock = MillisecsPerBlock;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 }
 
 parameter_types! {

--- a/code/parachain/frame/dex-router/src/mock.rs
+++ b/code/parachain/frame/dex-router/src/mock.rs
@@ -19,7 +19,6 @@ pub type Amount = i128;
 pub type PoolId = u128;
 pub type BlockNumber = u64;
 pub type AccountId = u128;
-pub type PositionId = u128;
 pub type CurrencyId = u128;
 
 #[allow(dead_code)]
@@ -198,10 +197,6 @@ impl pallet_staking_rewards::Config for Test {
 	type FinancialNftInstanceId = u64;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 	type LockId = StakingRewardsLockId;
 	type TreasuryAccount = TreasuryAccountId;
 	type ExistentialDeposits = ExistentialDeposits;

--- a/code/parachain/frame/ibc/src/mock.rs
+++ b/code/parachain/frame/ibc/src/mock.rs
@@ -122,6 +122,10 @@ impl CurrencyFactoryTrait for CurrencyIdGenerator {
 		Ok(1)
 	}
 
+	fn expect_create(_id: RangeId, _ed: Self::Balance) -> Self::AssetId {
+		1
+	}
+
 	fn protocol_asset_id_to_unique_asset_id(
 		_protocol_asset_id: u32,
 		_range_id: RangeId,

--- a/code/parachain/frame/pablo/proptest-regressions/stable_swap_tests.txt
+++ b/code/parachain/frame/pablo/proptest-regressions/stable_swap_tests.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4be342d172b4ab7f30b4010ea48937c8325f74ea81a62f118eccb7e466cb2f75 # shrinks to value = 1
+cc da0bb223124c7dcb0586aaf83f5dde1cced92031ff8b396c27127b6b4ae19435 # shrinks to value = 1
+cc 03a3e983af5daf9a261b59b535861441135d67c46b5c7ce0fd7b97b4b5a93683 # shrinks to usdc_balance = 1, usdt_balance = 1

--- a/code/parachain/frame/pablo/proptest-regressions/uniswap_tests.txt
+++ b/code/parachain/frame/pablo/proptest-regressions/uniswap_tests.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a33e6aa85f8ad17298f1301d5fb48e10b06b737cb2e6c9b9198f289823a34587 # shrinks to base_weight_in_percent = 1
+cc 2942a97307e8723669376867a387094e61f5ae0088f998cba779e7aa5ff0cf57 # shrinks to btc_value = 1
+cc 19d7de02076f0c650310f0d17b2eb3605c081a12e793c93e3a41e574728fb44f # shrinks to usdt_value = 1
+cc d1690ed74aa200abc07d2759bc0f8c4733ab289af441ff201448c8fce9289c1a # shrinks to btc_value = 1
+cc dadd955e3fdd0c32272f6195539e4a4a8a4ab5721c9d67737b62c5d1a520cb04 # shrinks to base_weight_in_percent = 100

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -388,20 +388,6 @@ pub mod pallet {
 		#[pallet::constant]
 		type PbloAssetId: Get<Self::AssetId>;
 
-		/// AssetId of the xToken variant of PICA asset
-		#[pallet::constant]
-		type XPicaAssetId: Get<Self::AssetId>;
-
-		/// AssetId of the xToken variant of PBLO asset
-		#[pallet::constant]
-		type XPbloAssetId: Get<Self::AssetId>;
-
-		#[pallet::constant]
-		type PicaStakeFinancialNftCollectionId: Get<Self::AssetId>;
-
-		#[pallet::constant]
-		type PbloStakeFinancialNftCollectionId: Get<Self::AssetId>;
-
 		#[pallet::constant]
 		type MsPerBlock: Get<u32>;
 	}

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -72,7 +72,7 @@ pub mod pallet {
 	use codec::FullCodec;
 	use composable_support::math::safe::{safe_multiply_by_rational, SafeArithmetic, SafeSub};
 	use composable_traits::{
-		currency::{CurrencyFactory, LocalAssets, RangeId},
+		currency::{CurrencyFactory, LocalAssets},
 		defi::{CurrencyPair, Rate},
 		dex::{
 			Amm, ConstantProductPoolInfo, Fee, LiquidityBootstrappingPoolInfo, PriceAggregate,
@@ -684,8 +684,6 @@ pub mod pallet {
 				end_block,
 				reward_configs,
 				lock,
-				share_asset_id: Self::get_x_token_from_pool(*pool_id)?,
-				financial_nft_asset_id: Self::get_financial_nft_from_pool(*pool_id)?,
 			})
 		}
 
@@ -843,44 +841,6 @@ pub mod pallet {
 				)?;
 			}
 			Ok(())
-		}
-
-		fn get_x_token_from_pool(pool_id: T::PoolId) -> Result<T::AssetId, DispatchError> {
-			// Get token asset ID from pool ID
-			let pool = Self::get_pool(pool_id)?;
-			let token_id = match pool {
-				PoolConfiguration::StableSwap(info) => info.lp_token,
-				PoolConfiguration::ConstantProduct(info) => info.lp_token,
-				// REVIEW: Throw error for LBP trying to get xTokens?
-				PoolConfiguration::LiquidityBootstrapping(_) =>
-					return Err(Error::<T>::NoXTokenForLbp.into()),
-			};
-
-			// Match token asset ID with xToken asset ID
-			match token_id {
-				x if x == T::PicaAssetId::get() => Ok(T::XPicaAssetId::get()),
-				x if x == T::PbloAssetId::get() => Ok(T::XPbloAssetId::get()),
-				_ => Ok(T::CurrencyFactory::create(RangeId::XTOKEN_ASSETS, T::Balance::default())?),
-			}
-		}
-
-		fn get_financial_nft_from_pool(pool_id: T::PoolId) -> Result<T::AssetId, DispatchError> {
-			// Get token asset ID from pool ID
-			let pool = Self::get_pool(pool_id)?;
-			let token_id = match pool {
-				PoolConfiguration::StableSwap(info) => info.lp_token,
-				PoolConfiguration::ConstantProduct(info) => info.lp_token,
-				// REVIEW: Throw error for LBP trying to get xTokens?
-				PoolConfiguration::LiquidityBootstrapping(_) =>
-					return Err(Error::<T>::NoXTokenForLbp.into()),
-			};
-
-			// Match token asset ID with fNFT asset ID
-			match token_id {
-				x if x == T::PicaAssetId::get() => Ok(T::PicaStakeFinancialNftCollectionId::get()),
-				x if x == T::PbloAssetId::get() => Ok(T::PbloStakeFinancialNftCollectionId::get()),
-				_ => Ok(T::CurrencyFactory::create(RangeId::FNFT_ASSETS, T::Balance::default())?),
-			}
 		}
 	}
 

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -40,11 +40,11 @@ frame_support::construct_runtime!(
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
 		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Pablo: pablo::{Pallet, Call, Storage, Event<T>},
-		LpTokenFactory: pallet_currency_factory::{Pallet, Storage, Event<T>},
 		Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>},
 		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
+		LpTokenFactory: pallet_currency_factory::{Pallet, Storage, Event<T>},
 		StakingRewards: pallet_staking_rewards::{Pallet, Storage, Call, Event<T>},
+		Pablo: pablo::{Pallet, Call, Storage, Event<T>},
 	}
 );
 
@@ -156,10 +156,6 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const PicaAssetId : CurrencyId = 1;
 	pub const PbloAssetId : CurrencyId = 2;
-	pub const XPicaAssetId: CurrencyId = 101;
-	pub const XPbloAssetId: CurrencyId = 102;
-	pub const PicaStakeFinancialNftCollectionId: CurrencyId = 1001;
-	pub const PbloStakeFinancialNftCollectionId: CurrencyId = 1001;
 	// REVIEW(benluelo): Use a better value for this?
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
 }
@@ -226,10 +222,6 @@ impl pablo::Config for Test {
 	type MsPerBlock = MillisecsPerBlock;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -180,11 +180,7 @@ impl pallet_staking_rewards::Config for Test {
 	type RewardPoolCreationOrigin = EnsureRoot<Self::AccountId>;
 	type RewardPoolUpdateOrigin = EnsureRoot<Self::AccountId>;
 	type PicaAssetId = PicaAssetId;
-	type XPicaAssetId = XPicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 	type WeightInfo = ();
 	type LockId = StakingRewardsLockId;
 	type TreasuryAccount = TreasuryAccountId;

--- a/code/parachain/frame/pablo/src/uniswap_tests.rs
+++ b/code/parachain/frame/pablo/src/uniswap_tests.rs
@@ -701,7 +701,7 @@ proptest! {
 
 	#[test]
 	fn weights_sum_to_one(
-		base_weight_in_percent in 1..100u32,
+		base_weight_in_percent in 1..100_u32,
 	) {
 	  new_test_ext().execute_with(|| {
 		  let pool_init_config = PoolInitConfiguration::ConstantProduct {

--- a/code/parachain/frame/staking-rewards/src/benchmarking.rs
+++ b/code/parachain/frame/staking-rewards/src/benchmarking.rs
@@ -20,10 +20,10 @@ use sp_arithmetic::{traits::SaturatedConversion, Perbill, Permill};
 use sp_runtime::traits::{BlockNumberProvider, One};
 use sp_std::collections::btree_map::BTreeMap;
 
-// PICA as configured in the Test runtime (./frame/staking-rewards/src/test/runtime.rs)
+/// Arbritrary asset ID not pre configured by the runtime
 pub const BASE_ASSET_ID: u128 = 42;
-/// fNFT Asset ID = u32::MAX * (fNFT_RANGE_ID(4) + 1) + INDEX(1)
-pub const STAKING_FNFT_COLLECTION_ID: u128 = u32::MAX as u128 * (4 + 1) + 1;
+/// fNFT Asset ID = u32::MAX * (fNFT_RANGE_ID(4) + 1) + INDEX(3)
+pub const STAKING_FNFT_COLLECTION_ID: u128 = u32::MAX as u128 * (4 + 1) + 3;
 pub const FNFT_INSTANCE_ID_BASE: u64 = 0;
 
 fn get_reward_pool<T: Config>(

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -442,18 +442,14 @@ pub mod pallet {
 			create_default_pool::<T>(
 				&owner,
 				T::PicaAssetId::get(),
-				T::CurrencyFactory::create(RangeId::XTOKEN_ASSETS, T::Balance::default())
-					.expect("Range has space; QED"),
-				T::CurrencyFactory::create(RangeId::FNFT_ASSETS, T::Balance::default())
-					.expect("Range has space; QED"),
+				T::CurrencyFactory::expect_create(RangeId::XTOKEN_ASSETS, T::Balance::default()),
+				T::CurrencyFactory::expect_create(RangeId::FNFT_ASSETS, T::Balance::default()),
 			);
 			create_default_pool::<T>(
 				&owner,
 				T::PbloAssetId::get(),
-				T::CurrencyFactory::create(RangeId::XTOKEN_ASSETS, T::Balance::default())
-					.expect("Range has space; QED"),
-				T::CurrencyFactory::create(RangeId::FNFT_ASSETS, T::Balance::default())
-					.expect("Range has space; QED"),
+				T::CurrencyFactory::expect_create(RangeId::XTOKEN_ASSETS, T::Balance::default()),
+				T::CurrencyFactory::expect_create(RangeId::FNFT_ASSETS, T::Balance::default()),
 			);
 		}
 	}

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -43,6 +43,7 @@ use sp_std::collections::{btree_map::BTreeMap, btree_set::BTreeSet};
 
 use self::prelude::{
 	add_to_rewards_pot_and_assert, create_rewards_pool_and_assert, split_and_assert,
+	MOCK_REWARD_ASSET_ID, MOCK_STAKE_ASSET_ID,
 };
 
 mod prelude;

--- a/code/parachain/frame/staking-rewards/src/test/prelude.rs
+++ b/code/parachain/frame/staking-rewards/src/test/prelude.rs
@@ -38,9 +38,6 @@ pub(crate) const fn block_seconds(amount_of_blocks: u64) -> u128 {
 
 pub(crate) const ONE_YEAR_OF_BLOCKS: u64 = 60 * 60 * 24 * 365 / (block_seconds(1) as u64);
 
-/// Mock ID for staking fNFT collection
-pub(crate) const STAKING_FNFT_COLLECTION_ID: CurrencyId = 1;
-
 // helpers
 
 // TODO: Make generic over runtime
@@ -735,8 +732,6 @@ pub(crate) fn create_rewards_pool_and_assert<Runtime, RuntimeEvent>(
 			end_block,
 			reward_configs: _,
 			lock: _,
-			share_asset_id: _,
-			financial_nft_asset_id: _,
 		} => assert_extrinsic_event::<Runtime, RuntimeEvent, crate::Event<Runtime>, _, _>(
 			Pallet::<Runtime>::create_reward_pool(OriginFor::<Runtime>::root(), reward_config),
 			crate::Event::<Runtime>::RewardPoolCreated { pool_id: asset_id, owner, end_block },

--- a/code/parachain/frame/staking-rewards/src/test/prelude.rs
+++ b/code/parachain/frame/staking-rewards/src/test/prelude.rs
@@ -37,6 +37,10 @@ pub(crate) const fn block_seconds(amount_of_blocks: u64) -> u128 {
 }
 
 pub(crate) const ONE_YEAR_OF_BLOCKS: u64 = 60 * 60 * 24 * 365 / (block_seconds(1) as u64);
+/// Arbitrary asset ID not pre-configured by the runtime
+pub(crate) const MOCK_STAKE_ASSET_ID: u128 = 42;
+/// Arbitrary asset ID not pre-configured by the runtime
+pub(crate) const MOCK_REWARD_ASSET_ID: u128 = 142;
 
 // helpers
 

--- a/code/parachain/frame/staking-rewards/src/test/runtime.rs
+++ b/code/parachain/frame/staking-rewards/src/test/runtime.rs
@@ -295,5 +295,11 @@ impl InstanceFilter<Call> for ProxyType {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	frame_system::GenesisConfig::default().build_storage::<Test>().unwrap().into()
+	let mut storage = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.expect("Default storage is valid; QED");
+	crate::GenesisConfig::<Test>::default()
+		.assimilate_storage(&mut storage)
+		.expect("Staking rewards genesis config is valid; QED");
+	storage.into()
 }

--- a/code/parachain/frame/staking-rewards/src/test/runtime.rs
+++ b/code/parachain/frame/staking-rewards/src/test/runtime.rs
@@ -229,10 +229,6 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool : u32 = 10;
 	pub const PicaAssetId : CurrencyId = 1;
 	pub const PbloAssetId : CurrencyId = 2;
-	pub const XPicaAssetId: CurrencyId = 101;
-	pub const XPbloAssetId: CurrencyId = 102;
-	pub const PicaStakeFinancialNftCollectionId: CurrencyId = 1001;
-	pub const PbloStakeFinancialNftCollectionId: CurrencyId = 1002;
 	pub const StakingRewardsLockId: LockIdentifier = *b"stk_lock";
 	// REVIEW(benluelo): Use a better value for this?
 	pub const TreasuryAccountId: AccountId = sr25519::Public([10_u8; 32]);
@@ -255,13 +251,8 @@ impl crate::Config for Test {
 	type RewardPoolUpdateOrigin = EnsureRoot<Self::AccountId>;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 	type WeightInfo = ();
 	type ExistentialDeposits = ExistentialDeposits;
-
 	type LockId = StakingRewardsLockId;
 	type TreasuryAccount = TreasuryAccountId;
 }

--- a/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_reward_accumulation_hook.rs
@@ -44,8 +44,6 @@ fn test_reward_update_calculation() {
 			end_block: ONE_YEAR_OF_BLOCKS * 10 + 1,
 			reward_configs: [(PICA::ID, reward_config)].into_iter().try_collect().unwrap(),
 			lock: default_lock_config(),
-			share_asset_id: XPICA::ID,
-			financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
 		});
 
 		add_to_rewards_pot_and_assert(ALICE, PICA::ID, PICA::ID, PICA::units(10_000));
@@ -182,8 +180,6 @@ fn test_accumulate_rewards_pool_empty_refill() {
 				.try_collect()
 				.unwrap(),
 				lock: default_lock_config(),
-				share_asset_id: XA::ID,
-				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
 			},
 		);
 
@@ -313,8 +309,6 @@ fn test_accumulate_rewards_hook() {
 				.try_collect()
 				.unwrap(),
 				lock: default_lock_config(),
-				share_asset_id: XA::ID,
-				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
 			},
 		);
 
@@ -351,8 +345,6 @@ fn test_accumulate_rewards_hook() {
 				.try_collect()
 				.unwrap(),
 				lock: default_lock_config(),
-				share_asset_id: XC::ID,
-				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID + 1,
 			},
 		);
 
@@ -605,8 +597,6 @@ fn test_accumulate_rewards_hook() {
 				.try_collect()
 				.unwrap(),
 				lock: default_lock_config(),
-				share_asset_id: XF::ID,
-				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID + 2,
 			},
 		);
 

--- a/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
+++ b/code/parachain/frame/staking-rewards/src/test/test_update_reward_pools.rs
@@ -1,6 +1,6 @@
 use composable_tests_helpers::test::{
 	block::process_and_progress_blocks,
-	currency::{PICA, USDT, XPICA},
+	currency::{PICA, USDT},
 	helper::assert_extrinsic_event,
 };
 use composable_traits::staking::{
@@ -18,8 +18,6 @@ use crate::test::{
 	test_reward_accumulation_hook::{check_rewards, CheckRewards, PoolRewards},
 	Test,
 };
-
-use super::prelude::STAKING_FNFT_COLLECTION_ID;
 
 #[test]
 fn test_update_reward_pool() {
@@ -48,8 +46,6 @@ fn test_update_reward_pool() {
 				.try_collect()
 				.expect("Rewards pool has a valid config for creation; QED"),
 				lock: default_lock_config(),
-				share_asset_id: XPICA::ID,
-				financial_nft_asset_id: STAKING_FNFT_COLLECTION_ID,
 			},
 		);
 

--- a/code/parachain/frame/vault/src/mocks/currency_factory.rs
+++ b/code/parachain/frame/vault/src/mocks/currency_factory.rs
@@ -97,6 +97,14 @@ pub mod pallet {
 			Ok(MockCurrencyId::LpToken(lp_token_id))
 		}
 
+		fn expect_create(_id: RangeId, _ed: Self::Balance) -> Self::AssetId {
+			let lp_token_id = CurrencyCounter::<T>::mutate(|c| {
+				*c += 1;
+				*c
+			});
+			MockCurrencyId::LpToken(lp_token_id)
+		}
+
 		fn protocol_asset_id_to_unique_asset_id(
 			_protocol_asset_id: u32,
 			_range_id: RangeId,

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -889,10 +889,6 @@ impl pallet_staking_rewards::Config for Runtime {
 	type FinancialNftInstanceId = FinancialNftInstanceId;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 	type LockId = StakingRewardsLockId;
 	type TreasuryAccount = TreasuryAccount;
 	type ExistentialDeposits = MultiExistentialDeposits;

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -864,10 +864,6 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool : u32 = 10;
 	pub const PicaAssetId : CurrencyId = CurrencyId::PICA;
 	pub const PbloAssetId : CurrencyId = CurrencyId::PBLO;
-	pub const XPicaAssetId: CurrencyId = CurrencyId::xPICA;
-	pub const XPbloAssetId: CurrencyId = CurrencyId::xPBLO;
-	pub const PicaStakeFinancialNftCollectionId: CurrencyId = CurrencyId::PICA_STAKE_FNFT_COLLECTION;
-	pub const PbloStakeFinancialNftCollectionId: CurrencyId = CurrencyId::PBLO_STAKE_FNFT_COLLECTION;
 	pub const StakingRewardsLockId: LockIdentifier = *b"stk_lock";
 }
 
@@ -1087,10 +1083,6 @@ impl pablo::Config for Runtime {
 	type MsPerBlock = MillisecsPerBlock;
 	type PicaAssetId = PicaAssetId;
 	type PbloAssetId = PbloAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -128,26 +128,6 @@ impl CurrencyId {
 		/// Acala Dollar
 		#[allow(non_upper_case_globals)]
 		pub const aUSD: CurrencyId = CurrencyId(134);
-
-		// Staked asset xTokens (1001 - 2000)
-		/// Staked asset xPICA Token
-		#[allow(non_upper_case_globals)]
-		pub const xPICA: CurrencyId = CurrencyId(1001);
-		/// Staked asset xLAYR Token
-		#[allow(non_upper_case_globals)]
-		pub const xLAYR: CurrencyId = CurrencyId(1002);
-		/// Staked asset xKSM Token
-		#[allow(non_upper_case_globals)]
-		pub const xKSM: CurrencyId = CurrencyId(1004);
-		/// Staked asset xPBLO Token
-		#[allow(non_upper_case_globals)]
-		pub const xPBLO: CurrencyId = CurrencyId(1005);
-
-		// fNFT Collection IDs (2001 - 100_000_000_000)
-		/// PICA Stake fNFT Collection
-		pub const PICA_STAKE_FNFT_COLLECTION: CurrencyId = CurrencyId(2001);
-		/// PBLO Stake fNFT Collection
-		pub const PBLO_STAKE_FNFT_COLLECTION: CurrencyId = CurrencyId(2005);
 	}
 
 	#[inline(always)]


### PR DESCRIPTION
## Issue
[[CU-3153c9f]](https://app.clickup.com/t/3153c9f)

## Description
Had to change `FinancialNftProtocl::value_of` in staking because it incorrectly queried pools by fNFT collection ID rather than stake asset ID.

Added function to `CurrencyFactory` trait `expect_create()`, which creates an asset ID without a transactional layer so it can be used within genesis builds of other pallets.

NOTE: All tests that rely on `with_stake` and use its optional `claim` are incorrect and should be rewritten with correct values. This is outside the scope of this PR.