### PR TITLE
#wip use GH runner for tests  and some tests optimization

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -387,12 +387,7 @@ jobs:
 
   unit-tests:
     name: "Unit Tests"
-    needs: common-deps
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - sre
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-unittests-${{ github.ref }}
       cancel-in-progress: true
@@ -418,12 +413,7 @@ jobs:
 
   unit-tests-with-coverage:
     name: "Unit Tests with coverage"
-    needs: common-deps
-    runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - sre
+    runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-unittests-with-coverage-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -56,11 +56,11 @@ jobs:
       - run: |
           cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps --no-update-lock-file --show-trace -L
 
-  build-common-test-deps:
+  build-common-deps-nightly:
     needs:
       - check-nix
     concurrency:
-      group: ${{ github.workflow }}-build-common-test-deps-${{ github.ref }}
+      group: ${{ github.workflow }}-build-common-deps-nightly-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     container:
@@ -82,7 +82,7 @@ jobs:
           name: ${{  env.CACHIX_COMPOSABLE }}
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: |
-          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-test-deps --no-update-lock-file --show-trace -L
+          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps-nightly --no-update-lock-file --show-trace -L
           
   check-nix:
     name: "Check nix"
@@ -417,7 +417,7 @@ jobs:
     name: "Unit Tests"
     runs-on: ubuntu-latest
     needs:
-      - build-common-test-deps
+      - build-common-deps-nightly
     concurrency:
       group: ${{ github.workflow }}-unittests-${{ github.ref }}
       cancel-in-progress: true
@@ -445,7 +445,7 @@ jobs:
     name: "Unit Tests with coverage"
     runs-on: ubuntu-latest
     needs:
-      - build-common-test-deps    
+      - build-common-deps-nightly    
     concurrency:
       group: ${{ github.workflow }}-unittests-with-coverage-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -56,11 +56,11 @@ jobs:
       - run: |
           cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps --no-update-lock-file --show-trace -L
 
-  build-common-deps-nightly:
+  build-common-test-deps:
     needs:
       - check-nix
     concurrency:
-      group: ${{ github.workflow }}-build-common-deps-nightly-${{ github.ref }}
+      group: ${{ github.workflow }}-build-common-test-deps-${{ github.ref }}
       cancel-in-progress: true
     runs-on: ubuntu-latest
     container:
@@ -82,7 +82,7 @@ jobs:
           name: ${{  env.CACHIX_COMPOSABLE }}
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: |
-          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps-nightly --no-update-lock-file --show-trace -L
+          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-test-deps --no-update-lock-file --show-trace -L
           
   check-nix:
     name: "Check nix"
@@ -417,7 +417,7 @@ jobs:
     name: "Unit Tests"
     runs-on: ubuntu-latest
     needs:
-      - build-common-deps-nightly
+      - build-common-test-deps
     concurrency:
       group: ${{ github.workflow }}-unittests-${{ github.ref }}
       cancel-in-progress: true
@@ -445,7 +445,7 @@ jobs:
     name: "Unit Tests with coverage"
     runs-on: ubuntu-latest
     needs:
-      - build-common-deps-nightly    
+      - build-common-test-deps    
     concurrency:
       group: ${{ github.workflow }}-unittests-with-coverage-${{ github.ref }}
       cancel-in-progress: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -56,6 +56,34 @@ jobs:
       - run: |
           cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps --no-update-lock-file --show-trace -L
 
+  build-common-test-deps:
+    needs:
+      - check-nix
+    concurrency:
+      group: ${{ github.workflow }}-build-common-test-deps-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    container:
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+    steps:
+      # TODO: do composable-nix-os which has experimental-features, proper channel, and cachix installed with composable cache
+      - uses: actions/checkout@v3
+      - run: |
+          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
+          echo "sandbox = relaxed" >> /etc/nix/nix.conf
+          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
+      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
+        with:
+          skipPush: true
+          installCommand: |
+            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
+            nix-channel --update
+            nix-env -iA nixpkgs.cachix
+          name: ${{  env.CACHIX_COMPOSABLE }}
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: |
+          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-test-deps --no-update-lock-file --show-trace -L
+          
   check-nix:
     name: "Check nix"
     continue-on-error: false
@@ -388,6 +416,8 @@ jobs:
   unit-tests:
     name: "Unit Tests"
     runs-on: ubuntu-latest
+    needs:
+      - build-common-test-deps
     concurrency:
       group: ${{ github.workflow }}-unittests-${{ github.ref }}
       cancel-in-progress: true
@@ -414,6 +444,8 @@ jobs:
   unit-tests-with-coverage:
     name: "Unit Tests with coverage"
     runs-on: ubuntu-latest
+    needs:
+      - build-common-test-deps    
     concurrency:
       group: ${{ github.workflow }}-unittests-with-coverage-${{ github.ref }}
       cancel-in-progress: true

