### PR TITLE
Switch reward multiplier to FixedU64 to allow values > 1

### DIFF
--- a/code/parachain/frame/composable-support/src/validation.rs
+++ b/code/parachain/frame/composable-support/src/validation.rs
@@ -72,12 +72,22 @@ use scale_info::TypeInfo;
 use sp_runtime::DispatchError;
 use sp_std::ops::Deref;
 
+pub mod validators;
+
 /// Black box that embeds the validated value.
 /// Validated during construction or serde.
-#[derive(Default, Copy, Clone)]
+#[derive(Default)]
 pub struct Validated<T, U> {
 	value: T,
 	_marker: PhantomData<U>,
+}
+
+impl<T: Copy, U> Copy for Validated<T, U> {}
+
+impl<T: Clone, U> Clone for Validated<T, U> {
+	fn clone(&self) -> Self {
+		Self { value: self.value.clone(), _marker: PhantomData }
+	}
 }
 
 impl<T, U> TypeInfo for Validated<T, U>

--- a/code/parachain/frame/composable-support/src/validation/validators.rs
+++ b/code/parachain/frame/composable-support/src/validation/validators.rs
@@ -1,0 +1,46 @@
+use num_traits::One;
+
+use super::Validate;
+
+/// >= 1
+pub struct GeOne;
+
+impl<T: One + PartialOrd> Validate<T, GeOne> for GeOne {
+	fn validate(input: T) -> Result<T, &'static str> {
+		if input >= T::one() {
+			Ok(input)
+		} else {
+			Err("Input value was < 1")
+		}
+	}
+}
+
+#[test]
+fn test_ge_one() {
+	use crate::validation::Validate;
+	use frame_support::{assert_err, assert_ok};
+
+	// unsigned
+	assert_ok!(GeOne::validate(1_u32), 1);
+	assert_ok!(GeOne::validate(2_u32), 2);
+	assert_ok!(GeOne::validate(u32::MAX), u32::MAX);
+	assert_err!(GeOne::validate(0_u32), "Input value was < 1");
+
+	// signed
+	assert_ok!(GeOne::validate(1_i32), 1);
+	assert_ok!(GeOne::validate(2_i32), 2);
+	assert_err!(GeOne::validate(-1_i32), "Input value was < 1");
+	assert_err!(GeOne::validate(0_i32), "Input value was < 1");
+	assert_ok!(GeOne::validate(i32::MAX), i32::MAX);
+	assert_err!(GeOne::validate(i32::MIN), "Input value was < 1");
+
+	// floats
+	assert_ok!(GeOne::validate(1.0_f32), 1.0);
+	assert_ok!(GeOne::validate(1.1_f32), 1.1);
+	assert_err!(GeOne::validate(0.9_f32), "Input value was < 1");
+	assert_ok!(GeOne::validate(2.0_f32), 2.0);
+	assert_err!(GeOne::validate(-1.0_f32), "Input value was < 1");
+	assert_err!(GeOne::validate(0.0_f32), "Input value was < 1");
+	assert_ok!(GeOne::validate(f32::MAX), f32::MAX);
+	assert_err!(GeOne::validate(f32::MIN), "Input value was < 1");
+}

--- a/code/parachain/frame/composable-traits/src/staking/lock.rs
+++ b/code/parachain/frame/composable-traits/src/staking/lock.rs
@@ -1,4 +1,5 @@
 use codec::{Decode, Encode};
+use composable_support::validation::{validators::GeOne, Validated};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*, BoundedBTreeMap};
 use scale_info::TypeInfo;
 use sp_arithmetic::fixed_point::FixedU64;
