### PR TITLE
#CU-3p68uc0 #bridge hyperspace devnet skeleton

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -857,6 +857,57 @@ jobs:
           fi;
           docker push --all-tags "${{ env.DOCKER_REGISTRY_NAME }}/${CONTAINER_NAME}"
 
+  hyperspace-container-publish:
+    needs:
+      - effects-gate
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    concurrency:
+      group: ${{ github.workflow }}-hyperspace-container-${{ github.ref }}
+      cancel-in-progress: true
+    container:
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+    steps:
+      - uses: actions/checkout@v3
+      - run: |
+          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
+          echo "sandbox = relaxed" >> /etc/nix/nix.conf
+          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
+      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
+        with:
+          skipPush: true
+          installCommand: |
+            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
+            nix-channel --update
+            nix-env -iA nixpkgs.cachix nixpkgs.docker nixpkgs.docker-buildx
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          name: composable-community
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - run: |
+          # enable required features (see https://github.com/cachix/install-nix-action/issues/19)
+          mkdir -p ~/.config/nix
+          echo "system-features = kvm" >> ~/.config/nix/nix.conf
+      - run: |
+          CONTAINER_PACKAGE_NAME=hyperspace-container
+          LOCAL_CONTAINER_NAME=composable-hyperspace-container
+          REMOTE_CONTAINER_NAME=composable-hyperspace:latest
+          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#${CONTAINER_PACKAGE_NAME} --no-update-lock-file --show-trace -L
+          docker load --input ./result
+          # update soon https://github.com/actions/checkout/issues/760
+          git config --global --add safe.directory /__w/composable/composable
+          SHA256=$(sha256sum ./result | cut --delimiter " " --fields 1)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          docker image tag $LOCAL_CONTAINER_NAME "${{ env.DOCKER_REGISTRY_NAME }}/${REMOTE_CONTAINER_NAME}:${COMMIT_SHA}"
+          docker image tag $LOCAL_CONTAINER_NAME "${{ env.DOCKER_REGISTRY_NAME }}/${REMOTE_CONTAINER_NAME}:${SHA256}"
+          if [ $(git symbolic-ref HEAD) = "refs/heads/main" ]; then
+            docker image tag $LOCAL_CONTAINER_NAME "${{ env.DOCKER_REGISTRY_NAME }}/${REMOTE_CONTAINER_NAME}:latest"
+          fi;
+          docker push --all-tags "${{ env.DOCKER_REGISTRY_NAME }}/${REMOTE_CONTAINER_NAME}"
+
+
   composable-centauri-publish:
     if: ${{ github.ref == 'refs/heads/centauri' }}
     name: "Docker composable-centauri"
@@ -1287,6 +1338,15 @@ jobs:
             # runs non configured hyperspace
             nix shell --command "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#hyperspace
             ````
+
+            ```shell
+            # runs bridge connected to parachains
+            nix run "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#devnet-bridge
+            ````
+
+            Bridge is published as OSI image too.
+
+            #### Notes
 
             Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1288,12 +1288,6 @@ jobs:
             nix shell --command "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#hyperspace
             ````
 
-            
-            ```shell
-            # runs non configured hyperspace
-            nix shell --command "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#hyperspace
-            ````
-
             Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
 
           comment_includes: 'Nix commands for this PR'

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1288,6 +1288,12 @@ jobs:
             nix shell --command "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#hyperspace
             ````
 
