### PR TITLE
improving unit test runs time

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -55,6 +55,33 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: |
           cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-deps --no-update-lock-file --show-trace -L
+  build-common-test-deps:
+    needs:
+      - check-nix
+    concurrency:
+      group: ${{ github.workflow }}-build-common-test-deps-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    container:
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+    steps:
+      # TODO: do composable-nix-os which has experimental-features, proper channel, and cachix installed with composable cache
+      - uses: actions/checkout@v3
+      - run: |
+          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
+          echo "sandbox = relaxed" >> /etc/nix/nix.conf
+          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
+      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
+        with:
+          skipPush: true
+          installCommand: |
+            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
+            nix-channel --update
+            nix-env -iA nixpkgs.cachix
+          name: ${{  env.CACHIX_COMPOSABLE }}
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: |
+          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#common-test-deps --no-update-lock-file --show-trace -L
 
   check-nix:
     name: "Check nix"
@@ -81,11 +108,7 @@ jobs:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           name: composable-community
       - run: |
-          nix flake show --allow-import-from-derivation  --show-trace --fallback -L
-          # TODO: --override-input with flake-utils with only linux system to allow next to run
-          # TODO: are we always will be in broken nix state as arion cannot be built (only run)
-          # https://github.com/numtide/flake-utils/issues/80
-          # nix flake check --keep-going --allow-import-from-derivation  --show-trace --no-update-lock-file --fallback -L
+          nix flake show --allow-import-from-derivation  --show-trace --fallback --debug --print-build-logs --keep-failed          
 
   cargo-fmt-check:
     name: "Cargo fmt check"
@@ -387,7 +410,8 @@ jobs:
 
   unit-tests:
     name: "Unit Tests"
-    needs: common-deps
+    needs:
+      - build-common-test-deps
     runs-on:
       - self-hosted
       - linux

--- a/flake.lock
+++ b/flake.lock
@@ -33,12 +33,9 @@
       "locked": {
         "lastModified": 1660447363,
         "narHash": "sha256-Y1OtGWEb0bgFlp9YULaiYcgfEoHVIz1NuXwzlFZ/0HE=",
-        "lastModified": 1665356181,
-        "narHash": "sha256-ONEzlKL5LN4Y1TRfFY6C39G2Am1YFEjArwMYJONFhhs=",
         "owner": "ipetkov",
         "repo": "crane",
         "rev": "5548a68f5d4d60a2315ab1232e6fba5528e71dc8",
-        "rev": "d78cb0453b9823d2102f7b22bb98686215462416",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -33,9 +33,12 @@
       "locked": {
         "lastModified": 1660447363,
         "narHash": "sha256-Y1OtGWEb0bgFlp9YULaiYcgfEoHVIz1NuXwzlFZ/0HE=",
+        "lastModified": 1665356181,
+        "narHash": "sha256-ONEzlKL5LN4Y1TRfFY6C39G2Am1YFEjArwMYJONFhhs=",
         "owner": "ipetkov",
         "repo": "crane",
         "rev": "5548a68f5d4d60a2315ab1232e6fba5528e71dc8",
+        "rev": "d78cb0453b9823d2102f7b22bb98686215462416",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
* Unit tests are slow

## Description
* do not test integration as part of unit
* share deps as suggested by ipetkov (he said need to use deps with cargoCheck)
* small clean up in nix check
* cut 20 minutes out of 50
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/757125/195350353-0a842084-1d19-4764-bec6-aec4818955fd.png">


## Checklist
- CI passes