--- a/flake.lock
+++ b/flake.lock
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1660447363,
-        "narHash": "sha256-Y1OtGWEb0bgFlp9YULaiYcgfEoHVIz1NuXwzlFZ/0HE=",
+        "lastModified": 1665356181,
+        "narHash": "sha256-ONEzlKL5LN4Y1TRfFY6C39G2Am1YFEjArwMYJONFhhs=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5548a68f5d4d60a2315ab1232e6fba5528e71dc8",
+        "rev": "d78cb0453b9823d2102f7b22bb98686215462416",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -255,9 +255,9 @@
             src = rust-src;
             SKIP_WASM_BUILD = "1";
             cargoExtraArgs = "--tests --release";
-            doInstallCargoArtifacts = false;
             doCheck = true;
           };
+
           common-test-deps =
             crane-nightly.buildDepsOnly (common-test-attrs // { });
 
@@ -829,16 +829,18 @@
               run-with-benchmarks "composable-dev";
 
             check-picasso-integration-tests = crane-nightly.cargoBuild
-              (common-test-attrs // {
+              (common-attrs // {
                 pname = "picasso-local-integration-tests";
+                doInstallCargoArtifacts = false;
                 cargoArtifacts = common-test-deps;
                 cargoBuildCommand = "cargo test";
                 cargoExtraArgs =
                   "--package local-integration-tests --features=local-integration-tests,picasso,std --no-default-features --verbose";
               });
             check-dali-integration-tests = crane-nightly.cargoBuild
-              (common-test-attrs // {
+              (common-attrs // {
                 pname = "dali-local-integration-tests";
+                doInstallCargoArtifacts = false;
                 cargoArtifacts = common-test-deps;
                 cargoBuildCommand = "cargo test";
                 cargoExtraArgs =
@@ -847,6 +849,7 @@
 
             unit-tests = crane-nightly.cargoBuild (common-attrs // {
               pnameSuffix = "-tests";
+              doInstallCargoArtifacts = false;
               cargoArtifacts = common-test-deps;
               # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
               # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")

--- a/flake.nix
+++ b/flake.nix
@@ -248,6 +248,12 @@
           common-bench-deps =
             crane-nightly.buildDepsOnly (common-bench-attrs // { });
 
+          common-test-attrs = common-attrs // {
+            cargoExtraArgs = "--tests --release";
+          };
+          common-test-deps =
+            crane-nightly.buildDepsOnly (common-test-attrs // { });
+
           # Build a wasm runtime, unoptimized
           mk-runtime = name: features:
             let file-name = "${name}_runtime.wasm";
@@ -489,6 +495,7 @@
           packages = rec {
             inherit wasm-optimizer;
             inherit common-deps;
+            inherit common-test-deps;
             inherit common-bench-deps;
             inherit dali-runtime;
             inherit picasso-runtime;
@@ -833,7 +840,7 @@
 
             unit-tests = crane-nightly.cargoBuild (common-attrs // {
               pnameSuffix = "-tests";
-              cargoArtifacts = common-deps;
+              cargoArtifacts = common-test-deps;
               # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
               # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")
               cargoBuildCommand =
@@ -864,7 +871,7 @@
               // {
                 pnameSuffix = "-tests-with-coverage";
                 buildInputs = [ cargo-llvm-cov ];
-                cargoArtifacts = common-deps-nightly;
+                cargoArtifacts = common-test-deps;
                 # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
                 # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")
                 cargoBuildCommand = "cargo llvm-cov";

--- a/flake.nix
+++ b/flake.nix
@@ -248,12 +248,6 @@
           common-bench-deps =
             crane-nightly.buildDepsOnly (common-bench-attrs // { });
 
-          common-test-attrs = common-attrs // {
-            cargoExtraArgs = "--tests --release";
-          };
-          common-test-deps =
-            crane-nightly.buildDepsOnly (common-test-attrs // { });
-
           # Build a wasm runtime, unoptimized
           mk-runtime = name: features:
             let file-name = "${name}_runtime.wasm";
@@ -495,7 +489,7 @@
           packages = rec {
             inherit wasm-optimizer;
             inherit common-deps;
-            inherit common-test-deps;
+            inherit common-deps-nightly;
             inherit common-bench-deps;
             inherit dali-runtime;
             inherit picasso-runtime;
@@ -840,11 +834,13 @@
 
             unit-tests = crane-nightly.cargoBuild (common-attrs // {
               pnameSuffix = "-tests";
-              cargoArtifacts = common-test-deps;
+              cargoArtifacts = common-deps-nightly;
+
               # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
               # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")
-              cargoBuildCommand =
-                "cargo test --workspace --release --locked --verbose --exclude local-integration-tests";
+              cargoBuildCommand = "cargo test";
+              cargoExtraArgs =
+                " --workspace --release --locked --verbose --exclude local-integration-tests";
             });
 
             cargo-llvm-cov = rustPlatform.buildRustPackage rec {
@@ -871,7 +867,7 @@
               // {
                 pnameSuffix = "-tests-with-coverage";
                 buildInputs = [ cargo-llvm-cov ];
-                cargoArtifacts = common-test-deps;
+                cargoArtifacts = common-deps-nightly;
                 # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
                 # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")
                 cargoBuildCommand = "cargo llvm-cov";

--- a/flake.nix
+++ b/flake.nix
@@ -255,6 +255,7 @@
             src = rust-src;
             SKIP_WASM_BUILD = "1";
             cargoExtraArgs = "--tests --release";
+            doInstallCargoArtifacts = false;
             doCheck = true;
           };
           common-test-deps =

--- a/flake.nix
+++ b/flake.nix
@@ -829,20 +829,20 @@
               run-with-benchmarks "composable-dev";
 
             check-picasso-integration-tests = crane-nightly.cargoBuild
-              (common-attrs // {
+              (common-test-attrs // {
                 pname = "picasso-local-integration-tests";
-                cargoBuildCommand =
-                  "cargo test --package local-integration-tests";
+                cargoArtifacts = common-test-deps;
+                cargoBuildCommand = "cargo test";
                 cargoExtraArgs =
-                  "--features=local-integration-tests,picasso,std --no-default-features --verbose";
+                  "--package local-integration-tests --features=local-integration-tests,picasso,std --no-default-features --verbose";
               });
             check-dali-integration-tests = crane-nightly.cargoBuild
-              (common-attrs // {
+              (common-test-attrs // {
                 pname = "dali-local-integration-tests";
-                cargoBuildCommand =
-                  "cargo test --package local-integration-tests";
+                cargoArtifacts = common-test-deps;
+                cargoBuildCommand = "cargo test";
                 cargoExtraArgs =
-                  "--features=local-integration-tests,dali,std --no-default-features --verbose";
+                  "--package local-integration-tests --features=local-integration-tests,dali,std --no-default-features --verbose";
               });
 
             unit-tests = crane-nightly.cargoBuild (common-attrs // {

--- a/flake.nix
+++ b/flake.nix
@@ -837,7 +837,7 @@
               # NOTE: do not add --features=runtime-benchmarks because it force multi ED to be 0 because of dependencies
               # NOTE: in order to run benchmarks as tests, just make `any(test, feature = "runtime-benchmarks")
               cargoBuildCommand =
-                "cargo test --workspace --release --locked --verbose";
+                "cargo test --workspace --release --locked --verbose --exclude local-integration-tests";
             });
 
             cargo-llvm-cov = rustPlatform.buildRustPackage rec {


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
* autoscaled runner still hang and fail randomly

## Description
* tests should not wait for common-deps as these are different code becasue `#[cfg(test)]` may be on codes - so it recompiles anyway.
* checking how fast is GH managed runner vs 50 minutes of hosted
* do not run `local-integration-tests` as part of tests as they run separately
* TODO: seems need to find out how to build shared deps

## Notes

Yep, it compile 100% own deps

```
2022-10-06T10:57:09.7877667Z composable-tests>    Compiling sc-utils v4.0.0-dev (https://github.com/ComposableFi/substrate?rev=fd75550a935d69b6a4ee4f8a48767557b4c9e801#fd75550a)
2022-10-06T10:57:09.7901859Z composable-tests>      Running `rustc --crate-name sc_utils --edition=2021 /nix/store/ihdw1ls8p5nm7lr01jg133nx3g1cd11i-vendor-cargo-deps/66c02ed170967318fab5674d1f77e651b5ccb22d885f7ef25f9b2288bd47f7de/sc-utils-4.0.0-dev/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C embed-bitcode=no --cfg 'feature="default"' --cfg 'feature="metered"' -C metadata=37dc5178145d67fc -C extra-filename=-37dc5178145d67fc --out-dir /tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps -L dependency=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps --extern futures=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/libfutures-bd275bd2f526b945.rmeta --extern futures_timer=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/libfutures_timer-d7e10fcd41166873.rmeta --extern lazy_static=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/liblazy_static-2929070d3a17e85e.rmeta --extern log=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/liblog-ce68bf3efef0e858.rmeta --extern parking_lot=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/libparking_lot-1802293bdcdb6c2f.rmeta --extern prometheus=/tmp/nix-build-composable-tests-2.3.2.drv-0/source/target/release/deps/libprometheus-4832f1279743843a.rmeta --cap-lints allow --remap-path-prefix /nix/store/ihdw1ls8p5nm7lr01jg133nx3g1cd11i-vendor-cargo-deps=/sources`
2022-10-06T10:57:09.8399495Z composable-tests>    Compiling globset v0.4.9
```