### PR TITLE
#CU-3p68u6n basic nixification of hyperspace

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -667,6 +667,19 @@
               meta = { mainProgram = "polkadot"; };
             };
 
+            hyperspace = crane-nightly.buildPackage (common-attrs // {
+              name = "hyperspace";
+              cargoArtifacts = common-deps-nightly;
+              cargoExtraArgs = ''
+                --package hyperspace                
+              '';
+              installPhase = ''
+                mkdir -p $out/bin
+                cp target/release/hyperspace $out/bin/hyperspace
+              '';
+              meta = { mainProgram = "hyperspace"; };
+            });
+
             polkadot-launch =
               callPackage ./scripts/polkadot-launch/polkadot-launch.nix { };
 
@@ -1220,6 +1233,11 @@
             junod = {
               type = "app";
               program = "${packages.junod}/bin/junod";
+            };
+
+            hyperspace = {
+              type = "app";
+              program = pkgs.lib.meta.getExe packages.hyperspace;
             };
 
             # TODO: move list of chains out of here and do fold


### PR DESCRIPTION
## Issue
* https://app.clickup.com/t/3p68u6n

## Description
* basic nix for follow tasks
* next will be https://app.clickup.com/t/3p68uc0

## Checklist
```
dz@dz-pc-11:~/github.com/ComposableFi/composable$ nix run .#hyperspace
warning: Git tree '/home/dz/github.com/ComposableFi/composable' is dirty
hyperspace 
Possible subcommands of the main binary

USAGE:
    hyperspace <SUBCOMMAND>

OPTIONS:
    -h, --help    Print help information

SUBCOMMANDS:
    help     Print this message or the help of the given subcommand(s)
    relay    Start relaying messages between two chains
```