@@ -16,7 +17,8 @@ use crate::time::{DurationSeconds, Timestamp};
 pub struct LockConfig<MaxDurationPresets: Get<u32>> {
 	/// The possible locking duration.
 	// TODO(benluelo): Use Validated on the multiplier?
-	pub duration_presets: BoundedBTreeMap<DurationSeconds, FixedU64, MaxDurationPresets>,
+	pub duration_presets:
+		BoundedBTreeMap<DurationSeconds, Validated<FixedU64, GeOne>, MaxDurationPresets>,
 	/// The penalty applied if a staker unstake before the end date.
 	/// In case of zero penalty, you cannot unlock before it duration ends.
 	pub unlock_penalty: Perbill,

--- a/code/parachain/frame/composable-traits/src/staking/lock.rs
+++ b/code/parachain/frame/composable-traits/src/staking/lock.rs
@@ -16,7 +16,6 @@ use crate::time::{DurationSeconds, Timestamp};
 #[scale_info(skip_type_params(MaxDurationPresets))]
 pub struct LockConfig<MaxDurationPresets: Get<u32>> {
 	/// The possible locking duration.
-	// TODO(benluelo): Use Validated on the multiplier?
 	pub duration_presets:
 		BoundedBTreeMap<DurationSeconds, Validated<FixedU64, GeOne>, MaxDurationPresets>,
 	/// The penalty applied if a staker unstake before the end date.

--- a/code/parachain/frame/composable-traits/src/staking/lock.rs
+++ b/code/parachain/frame/composable-traits/src/staking/lock.rs
@@ -1,11 +1,12 @@
-use crate::time::{DurationSeconds, Timestamp};
 use codec::{Decode, Encode};
 use frame_support::{dispatch::DispatchResult, pallet_prelude::*, BoundedBTreeMap};
+use scale_info::TypeInfo;
+use sp_arithmetic::fixed_point::FixedU64;
+use sp_runtime::Perbill;
 
 use core::fmt::Debug;
 
-use scale_info::TypeInfo;
-use sp_runtime::Perbill;
+use crate::time::{DurationSeconds, Timestamp};
 
 /// defines staking duration, rewards and early unstake penalty
 #[derive(
@@ -14,7 +15,8 @@ use sp_runtime::Perbill;
 #[scale_info(skip_type_params(MaxDurationPresets))]
 pub struct LockConfig<MaxDurationPresets: Get<u32>> {
 	/// The possible locking duration.
-	pub duration_presets: BoundedBTreeMap<DurationSeconds, Perbill, MaxDurationPresets>,
+	// TODO(benluelo): Use Validated on the multiplier?
+	pub duration_presets: BoundedBTreeMap<DurationSeconds, FixedU64, MaxDurationPresets>,
 	/// The penalty applied if a staker unstake before the end date.
 	/// In case of zero penalty, you cannot unlock before it duration ends.
 	pub unlock_penalty: Perbill,

--- a/code/parachain/frame/pablo/proptest-regressions/stable_swap_tests.txt
+++ b/code/parachain/frame/pablo/proptest-regressions/stable_swap_tests.txt
@@ -1,0 +1,9 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc dda3d39bba4605659556066e441795172db1502df92d9e506adaf757e6bdde2b # shrinks to value = 1
+cc 5f76b66b17a1b20110bb9dcc4d4004256903ee21c98263030afffdcfe22f2655 # shrinks to value = 1
+cc d2601b3e3e3888ca21090be0050d728e3775b0da4948ae9457e6d1477b17714f # shrinks to usdc_balance = 1, usdt_balance = 1

--- a/code/parachain/frame/pablo/proptest-regressions/uniswap_tests.txt
+++ b/code/parachain/frame/pablo/proptest-regressions/uniswap_tests.txt
@@ -1,0 +1,11 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5a1136064422e76c3d05477d63fa689572a5365e863499b517d2686a5720cb78 # shrinks to base_weight_in_percent = 1
+cc 9f244f8ca0be0b09e27059bdd03940217d7d49bd8adf0e8d6cbac41ca76d6c15 # shrinks to btc_value = 1
+cc 9f8fc2f342052f3ec0b89b5134af576b2d61db6ab4066150c5c378c30f633225 # shrinks to usdt_value = 1
+cc 78af626c818a955574c5503aad9f53f31d2f2d4cd362e0edd1499a65bba6a39c # shrinks to btc_value = 1
+cc a2616ab1058fbc1f372aa37344b8241174d1c7e25fb629e907ae79752d605739 # shrinks to base_weight_in_percent = 100

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -70,7 +70,10 @@ pub mod pallet {
 		WeightInfo,
 	};
 	use codec::FullCodec;
-	use composable_support::math::safe::{safe_multiply_by_rational, SafeArithmetic, SafeSub};
+	use composable_support::{
+		math::safe::{safe_multiply_by_rational, SafeArithmetic, SafeSub},
+		validation::TryIntoValidated,
+	};
 	use composable_traits::{
 		currency::{CurrencyFactory, LocalAssets, RangeId},
 		defi::{CurrencyPair, Rate},
@@ -668,8 +671,18 @@ pub mod pallet {
 				.try_collect()
 				.map_err(|_| Error::<T>::StakingPoolConfigError)?;
 			let duration_presets = [
-				(ONE_WEEK, FixedU64::from_rational(1, 100)),
-				(ONE_MONTH, FixedU64::from_rational(1, 10)),
+				(
+					ONE_WEEK,
+					FixedU64::from_rational(101, 100)
+						.try_into_validated()
+						.expect("valid reward multiplier"),
+				),
+				(
+					ONE_MONTH,
+					FixedU64::from_rational(11, 10)
+						.try_into_validated()
+						.expect("valid reward multiplier"),
+				),
 			]
 			.into_iter()
 			.try_collect()

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -93,6 +93,7 @@ pub mod pallet {
 		},
 		transactional, BoundedBTreeMap, PalletId, RuntimeDebug,
 	};
+	use sp_arithmetic::fixed_point::FixedU64;
 
 	use crate::liquidity_bootstrapping::LiquidityBootstrapping;
 	use composable_maths::dex::{
@@ -666,11 +667,13 @@ pub mod pallet {
 				.into_iter()
 				.try_collect()
 				.map_err(|_| Error::<T>::StakingPoolConfigError)?;
-			let duration_presets =
-				[(ONE_WEEK, Perbill::from_percent(1)), (ONE_MONTH, Perbill::from_percent(10))]
-					.into_iter()
-					.try_collect()
-					.map_err(|_| Error::<T>::StakingPoolConfigError)?;
+			let duration_presets = [
+				(ONE_WEEK, FixedU64::from_rational(1, 100)),
+				(ONE_MONTH, FixedU64::from_rational(1, 10)),
+			]
+			.into_iter()
+			.try_collect()
+			.map_err(|_| Error::<T>::StakingPoolConfigError)?;
 			let lock = LockConfig { duration_presets, unlock_penalty: Perbill::from_percent(5) };
 			let five_years_block = 5 * 365 * 24 * 60 * 60 / T::MsPerBlock::get();
 			// NOTE(connor): `start_block` must greater than current block

--- a/code/parachain/frame/staking-rewards/src/benchmarking.rs
+++ b/code/parachain/frame/staking-rewards/src/benchmarking.rs
@@ -16,7 +16,7 @@ use frame_support::{
 	BoundedBTreeMap,
 };
 use frame_system::{EventRecord, RawOrigin};
-use sp_arithmetic::{traits::SaturatedConversion, Perbill, Permill};
+use sp_arithmetic::{fixed_point::FixedU64, traits::SaturatedConversion, Perbill, Permill};
 use sp_runtime::traits::{BlockNumberProvider, One};
 use sp_std::collections::btree_map::BTreeMap;
 
@@ -46,8 +46,8 @@ fn get_reward_pool<T: Config>(
 fn lock_config<T: Config>() -> LockConfig<T::MaxStakingDurationPresets> {
 	LockConfig {
 		duration_presets: [
-			(ONE_HOUR, Perbill::from_percent(1)),                // 1%
-			(ONE_MINUTE, Perbill::from_rational(1_u32, 10_u32)), // 0.1%
+			(ONE_HOUR, FixedU64::from_rational(1, 100)),     // 1%
+			(ONE_MINUTE, FixedU64::from_rational(1, 1_000)), // 0.1%
 		]
 		.into_iter()
 		.try_collect()
@@ -107,7 +107,7 @@ benchmarks! {
 		let asset_id = BASE_ASSET_ID.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
-		let reward_multiplier = Perbill::from_percent(1);
+		let reward_multiplier = FixedU64::from_rational(1, 100);
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);

--- a/code/parachain/frame/staking-rewards/src/benchmarking.rs
+++ b/code/parachain/frame/staking-rewards/src/benchmarking.rs
@@ -46,8 +46,8 @@ fn get_reward_pool<T: Config>(
 fn lock_config<T: Config>() -> LockConfig<T::MaxStakingDurationPresets> {
 	LockConfig {
 		duration_presets: [
-			(ONE_HOUR, FixedU64::from_rational(1, 100)),     // 1%
-			(ONE_MINUTE, FixedU64::from_rational(1, 1_000)), // 0.1%
+			(ONE_HOUR, FixedU64::from_rational(101, 100).try_into_validated().expect(">= 1")), /* 1% */
+			(ONE_MINUTE, FixedU64::from_rational(1_001, 1_000).try_into_validated().expect(">= 1")), /* 0.1% */
 		]
 		.into_iter()
 		.try_collect()
@@ -107,7 +107,7 @@ benchmarks! {
 		let asset_id = BASE_ASSET_ID.into();
 		let amount = 100_500_u128.into();
 		let duration_preset = ONE_HOUR;
-		let reward_multiplier = FixedU64::from_rational(1, 100);
+		let reward_multiplier = FixedU64::from_rational(101, 100);
 		let keep_alive = true;
 		let staker = whitelisted_caller();
 		let pool_owner: T::AccountId = account("owner", 0, 0);

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -492,10 +492,13 @@ pub mod pallet {
 			end_block: T::BlockNumber::zero(),
 			lock: LockConfig {
 				duration_presets: [
-					(ONE_WEEK, FixedU64::from_rational(1, 100).try_into_validated().expect(">= 1")),
+					(
+						ONE_WEEK,
+						FixedU64::from_rational(101, 100).try_into_validated().expect(">= 1"),
+					),
 					(
 						ONE_MONTH,
-						FixedU64::from_rational(10, 100).try_into_validated().expect(">= 1"),
+						FixedU64::from_rational(110, 100).try_into_validated().expect(">= 1"),
 					),
 				]
 				.into_iter()

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 		prelude::{stake_and_assert, unstake_and_assert, H256, MINIMUM_STAKING_AMOUNT},
 		runtime::*,
 	},
-	Config, RewardPoolConfigurationOf, RewardPools, StakeOf, Stakes,
+	Config, RewardPoolConfigurationOf, RewardPools, Stakes,
 };
 use composable_support::validation::TryIntoValidated;
 use composable_tests_helpers::test::{
@@ -21,7 +21,7 @@ use composable_traits::{
 		lock::{Lock, LockConfig},
 		ProtocolStaking, RewardConfig,
 		RewardPoolConfiguration::RewardRateBasedIncentive,
-		RewardRate, Stake, Staking,
+		RewardRate, Stake,
 	},
 	time::{DurationSeconds, ONE_HOUR, ONE_MINUTE},
 };
@@ -216,8 +216,18 @@ fn create_staking_reward_pool_should_fail_when_slashed_minimum_amount_is_less_th
 					reward_configs: default_reward_config(),
 					lock: LockConfig {
 						duration_presets: [
-							(ONE_HOUR, Perbill::from_percent(1)),                // 1%
-							(ONE_MINUTE, Perbill::from_rational(1_u32, 10_u32)), // 0.1%
+							(
+								ONE_HOUR,
+								FixedU64::from_rational(101, 100)
+									.try_into_validated()
+									.expect("valid reward multiplier")
+							), // 1%
+							(
+								ONE_MINUTE,
+								FixedU64::from_rational(11, 10)
+									.try_into_validated()
+									.expect("valid reward multiplier")
+							), // 0.1%
 						]
 						.into_iter()
 						.try_collect()

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -85,7 +85,10 @@ fn duration_presets_minimum_is_1() {
 				reward_configs: default_reward_config(),
 				lock: LockConfig {
 					duration_presets: [
-						(ONE_MINUTE, FixedU64::from_rational(1, 10)), // 0.1%
+						(
+							ONE_MINUTE,
+							FixedU64::from_rational(110, 100).try_into_validated().expect(">= 1")
+						), // 0.1%
 					]
 					.into_iter()
 					.try_collect()
@@ -168,8 +171,18 @@ fn create_staking_reward_pool_should_fail_when_slashed_amount_is_less_than_exist
 					reward_configs: default_reward_config(),
 					lock: LockConfig {
 						duration_presets: [
-							(ONE_HOUR, FixedU64::from_rational(1, 100)),     // 1%
-							(ONE_MINUTE, FixedU64::from_rational(1, 1_000)), // 0.1%
+							(
+								ONE_HOUR,
+								FixedU64::from_rational(101, 100)
+									.try_into_validated()
+									.expect(">= 1")
+							), // 1%
+							(
+								ONE_MINUTE,
+								FixedU64::from_rational(1_001, 1_000)
+									.try_into_validated()
+									.expect(">= 1")
+							), // 0.1%
 						]
 						.into_iter()
 						.try_collect()
@@ -554,36 +567,29 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 	new_test_ext().execute_with(|| {
 		const AMOUNT: u128 = 100_500_u128;
 		const DURATION_PRESET: u64 = ONE_HOUR;
-		const TOTAL_REWARDS: u128 = 100;
-		const TOTAL_SHARES: u128 = 200;
+
 		let fnft_asset_account = FinancialNft::asset_account(&1, &0);
 
 		process_and_progress_blocks::<StakingRewards, Test>(1);
-		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
+
+		create_rewards_pool_and_assert::<Test, runtime::Event>(get_default_reward_pool());
+
 		process_and_progress_blocks::<StakingRewards, Test>(1);
 
-		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
-		mint_assets([ALICE], [staked_asset_id], AMOUNT * 2);
-		update_total_rewards_and_total_shares_in_rewards_pool(
-			PICA::ID,
-			TOTAL_REWARDS,
-			TOTAL_SHARES,
-		);
+		mint_assets([ALICE], [PICA::ID], AMOUNT * 2);
 
-		assert_ok!(StakingRewards::stake(Origin::signed(ALICE), PICA::ID, AMOUNT, DURATION_PRESET));
+		stake_and_assert::<Test, runtime::Event>(ALICE, PICA::ID, AMOUNT, DURATION_PRESET);
+
 		let rewards_pool = StakingRewards::pools(PICA::ID).expect("rewards_pool expected");
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, DURATION_PRESET)
 			.expect("reward_multiplier expected");
-		let inflation = StakingRewards::boosted_amount(reward_multiplier, AMOUNT)
-			.expect("boosted amount should not overflow") *
-			TOTAL_REWARDS /
-			TOTAL_SHARES;
-		assert_eq!(inflation, 502);
+		let boosted_amount = StakingRewards::boosted_amount(reward_multiplier, AMOUNT)
+			.expect("boosted amount should not overflow");
+
 		let reductions = rewards_pool
 			.rewards
-			.into_inner()
 			.iter()
-			.map(|(asset_id, _reward)| (*asset_id, inflation))
+			.map(|(asset_id, _reward)| (*asset_id, 0))
 			.try_collect()
 			.expect("reductions expected");
 
@@ -604,31 +610,8 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 			})
 		);
 
-		assert_eq!(balance(staked_asset_id, &ALICE), AMOUNT);
-		assert_eq!(balance(staked_asset_id, &fnft_asset_account), AMOUNT);
-
-		assert!(FinancialNft::instance(1, 0).is_some());
-
-		assert_last_event_with::<Test, Event, _, _>(|event| match event {
-			crate::Event::Staked {
-				pool_id,
-				owner,
-				amount,
-				duration_preset: _,
-				fnft_collection_id: _,
-				fnft_instance_id: _,
-				reward_multiplier,
-				keep_alive: _,
-			} => {
-				assert_eq!(owner, ALICE);
-				assert_eq!(pool_id, PICA::ID);
-				assert_eq!(amount, 100_500_u32.into());
-				assert_eq!(reward_multiplier, FixedU64::from_rational(1, 100));
-
-				Some(())
-			},
-			_ => None,
-		});
+		assert_eq!(balance(PICA::ID, &ALICE), AMOUNT);
+		assert_eq!(balance(PICA::ID, &fnft_asset_account), AMOUNT);
 	});
 }
 
@@ -638,18 +621,16 @@ fn test_extend_stake_amount() {
 		process_and_progress_blocks::<StakingRewards, Test>(1);
 
 		assert_ok!(StakingRewards::create_reward_pool(Origin::root(), get_default_reward_pool()));
+
 		let staker = ALICE;
 		let pool_id = PICA::ID;
 		let amount = 100_500_u32.into();
 		let extend_amount = 100_500_u32.into();
 		let existential_deposit = 1_000_u128;
 		let duration_preset = ONE_HOUR;
-		let total_rewards = 100;
-		let total_shares = 200;
 
 		let staked_asset_id = StakingRewards::pools(PICA::ID).expect("asset_id expected").asset_id;
 		mint_assets([staker], [staked_asset_id], amount * 2 + existential_deposit);
-		update_total_rewards_and_total_shares_in_rewards_pool(pool_id, total_rewards, total_shares);
 
 		process_and_progress_blocks::<StakingRewards, Test>(1);
 		assert_ok!(StakingRewards::stake(Origin::signed(staker), pool_id, amount, duration_preset));
@@ -658,27 +639,15 @@ fn test_extend_stake_amount() {
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, duration_preset)
 			.expect("reward_multiplier expected");
 		let boosted_amount = StakingRewards::boosted_amount(reward_multiplier, amount).expect("boosted amount should not overflow") ;
-		let inflation = boosted_amount * total_rewards / total_shares;
 
 		assert_ok!(StakingRewards::extend(Origin::signed(staker), 1, 0, extend_amount));
 
 		let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 
-		let total_rewards =	rewards_pool
-			.rewards
-			.iter()
-			.fold(0, |total_rewards, (_asset_id, reward)| {
-				total_rewards + reward.total_rewards
-			});
-
-		let inflation_extended = extend_amount * total_rewards / rewards_pool.total_shares;
-		let inflation = inflation + inflation_extended;
-		assert_eq!(inflation, 50710);
-
 		let reductions = rewards_pool
 			.rewards
 			.iter()
-			.map(|(asset_id, _reward)| (*asset_id, inflation))
+			.map(|(asset_id, _reward)| (*asset_id, 0))
 			.try_collect()
 			.expect("reductions expected");
 
@@ -934,67 +903,67 @@ fn test_split_position() {
 		);
 		process_and_progress_blocks::<StakingRewards, Test>(1);
 
-		let reduction = PICA::units(10);
-		let stake = StakeOf::<Test> {
-			reward_pool_id: PICA::ID,
-			stake: PICA::units(1_000),
-			share: PICA::units(10),
-			reductions: [(USDT::ID, reduction)]
-				.into_iter()
-				.try_collect()
-				.expect("BoundedBTreeMap creation failed"),
-			lock: Lock {
-				started_at: 10000_u64,
-				duration: 10000000_u64,
-				unlock_penalty: Perbill::from_percent(2),
-			},
-			fnft_instance_id: 0,
-		};
-		mint_assets([BOB], [PICA::ID], PICA::units(2000));
+		mint_assets([ALICE], [PICA::ID], PICA::units(2000));
 
-		assert_extrinsic_event::<Test, _, _, _, _>(
-			StakingRewards::stake(Origin::signed(BOB), PICA::ID, PICA::units(1_000), ONE_HOUR),
-			crate::Event::Staked {
-				pool_id: PICA::ID,
-				owner: BOB,
-				amount: PICA::units(1_000),
-				duration_preset: ONE_HOUR,
-				fnft_collection_id: 1,
-				fnft_instance_id: 0,
-				reward_multiplier: FixedU64::from_rational(1, 100),
-				keep_alive: true,
-			},
+		let existing_fnft_instance_id = stake_and_assert::<Test, runtime::Event>(
+			ALICE,
+			PICA::ID,
+			PICA::units(1_000),
+			ONE_HOUR,
+			// crate::Event::Staked {
+			// 	pool_id: PICA::ID,
+			// 	owner: BOB,
+			// 	amount: PICA::units(1_000),
+			// 	duration_preset: ONE_HOUR,
+			// 	fnft_collection_id: 1,
+			// 	fnft_instance_id: 0,
+			// 	reward_multiplier: FixedU64::from_rational(101, 100),
+			// 	keep_alive: true,
+			// },
 		);
-		Stakes::<Test>::insert(1, 0, stake.clone());
+
+		let existing_stake_before_split =
+			Stakes::<Test>::get(1, existing_fnft_instance_id).expect("stake should exist");
+
 		let ratio = Permill::from_rational(1_u32, 7_u32);
 		let left_from_one_ratio = ratio.left_from_one();
-		let split = <StakingRewards as Staking>::split(&ALICE, &(1, 0), ratio);
-		assert_ok!(split);
-		let stake1 = Stakes::<Test>::get(1, 0);
-		let stake2 = Stakes::<Test>::get(1, 1);
-		assert!(stake1.is_some());
-		assert!(stake2.is_some());
-		let stake1 = stake1.unwrap();
-		let stake2 = stake2.unwrap();
+
+		let new_fnft_instance_id = split_and_assert::<Test, runtime::Event>(
+			ALICE,
+			1,
+			0,
+			ratio.try_into_validated().expect("valid split ratio"),
+		);
+
+		let existing_stake =
+			Stakes::<Test>::get(1, existing_fnft_instance_id).expect("stake should exist");
+		let new_stake = Stakes::<Test>::get(1, new_fnft_instance_id).expect("stake should exist");
+
 		// validate stake and share as per ratio
-		assert_eq!(stake1.stake, ratio.mul_floor(stake.stake));
-		assert_eq!(stake1.share, ratio.mul_floor(stake.share));
-		assert_eq!(stake1.reductions.get(&USDT::ID), Some(&ratio.mul_floor(reduction)));
-		assert_eq!(stake2.stake, left_from_one_ratio.mul_floor(stake.stake));
-		assert_eq!(stake2.share, left_from_one_ratio.mul_floor(stake.share));
+		assert_eq!(existing_stake.stake, ratio.mul_floor(existing_stake_before_split.stake));
+		assert_eq!(existing_stake.share, ratio.mul_floor(existing_stake_before_split.share));
 
-		assert_eq!(balance(PICA::ID, &FinancialNft::asset_account(&1, &0)), stake1.stake);
-		assert_eq!(balance(XPICA::ID, &FinancialNft::asset_account(&1, &0)), stake1.share);
-
-		assert_eq!(balance(PICA::ID, &FinancialNft::asset_account(&1, &1)), stake2.stake);
-		assert_eq!(balance(XPICA::ID, &FinancialNft::asset_account(&1, &1)), stake2.share);
+		assert_eq!(existing_stake.reductions.get(&USDT::ID), Some(&0));
 
 		assert_eq!(
-			stake2.reductions.get(&USDT::ID),
-			Some(&left_from_one_ratio.mul_floor(reduction))
+			new_stake.stake,
+			left_from_one_ratio.mul_floor(existing_stake_before_split.stake)
 		);
+		assert_eq!(
+			new_stake.share,
+			left_from_one_ratio.mul_floor(existing_stake_before_split.share)
+		);
+
+		assert_eq!(balance(PICA::ID, &FinancialNft::asset_account(&1, &0)), existing_stake.stake);
+		assert_eq!(balance(XPICA::ID, &FinancialNft::asset_account(&1, &0)), existing_stake.share);
+
+		assert_eq!(balance(PICA::ID, &FinancialNft::asset_account(&1, &1)), new_stake.stake);
+		assert_eq!(balance(XPICA::ID, &FinancialNft::asset_account(&1, &1)), new_stake.share);
+
+		assert_eq!(new_stake.reductions.get(&USDT::ID), Some(&0));
+
 		helper::assert_last_event::<Test>(Event::StakingRewards(crate::Event::SplitPosition {
-			positions: vec![(PICA::ID, 0, stake1.stake), (PICA::ID, 1, stake2.stake)],
+			positions: vec![(PICA::ID, 0, existing_stake.stake), (PICA::ID, 1, new_stake.stake)],
 		}));
 	});
 }
@@ -1243,34 +1212,42 @@ mod claim {
 
 	#[test]
 	fn should_change_stake_reductions_in_storage() {
-		let staker = ALICE;
-		let amount = 100_500;
-		let duration_preset = ONE_HOUR;
-		let total_rewards = 100;
-		let total_shares = 200;
-		let claim = 50;
+		const AMOUNT: u128 = 100_500;
+		const DURATION: u64 = ONE_HOUR;
 
-		with_stake(
-			staker,
-			amount,
-			duration_preset,
-			total_rewards,
-			total_shares,
-			Some(claim),
-			|_pool_id, _unlock_penalty, _stake_duration, _staked_asset_id| {
-				assert_ok!(StakingRewards::claim(Origin::signed(staker), 1, 0));
+		new_test_ext().execute_with(|| {
+			process_and_progress_blocks::<StakingRewards, Test>(1);
+			assert_ok!(StakingRewards::create_reward_pool(
+				Origin::root(),
+				get_default_reward_pool()
+			));
 
-				assert_last_event::<Test, _>(|e| {
-					matches!(&e.event,
-            		Event::StakingRewards(crate::Event::Claimed{ owner, fnft_collection_id, fnft_instance_id })
-            		if owner == &staker && fnft_collection_id == &1 && fnft_instance_id == &0)
-				});
+			let pool_id = PICA::ID;
+			let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected. QED");
+			let staked_asset_id = rewards_pool.asset_id;
 
-				let stake = Stakes::<Test>::get(1, 0).expect("expected stake. QED");
+			// far more than is necessary
+			mint_assets([CHARLIE], [USDT::ID], USDT::units(100_000_000));
+			add_to_rewards_pot_and_assert(CHARLIE, PICA::ID, USDT::ID, USDT::units(100_000_000));
 
-				assert_eq!(stake.reductions.get(&USDT::ID), Some(&502_u128));
-			},
-		);
+			process_and_progress_blocks::<StakingRewards, Test>(1);
+
+			mint_assets([ALICE], [PICA::ID], PICA::units(100_000_000));
+			let fnft_instance_id =
+				stake_and_assert::<Test, runtime::Event>(ALICE, pool_id, AMOUNT, DURATION);
+
+			assert_eq!(balance(staked_asset_id, &ALICE), PICA::units(100_000_000) - AMOUNT);
+
+			assert_extrinsic_event::<Test, runtime::Event, _, _, _>(
+				StakingRewards::claim(Origin::signed(ALICE), 1, 0),
+				crate::Event::Claimed { owner: ALICE, fnft_collection_id: 1, fnft_instance_id: 0 },
+			);
+
+			let stake = Stakes::<Test>::get(1, 0).expect("expected stake. QED");
+
+			// should be 1 block's worth of claims
+			assert_eq!(stake.reductions.get(&USDT::ID), Some(&60));
+		});
 	}
 
 	#[test]
@@ -1427,8 +1404,8 @@ fn get_default_reward_pool() -> RewardPoolConfigurationOf<Test> {
 fn default_lock_config() -> LockConfig<MaxStakingDurationPresets> {
 	LockConfig {
 		duration_presets: [
-			(ONE_HOUR, FixedU64::from_rational(1, 100)),     // 1%
-			(ONE_MINUTE, FixedU64::from_rational(1, 1_000)), // 0.1%
+			(ONE_HOUR, FixedU64::from_rational(101, 100).try_into_validated().expect(">= 1")), /* 1% */
+			(ONE_MINUTE, FixedU64::from_rational(1_001, 1_000).try_into_validated().expect(">= 1")), /* 0.1% */
 		]
 		.into_iter()
 		.try_collect()

--- a/code/parachain/frame/staking-rewards/src/test/mod.rs
+++ b/code/parachain/frame/staking-rewards/src/test/mod.rs
@@ -499,7 +499,8 @@ fn stake_in_case_of_zero_inflation_should_work() {
 			Some(Stake {
 				reward_pool_id: PICA::ID,
 				stake: amount,
-				share: StakingRewards::boosted_amount(reward_multiplier, amount).unwrap(),
+				share: StakingRewards::boosted_amount(reward_multiplier, amount)
+					.expect("boosted amount should not overflow"),
 				reductions,
 				lock: Lock {
 					started_at: 12,
@@ -512,13 +513,18 @@ fn stake_in_case_of_zero_inflation_should_work() {
 		assert_eq!(
 			<StakingRewards as FinancialNftProtocol>::value_of(&PICA::ID, &fnft_instance_id)
 				.expect("must return a value"),
-			vec![(XPICA::ID, StakingRewards::boosted_amount(reward_multiplier, amount).unwrap())]
+			vec![(
+				XPICA::ID,
+				StakingRewards::boosted_amount(reward_multiplier, amount)
+					.expect("boosted amount should not overflow"),
+			)]
 		);
 		assert_eq!(balance(staked_asset_id, &staker), amount);
 		assert_eq!(balance(staked_asset_id, &fnft_asset_account), amount);
 		assert_eq!(
 			balance(XPICA::ID, &fnft_asset_account),
-			StakingRewards::boosted_amount(reward_multiplier, amount).unwrap()
+			StakingRewards::boosted_amount(reward_multiplier, amount)
+				.expect("boosted amount should not overflow"),
 		);
 
 		assert_last_event_with::<Test, Event, crate::Event<Test>, _>(|event| {
@@ -568,7 +574,8 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 		let rewards_pool = StakingRewards::pools(PICA::ID).expect("rewards_pool expected");
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, DURATION_PRESET)
 			.expect("reward_multiplier expected");
-		let inflation = StakingRewards::boosted_amount(reward_multiplier, AMOUNT).unwrap() *
+		let inflation = StakingRewards::boosted_amount(reward_multiplier, AMOUNT)
+			.expect("boosted amount should not overflow") *
 			TOTAL_REWARDS /
 			TOTAL_SHARES;
 		assert_eq!(inflation, 502);
@@ -585,7 +592,8 @@ fn stake_in_case_of_not_zero_inflation_should_work() {
 			Some(Stake {
 				reward_pool_id: PICA::ID,
 				stake: AMOUNT,
-				share: StakingRewards::boosted_amount(reward_multiplier, AMOUNT).unwrap(),
+				share: StakingRewards::boosted_amount(reward_multiplier, AMOUNT)
+					.expect("boosted amount should not overflow"),
 				reductions,
 				lock: Lock {
 					started_at: 12,
@@ -649,7 +657,7 @@ fn test_extend_stake_amount() {
 		let rewards_pool = StakingRewards::pools(pool_id).expect("rewards_pool expected");
 		let reward_multiplier = StakingRewards::reward_multiplier(&rewards_pool, duration_preset)
 			.expect("reward_multiplier expected");
-		let boosted_amount = StakingRewards::boosted_amount(reward_multiplier, amount).unwrap();
+		let boosted_amount = StakingRewards::boosted_amount(reward_multiplier, amount).expect("boosted amount should not overflow") ;
 		let inflation = boosted_amount * total_rewards / total_shares;
 
 		assert_ok!(StakingRewards::extend(Origin::signed(staker), 1, 0, extend_amount));


### PR DESCRIPTION
Changes the reward multiplier to be a `FixedU64` instead of a `Perbill`