### PR TITLE
run separate simnode job on managed runner

### DIFF
--- a/.github/workflows/simnode.yml
+++ b/.github/workflows/simnode.yml
@@ -10,11 +10,7 @@ on:
 
 jobs:
   simnode:
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - sre
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
- simnode on hosted runner fails often for more then half year and lately often with not fix
- failed on my recent devnet jobs each time

## Description
- it was proven that hosted runner is approx same fast to run simnode as non hosted in shared nixified job
- so replacing on separate job too
 
## Checklist

- ci works same way as before