+            
+            ```shell
+            # runs non configured hyperspace
+            nix shell --command "github:ComposableFi/composable/${{ github.event.pull_request.head.sha }}#hyperspace
+            ````
+
             Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
 
           comment_includes: 'Nix commands for this PR'

--- a/.nix/devnet-specs/bridge.nix
+++ b/.nix/devnet-specs/bridge.nix
@@ -1,0 +1,53 @@
+{ pkgs, packages, ... }: {
+  modules = [
+    (let
+      # more secured parachain allows only tokens originated on it self
+      hyperspace = "dali-a-devnet-ibc-dali-b-devnet";
+
+      more-secured-parachain = "dali-a-devnet";
+      securedRelaychainPort = 9944;
+      securedParachainPort = 9988;
+
+      less-secured-parachain = "dali-b-devnet";
+      lessSecuredRelaychainPort = 19944;
+      lessSecuredParachainPort = 19988;
+
+      hyperspaceMetrics = 31328;
+
+      network-name = "composable_bridge_devnet";
+      mk-composable-container = container:
+        container // {
+          service = container.service // { networks = [ network-name ]; };
+        };
+    in {
+      config = {
+        project.name = "composable_xcvm_devnet";
+        networks."${network-name}" = { };
+        services = {
+          "${more-secured-parachain}" = mk-composable-container
+            (import ../services/devnet-dali.nix {
+              inherit pkgs;
+              inherit packages;
+              relaychainPort = securedRelaychainPort;
+              parachainPort = securedParachainPort;
+            });
+          "${less-secured-parachain}" = mk-composable-container
+            (import ../services/devnet-dali.nix {
+              inherit pkgs;
+              inherit packages;
+              relaychainPort = lessSecuredRelaychainPort;
+              parachainPort = lessSecuredParachainPort;
+              packageName = "devnet-dali-b";
+              binaryName = "devnet-dali-b";
+            });
+          "${hyperspace}" = mk-composable-container
+            (import ../services/hyperspace.nix {
+              inherit pkgs;
+              inherit packages;
+              metricsPort = hyperspaceMetrics;
+            });
+        };
+      };
+    })
+  ];
+}

--- a/.nix/services/devnet-dali.nix
+++ b/.nix/services/devnet-dali.nix
@@ -1,20 +1,23 @@
-{ pkgs, packages, relaychainPort, parachainPort }: {
+{ pkgs, packages, relaychainPort, parachainPort, packageName ? "devnet-dali"
+, binaryName ? "devnet-dali-dev" }: {
   image = {
-    contents = [ pkgs.coreutils packages.devnet-dali ];
+    contents = [ pkgs.coreutils packages.${packageName} ];
     enableRecommendedContents = true;
   };
+  #devnet-dali-b
   service = {
     restart = "always";
     command = [
       "sh"
       "-c"
       ''
-        ${packages.devnet-dali}/bin/run-devnet-dali-dev
+        ${packages.${packageName}}/bin/run-${binaryName}
       ''
     ];
-    ports =
-      [ "${toString relaychainPort}:9944" "${toString parachainPort}:9988" ];
+    ports = [
+      "${toString relaychainPort}:${toString relaychainPort}"
+      "${toString parachainPort}:${toString parachainPort}"
+    ];
     stop_signal = "SIGINT";
   };
 }
-

--- a/.nix/services/devnet-picasso.nix
+++ b/.nix/services/devnet-picasso.nix
@@ -1,0 +1,19 @@
+{ pkgs, packages, relaychainPort, parachainPort }: {
+  image = {
+    contents = [ pkgs.coreutils packages.devnet-picasso ];
+    enableRecommendedContents = true;
+  };
+  service = {
+    restart = "always";
+    command = [
+      "sh"
+      "-c"
+      ''
+        ${packages.devnet-picasso}/bin/run-devnet-picasso-dev
+      ''
+    ];
+    ports =
+      [ "${toString relaychainPort}:9955" "${toString parachainPort}:19988" ];
+    stop_signal = "SIGINT";
+  };
+}

--- a/.nix/services/hyperspace.nix
+++ b/.nix/services/hyperspace.nix
@@ -1,0 +1,17 @@
+{ pkgs, packages, metricsPort }: {
+  image = {
+    contents = [ pkgs.coreutils packages.hyperspace-template-default ];
+    enableRecommendedContents = true;
+  };
+  service = {
+    restart = "always";
+    command = [
+      "sh"
+      "-c"
+      ''
+        ${pkgs.lib.meta.getExe packages.hyperspace-template-default}
+      ''
+    ];
+    stop_signal = "SIGINT";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -77,12 +77,11 @@
         , useGlobalChainSpec ? true, polkadot-launch, composable-node
         , polkadot-node, chain-spec, network-config-path ?
           ./scripts/polkadot-launch/rococo-local-dali-dev.nix
-        , binary-name ? chain-spec, composableParaId ? 2087 }:
+        , binary-name ? chain-spec }:
         let
           original-config = (pkgs.callPackage network-config-path {
             polkadot-bin = polkadot-node;
             composable-bin = composable-node;
-            inherit composableParaId;
           }).result;
 
           patched-config = if useGlobalChainSpec then
@@ -726,7 +725,6 @@
               network-config-path = ./scripts/polkadot-launch/dali-dev-b.nix;
               chain-spec = "dali-dev";
               binary-name = "dali-b";
-              composableParaId = 2137;
             }).script;
 
             # Dali Centauri devnet

--- a/flake.nix
+++ b/flake.nix
@@ -491,8 +491,8 @@
                   '';
                 };
               };
-
           in builder {
+            # not parametrized yet
           };
 
           subwasm-release-body = let

--- a/flake.nix
+++ b/flake.nix
@@ -464,34 +464,35 @@
           };
 
           hyperspace-template = let
-            builder = { }: rec {
-              bin = crane-nightly.buildPackage (common-attrs // {
-                name = "hyperspace";
-                pname = "hyperspace";
-                cargoArtifacts = common-deps;
-                cargoExtraArgs = "--package hyperspace";
-                installPhase = ''
-                  mkdir --parents $out/bin
-                  cp target/release/hyperspace $out/bin/hyperspace
-                '';
-                meta = { mainProgram = "hyperspace"; };
-              });
-              config = pkgs.stdenv.lib.makeOverridable
-                (builtins.fromTOML (builtins.readFile ./config.toml));
+            builder = {
+              }: rec {
+                bin = crane-nightly.buildPackage (common-attrs // {
+                  name = "hyperspace";
+                  pname="hyperspace";
+                  cargoArtifacts = common-deps;
+                  cargoExtraArgs= "--package hyperspace";
+                  installPhase = ''
+                    mkdir --parents $out/bin
+                    cp target/release/hyperspace $out/bin/hyperspace
+                  '';
+                  meta = { mainProgram = "hyperspace"; };
+                });
+                config = pkgs.stdenv.lib.makeOverridable
+                  (builtins.fromTOML (builtins.readFile ./config.toml));
 
-              default = pkgs.writeShellApplication {
-                name = "default-hyperspace";
-                runtimeInputs = [ pkgs.coreutils pkgs.bash ];
-                text = ''
-                  echo ${config.result} > hyperspace.local.config.toml
-                  ${
-                    pkgs.lib.meta.getExe bin
-                  } relay --config hyperspace.local.config.toml 
-                '';
+                default = pkgs.writeShellApplication {
+                  name = "default-hyperspace";
+                  runtimeInputs = [ pkgs.coreutils pkgs.bash ];
+                  text = ''
+                    echo ${config.result} > hyperspace.local.config.toml
+                    ${
+                      pkgs.lib.meta.getExe bin
+                    } relay --config hyperspace.local.config.toml 
+                  '';
+                };
               };
-            };
+
           in builder {
-            # not parametrized yet
           };
 
           subwasm-release-body = let

--- a/flake.nix
+++ b/flake.nix
@@ -76,11 +76,13 @@
       mk-devnet = { pkgs, lib, writeTextFile, writeShellApplication
         , useGlobalChainSpec ? true, polkadot-launch, composable-node
         , polkadot-node, chain-spec, network-config-path ?
-          ./scripts/polkadot-launch/rococo-local-dali-dev.nix }:
+          ./scripts/polkadot-launch/rococo-local-dali-dev.nix
+        , binary-name ? chain-spec, composableParaId ? 2087 }:
         let
           original-config = (pkgs.callPackage network-config-path {
             polkadot-bin = polkadot-node;
             composable-bin = composable-node;
+            inherit composableParaId;
           }).result;
 
           patched-config = if useGlobalChainSpec then
@@ -93,7 +95,7 @@
             original-config;
 
           config = writeTextFile {
-            name = "devnet-${chain-spec}-config.json";
+            name = "devnet-${binary-name}-config.json";
             text = builtins.toJSON patched-config;
           };
         in {
@@ -102,7 +104,7 @@
             patched-config.parachains;
           relaychain-nodes = patched-config.relaychain.nodes;
           script = writeShellApplication {
-            name = "run-devnet-${chain-spec}";
+            name = "run-devnet-${binary-name}";
             text = ''
               # ISSUE: for some reason it does not cleans tmp and leads to block not produced
               export RUST_BACKTRACE="full"
@@ -464,33 +466,42 @@
           };
 
           hyperspace-template = let
-            builder = {
-              }: rec {
-                bin = crane-nightly.buildPackage (common-attrs // {
-                  name = "hyperspace";
-                  pname="hyperspace";
-                  cargoArtifacts = common-deps;
-                  cargoExtraArgs= "--package hyperspace";
-                  installPhase = ''
-                    mkdir --parents $out/bin
-                    cp target/release/hyperspace $out/bin/hyperspace
-                  '';
-                  meta = { mainProgram = "hyperspace"; };
-                });
-                config = pkgs.stdenv.lib.makeOverridable
-                  (builtins.fromTOML (builtins.readFile ./config.toml));
+            builder = { }: rec {
+              bin = crane-nightly.buildPackage (common-attrs // {
+                name = "hyperspace";
+                pname = "hyperspace";
+                cargoArtifacts = common-deps;
+                cargoExtraArgs = "--package hyperspace";
+                installPhase = ''
+                  mkdir --parents $out/bin
+                  cp target/release/hyperspace $out/bin/hyperspace
+                '';
+                meta = { mainProgram = "hyperspace"; };
+              });
+              rawConfig = (builtins.fromTOML
+                (builtins.readFile ./code/centauri/hyperspace/config.toml));
 
-                default = pkgs.writeShellApplication {
-                  name = "default-hyperspace";
-                  runtimeInputs = [ pkgs.coreutils pkgs.bash ];
-                  text = ''
-                    echo ${config.result} > hyperspace.local.config.toml
-                    ${
-                      pkgs.lib.meta.getExe bin
-                    } relay --config hyperspace.local.config.toml 
-                  '';
-                };
+              config = pkgs.lib.makeOverridable (result: { result = result; })
+                rawConfig;
+
+              default-config = writeTextFile {
+                name = "hyperspace.local.config.json";
+                text = "${builtins.toJSON (config.override
+                  (self: self // { chain_a = self.chain_a; })).result}";
               };
+
+              default = pkgs.writeShellApplication {
+                name = "default-hyperspace";
+                runtimeInputs = [ pkgs.coreutils pkgs.bash ];
+                text = ''
+                  ${pkgs.yq}/bin/yq  . ${default-config} --toml-output > hyperspace.local.config.toml
+                  cat hyperspace.local.config.toml
+                  ${
+                    pkgs.lib.meta.getExe bin
+                  } relay --config hyperspace.local.config.toml
+                '';
+              };
+            };
           in builder {
             # not parametrized yet
           };
@@ -709,6 +720,15 @@
               chain-spec = "dali-dev";
             }).script;
 
+            devnet-dali-b = (callPackage mk-devnet {
+              inherit pkgs;
+              inherit (packages) polkadot-launch composable-node polkadot-node;
+              network-config-path = ./scripts/polkadot-launch/dali-dev-b.nix;
+              chain-spec = "dali-dev";
+              binary-name = "dali-b";
+              composableParaId = 2137;
+            }).script;
+
             # Dali Centauri devnet
             bridge-devnet-dali = (callPackage mk-devnet {
               inherit pkgs;
@@ -721,6 +741,8 @@
             }).script;
 
             hyperspace = hyperspace-template.bin;
+
+            hyperspace-template-default = hyperspace-template.default;
 
             # Picasso devnet
             devnet-picasso = (callPackage mk-devnet {
@@ -741,6 +763,27 @@
                 config = {
                   Entrypoint =
                     [ "${packages.devnet-dali}/bin/run-devnet-dali-dev" ];
+                  WorkingDir = "/home/polkadot-launch";
+                };
+                runAsRoot = ''
+                  mkdir -p /home/polkadot-launch /tmp
+                  chown 1000:1000 /home/polkadot-launch
+                  chmod 777 /tmp
+                '';
+              };
+
+            hyperspace-container =
+              trace "Composable Hyperspace relayer" dockerTools.buildImage {
+                name = "composable-hyperspace-container";
+                tag = "latest";
+                copyToRoot = pkgs.buildEnv {
+                  name = "image-root";
+                  paths = [ curl websocat ] ++ container-tools;
+                  pathsToLink = [ "/bin" ];
+                };
+                config = {
+                  Entrypoint =
+                    [ "${packages.devnet-dali-b}/bin/run-devnet-dali-b" ];
                   WorkingDir = "/home/polkadot-launch";
                 };
                 runAsRoot = ''
@@ -1185,6 +1228,11 @@
               inherit pkgs;
               inherit packages;
             };
+
+            bridge = import ./.nix/devnet-specs/bridge.nix {
+              inherit pkgs;
+              inherit packages;
+            };
           };
 
           apps = let
@@ -1193,6 +1241,9 @@
               devnet-specs.default;
             devnet-xcvm-program =
               pkgs.composable.mkDevnetProgram "devnet-xcvm" devnet-specs.xcvm;
+            devnet-bridge-program =
+              pkgs.composable.mkDevnetProgram "devnet-bridge"
+              devnet-specs.bridge;
           in rec {
             devnet = {
               type = "app";
@@ -1204,9 +1255,19 @@
               program = "${devnet-xcvm-program}/bin/devnet-xcvm";
             };
 
+            devnet-bridge = {
+              type = "app";
+              program = "${devnet-bridge-program}/bin/devnet-bridge";
+            };
+
             devnet-dali = {
               type = "app";
               program = "${packages.devnet-dali}/bin/run-devnet-dali-dev";
+            };
+
+            devnet-dali-b = {
+              type = "app";
+              program = "${packages.devnet-dali-b}/bin/run-devnet-dali-b";
             };
             devnet-picasso = {
               type = "app";
@@ -1256,11 +1317,10 @@
               program = "${packages.junod}/bin/junod";
             };
 
-            hyperspace =
-              trace "runs hyperspace with default local configuration" {
-                type = "app";
-                program = hyperspace-template.default;
-              };
+            hyperspace = {
+              type = "app";
+              program = pkgs.lib.meta.getExe hyperspace-template.default;
+            };
 
             # TODO: move list of chains out of here and do fold
             benchmarks-once-composable = flake-utils.lib.mkApp {

--- a/scripts/polkadot-launch/dali-dev-b.nix
+++ b/scripts/polkadot-launch/dali-dev-b.nix
@@ -1,4 +1,4 @@
-{ pkgs, polkadot-bin, composable-bin, composableParaId ? 2087 }:
+{ pkgs, polkadot-bin, composable-bin, composableParaId ? 2137 }:
 with pkgs;
 let builder = pkgs.callPackage ./network-builder.nix { };
 in {

--- a/scripts/polkadot-launch/dali-dev-b.nix
+++ b/scripts/polkadot-launch/dali-dev-b.nix
@@ -1,9 +1,3 @@
-# definition of parachain
-# TODO: replace with zombienet
-# because it allows to specify more things and tests
-# more structured and portable and officially endorsed by parity
-# so with nix it is easier to build own (nix+curl+websocket)
-
 { pkgs, polkadot-bin, composable-bin, composableParaId ? 2087 }:
 with pkgs;
 let builder = pkgs.callPackage ./network-builder.nix { };
@@ -12,8 +6,8 @@ in {
     relaychain = {
       bin = "${polkadot-bin}/bin/polkadot";
       chain = "rococo-local";
-      port = 30444;
-      wsPort = 9944;
+      port = 40444;
+      wsPort = 19944;
       count = 2;
       flags = [
         "--unsafe-ws-external"
@@ -25,8 +19,8 @@ in {
     };
     parachains = [{
       id = composableParaId;
-      port = 31200;
-      wsPort = 9988;
+      port = 41200;
+      wsPort = 19988;
       count = 3;
       chain = "dali-dev";
       bin = "${composable-bin}/bin/composable";


### PR DESCRIPTION
## Description
* isolates devnets on ports (bumped +10000) second networks ports and relays 
* makes nix to run compose with relevant images
* hyperspace not relays message for 2 reasons to fix here https://app.clickup.com/t/3p68uk0 and https://app.clickup.com/t/3p6g7gr
* added job to build some hyperspace container
**UPDATE** no nix refactoring until merge https://app.clickup.com/t/3p68umm not to wreak mess

## Checklist

- see additions in ci help about how to run. run devnet-bridge
