### PR TITLE
Update CODEOWNERS so that non sre can fix things

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,10 @@
 
 ## CI and deployment related files
 
-.github/ @ComposableFi/sre
+.github/ @ComposableFi/sre @ComposableFi/core
 .github/CODEOWNERS @ComposableFi/core
-docker/ @ComposableFi/sre
-Makefile @ComposableFi/sre
+docker/ @ComposableFi/sre @ComposableFi/core
+Makefile @ComposableFi/sre @ComposableFi/core
 
 ## Parachain related files
 


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
- sre does not managed things we need
- they removing their stuff and move it into private separate repo
- we need to be unblocked 

## Description
* just made core approver of previosly sre  only stuff