### PR TITLE
#xcmp fixed some dotsama simulator. added rococo

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -6407,6 +6407,7 @@ dependencies = [
  "polkadot-primitives",
  "polkadot-runtime-parachains",
  "primitives 0.1.0",
+ "rococo-runtime",
  "scale-info",
  "smallvec 1.9.0",
  "sp-api",

--- a/code/integration-tests/local-integration-tests/Cargo.toml
+++ b/code/integration-tests/local-integration-tests/Cargo.toml
@@ -109,6 +109,7 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", default-feature
 
 # added on top of runtime for emulation of network
 kusama-runtime = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
+rococo-runtime = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
 parachains-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27" }
 paste = "1.0.6"
 polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
@@ -189,6 +190,7 @@ std = [
   "sp-consensus-aura/std",
   "scale-info/std",
   "kusama-runtime/std",
+  "rococo-runtime/std",
   "polkadot-core-primitives/std",
   "polkadot-primitives/std",
   "polkadot-runtime-parachains/std",
@@ -220,6 +222,7 @@ runtime-benchmarks = [
   "democracy/runtime-benchmarks",
   "utility/runtime-benchmarks",
   "kusama-runtime/runtime-benchmarks",
+  "rococo-runtime/runtime-benchmarks",
   "dali-runtime/runtime-benchmarks",
   "picasso-runtime/runtime-benchmarks",
   "polkadot-primitives/runtime-benchmarks",

--- a/code/integration-tests/local-integration-tests/src/statemine.rs
+++ b/code/integration-tests/local-integration-tests/src/statemine.rs
@@ -4,9 +4,9 @@ pub const UNIT: Balance = 1_000_000_000_000;
 pub const TEN: Balance = 10 * UNIT;
 // NOTE: alternative to having that found via test, it could be reading directly into storage/config
 // of polkadot and statemine NOTE: or try some basic simulate tests to get only fees out of runs
-pub const APPROXIMATE_FEE_WEIGHT: Balance = 4_000_000_000;
-pub const FEE_STATEMINE: Balance = 10_666_664;
-pub const FEE_KUSAMA: Balance = 106_666_660;
+pub const FEE_WEIGHT_THIS: Balance = 4_000_000_000;
+pub const FEE_NATIVE_STATEMINE: Balance = 10_666_664;
+pub const FEE_NATIVE_KUSAMA: Balance = 106_666_660;
 
 use crate::{helpers::simtest, kusama_test_net::*, prelude::*};
 use common::{xcmp::STATEMINE_PARA_ID, Balance};
@@ -14,6 +14,7 @@ use composable_traits::{defi::Ratio, xcm::assets::XcmAssetLocation};
 use cumulus_primitives_core::ParaId;
 use frame_support::{
 	assert_ok, log,
+	sp_runtime::assert_eq_error_rate,
 	traits::{fungible::Inspect, Currency},
 };
 use orml_traits::MultiCurrency;
@@ -25,6 +26,9 @@ use xcm::{
 	VersionedMultiLocation,
 };
 use xcm_emulator::TestExt;
+
+// <= what we may think users are ok
+const ORDER_OF_FEE_ESTIMATE_ERROR: Balance = 10;
 
 #[test]
 fn transfer_native_from_relay_chain_to_statemine() {
@@ -68,13 +72,18 @@ fn this_chain_statemine_transfers_back_and_forth_work() {
 	let statemine_para_id: AccountId = ParaId::from(STATEMINE_PARA_ID).into_account_truncating();
 
 	// minimum asset should be:
-	// APPROXIMATE_FEE_WEIGHT+FEE_KUSAMA+max(KUSAMA_ED,STATEMINE_ED+FEE_STATEMINE). but due to
-	// current half fee, sender asset should at least: APPROXIMATE_FEE_WEIGHT + 2 * FEE_KUSAMA
-	let relay_native_asset_amount = 3 * APPROXIMATE_FEE_WEIGHT + 3 * FEE_KUSAMA;
+	// FEE_WEIGHT_THIS+FEE_NATIVE_KUSAMA+max(KUSAMA_ED,STATEMINE_ED+FEE_NATIVE_STATEMINE). but due
+	// to current half fee, sender asset should at least: FEE_WEIGHT_THIS + 2 * FEE_NATIVE_KUSAMA
+	let relay_native_asset_amount = 3 * FEE_WEIGHT_THIS + 3 * FEE_NATIVE_KUSAMA;
 	let remote_asset_id = 3451561; // magic number to avoid zero defaults and easy to find
 	let foreign_asset_id_on_this = register_statemine_asset(remote_asset_id);
-	let accounted_native_balance = statemine_side(TEN + relay_native_asset_amount, remote_asset_id);
+	let this_parachain_account_id: AccountId =
+		polkadot_parachain::primitives::Sibling::from(THIS_PARA_ID).into_account_truncating();
 
+	statemine_side(TEN + relay_native_asset_amount, remote_asset_id);
+	let accounted_native_balance = Statemine::execute_with(|| {
+		statemine_runtime::Balances::balance(&this_parachain_account_id)
+	});
 	let (this_reserve, statemine_reserve) = KusamaRelay::execute_with(|| {
 		let _ = kusama_runtime::Balances::make_free_balance_be(&this_para_id, TEN);
 		(
@@ -85,38 +94,44 @@ fn this_chain_statemine_transfers_back_and_forth_work() {
 
 	this_chain_side(relay_native_asset_amount, foreign_asset_id_on_this);
 
-	// // during transfer relay rebalanced amounts
-	// KusamaRelay::execute_with(|| {
-	// 	assert!(kusama_runtime::Balances::free_balance(&this_para_id) < this_reserve);
-	// 	assert!(statemine_reserve < kusama_runtime::Balances::free_balance(&statemine_para_id));
-	// });
+	// during transfer relay rebalanced amounts
+	KusamaRelay::execute_with(|| {
+		assert!(kusama_runtime::Balances::free_balance(&this_para_id) < this_reserve);
+		assert_eq!(statemine_reserve, kusama_runtime::Balances::free_balance(&statemine_para_id));
+	});
 
-	// log::info!(target : "xcmp::test", "checking that assets for Bob are back");
-	// Statemine::execute_with(|| {
-	// 	use statemine_runtime::*;
-	// 	// This send back custom asset to Statemine, ensure recipient got custom asset
-	// 	assert_eq!(UNIT, Assets::balance(remote_asset_id, &AccountId::from(BOB)));
-	// 	// and withdraw sibling parachain sovereign account
-	// 	assert_eq!(9 * UNIT, Assets::balance(remote_asset_id, &this_parachain_account));
+	log::info!(target : "xcmp::test", "checking that assets for Bob are back");
+	Statemine::execute_with(|| {
+		use statemine_runtime::*;
+		// This send back custom asset to Statemine, ensure recipient got custom asset
+		assert_eq!(UNIT, Assets::balance(remote_asset_id, &AccountId::from(BOB)));
+		// and withdraw sibling parachain sovereign account
+		assert_eq!(9 * UNIT, Assets::balance(remote_asset_id, &this_parachain_account));
 
-	// 	assert_eq!(
-	// 		1003989333336, // approx. UNIT + APPROXIMATE_FEE_WEIGHT - FEE_STATEMINE,
-	// 		Balances::free_balance(&AccountId::from(BOB))
-	// 	);
-	// 	let new_balance = Balances::free_balance(&this_parachain_account);
-	// 	assert!(accounted_native_balance <= new_balance);
-	// 	//old value 10016522666636
-	// 	assert_eq!(
-	// 		10016599690386, /* approximately this UNIT + asset_amount - APPROXIMATE_FEE_WEIGHT -
-	// 		                 * FEE_KUSAMA
-	// 		                 * - FEE_STATEMINE - APPROXIMATE_FEE_WEIGHT, */
-	// 		new_balance,
-	// 	);
-	// });
+		assert_eq_error_rate!(
+			UNIT + FEE_WEIGHT_THIS - FEE_NATIVE_STATEMINE,
+			Balances::free_balance(&AccountId::from(BOB)),
+			ORDER_OF_FEE_ESTIMATE_ERROR * FEE_NATIVE_STATEMINE,
+		);
+		let new_native_amount = Balances::balance(&this_parachain_account);
+		assert!(
+			accounted_native_balance < new_native_amount,
+			"we test only case when fee is less than total transfer"
+		);
+
+		let hops = 2;
+		assert_eq_error_rate!(
+			accounted_native_balance + relay_native_asset_amount,
+			new_native_amount,
+			hops * ORDER_OF_FEE_ESTIMATE_ERROR *
+				(FEE_NATIVE_KUSAMA + FEE_NATIVE_STATEMINE + FEE_WEIGHT_THIS),
+		);
+		assert!(new_native_amount < accounted_native_balance + relay_native_asset_amount);
+	});
 }
 
 // transfer custom asset from this chain  to Statemine
-fn this_chain_side(fee_amount: u128, foreign_asset_id_on_this: CurrencyId) {
+fn this_chain_side(relay_native_asset_amount: u128, foreign_asset_id_on_this: CurrencyId) {
 	This::execute_with(|| {
 		use this_runtime::*;
 
@@ -125,23 +140,26 @@ fn this_chain_side(fee_amount: u128, foreign_asset_id_on_this: CurrencyId) {
 		// approx. TEN - fee
 		assert!(
 			bob_statemine_asset_amount < TEN &&
-				bob_statemine_asset_amount > TEN - FEE_STATEMINE - APPROXIMATE_FEE_WEIGHT,
+				bob_statemine_asset_amount > TEN - FEE_NATIVE_STATEMINE - FEE_WEIGHT_THIS,
 			"Fee taken up to some limit {:?} < {:?} && {:?} > {:?}",
 			bob_statemine_asset_amount,
 			TEN,
 			bob_statemine_asset_amount,
-			TEN - FEE_STATEMINE - APPROXIMATE_FEE_WEIGHT
+			TEN - FEE_NATIVE_STATEMINE - FEE_WEIGHT_THIS
 		);
 		// ensure sender has enough KSM balance to be charged as fee
 		assert_ok!(Tokens::deposit(CurrencyId::RELAY_NATIVE, &AccountId::from(BOB), TEN));
-		assert!(fee_amount != 0);
+		assert!(relay_native_asset_amount != 0);
 		log::info!(target: "xcmp::test", "sending assets back to statemine");
 		assert_ok!(XTokens::transfer_multicurrencies(
 			Origin::signed(BOB.into()),
 			// statemine sends and receives only its ids from u32 range, which is our foreign
 			// range,
-			vec![(foreign_asset_id_on_this, UNIT), (CurrencyId::RELAY_NATIVE, fee_amount)],
-			1,
+			vec![
+				(CurrencyId::RELAY_NATIVE, relay_native_asset_amount),
+				(foreign_asset_id_on_this, UNIT),
+			],
+			0,
 			Box::new(
 				MultiLocation::new(
 					1,
@@ -152,7 +170,7 @@ fn this_chain_side(fee_amount: u128, foreign_asset_id_on_this: CurrencyId) {
 				)
 				.into()
 			),
-			4 * APPROXIMATE_FEE_WEIGHT as u64
+			4 * FEE_WEIGHT_THIS as u64
 		));
 
 		assert_eq!(
@@ -160,7 +178,7 @@ fn this_chain_side(fee_amount: u128, foreign_asset_id_on_this: CurrencyId) {
 			Tokens::free_balance(foreign_asset_id_on_this, &AccountId::from(BOB))
 		);
 		assert_eq!(
-			TEN - fee_amount,
+			TEN - relay_native_asset_amount,
 			Tokens::free_balance(CurrencyId::RELAY_NATIVE, &AccountId::from(BOB))
 		);
 	});
@@ -176,11 +194,8 @@ fn statemine_setup_assets(
 	this_parachain_account_init_amount: Balance,
 ) -> () {
 	use statemine_runtime::*;
-	let target_parachain: AccountId =
-		polkadot_parachain::primitives::Sibling::from(THIS_PARA_ID).into_account_truncating();
 	Statemine::execute_with(|| {
 		let origin = Origin::signed(ALICE.into());
-		let alice_before = Balances::free_balance(&ALICE.into());
 		Balances::make_free_balance_be(&ALICE.into(), native_for_alice);
 		Balances::make_free_balance_be(&BOB.into(), native_for_bob);
 
@@ -192,11 +207,7 @@ fn statemine_setup_assets(
 			other_ed,
 		));
 
-		assert_eq!(
-			native_for_alice,
-			Balances::free_balance(&AccountId::from(ALICE)) +
-				Balances::reserved_balance(&AccountId::from(ALICE))
-		);
+		assert_eq!(native_for_alice, Balances::balance(&AccountId::from(ALICE)),);
 
 		assert_ok!(Assets::mint(
 			origin.clone(),
@@ -211,10 +222,7 @@ fn statemine_setup_assets(
 }
 
 // transfer custom asset from Statemine to This
-fn statemine_side(
-	this_parachain_account_init_amount: u128,
-	statemine_asset_id: CommonAssetId,
-) -> Balance {
+fn statemine_side(this_parachain_account_init_amount: u128, statemine_asset_id: CommonAssetId) {
 	use statemine_runtime::*;
 	let target_parachain: AccountId =
 		polkadot_parachain::primitives::Sibling::from(THIS_PARA_ID).into_account_truncating();
@@ -255,9 +263,6 @@ fn statemine_side(
 		// transferred NOT KSM
 		assert_eq!(this_parachain_account_init_amount, Balances::free_balance(&target_parachain));
 	});
-
-	// Rerun the Statemine::execute to actually send the egress message via XCM
-	Statemine::execute_with(|| Balances::balance(&target_parachain))
 }
 
 fn register_statemine_asset(remote_asset_id: CommonAssetId) -> CurrencyId {

--- a/code/parachain/frame/ibc/src/lib.rs
+++ b/code/parachain/frame/ibc/src/lib.rs
@@ -7,7 +7,6 @@
 	clippy::useless_conversion,
 	bad_style,
 	bare_trait_objects,
-	const_err,
 	improper_ctypes,
 	non_shorthand_field_patterns,
 	no_mangle_generic_items,

--- a/code/parachain/runtime/common/src/xcmp/mod.rs
+++ b/code/parachain/runtime/common/src/xcmp/mod.rs
@@ -27,6 +27,7 @@ use xcm_executor::{
 parameter_types! {
 	// similar to what Acala/Hydra has
 	pub const BaseXcmWeight: Weight = 100_000_000;
+	pub const XcmMaxAssetsForTransfer: usize = 2;
 }
 
 /// this is debug struct implementing as many XCMP interfaces as possible

--- a/code/parachain/runtime/dali/src/xcmp.rs
+++ b/code/parachain/runtime/dali/src/xcmp.rs
@@ -226,9 +226,6 @@ impl xcm_executor::Config for XcmConfig {
 
 parameter_types! {
 	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
-	/// set same is in Acala, sending more will require more weight for message, like:
-	/// weigh >= xtokens::WeightInfo::receive() * count
-	pub const MaxAssetsForTransfer: usize = 2;
 }
 
 parameter_type_with_key! {
@@ -261,7 +258,7 @@ impl orml_xtokens::Config for Runtime {
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type BaseXcmWeight = BaseXcmWeight;
 	type LocationInverter = LocationInverter<Ancestry>;
-	type MaxAssetsForTransfer = MaxAssetsForTransfer;
+	type MaxAssetsForTransfer = XcmMaxAssetsForTransfer;
 	type MinXcmFee = ParachainMinFee;
 	type MultiLocationsFilter = Everything;
 	type ReserveProvider = AbsoluteReserveProvider;

--- a/code/parachain/runtime/picasso/src/xcmp.rs
+++ b/code/parachain/runtime/picasso/src/xcmp.rs
@@ -245,8 +245,6 @@ impl xcm_executor::Config for XcmConfig {
 
 parameter_types! {
 	pub SelfLocation: MultiLocation = MultiLocation::new(1, X1(Parachain(ParachainInfo::parachain_id().into())));
-	// safe value to start to transfer 1 asset only in one message (as in Acala)
-	pub const MaxAssetsForTransfer: usize = 1;
 }
 
 parameter_type_with_key! {
@@ -279,7 +277,7 @@ impl orml_xtokens::Config for Runtime {
 	type Weigher = FixedWeightBounds<UnitWeightCost, Call, MaxInstructions>;
 	type BaseXcmWeight = BaseXcmWeight;
 	type LocationInverter = LocationInverter<Ancestry>;
-	type MaxAssetsForTransfer = MaxAssetsForTransfer;
+	type MaxAssetsForTransfer = XcmMaxAssetsForTransfer;
 	type MinXcmFee = ParachainMinFee;
 	type MultiLocationsFilter = Everything;
 	type ReserveProvider = AbsoluteReserveProvider;

--- a/code/run-local-integration-tests-debug.sh
+++ b/code/run-local-integration-tests-debug.sh
@@ -2,4 +2,4 @@
 RUST_BACKTRACE=full \
 SKIP_WASM_BUILD=1 \
 RUST_LOG=trace,parity-db=warn,trie=warn,runtime=trace,substrate-relay=trace,bridge=trace,xcmp=trace,xcm=trace \
-cargo +nightly test sibling_trap_assets_works --package local-integration-tests --features=local-integration-tests,picasso --no-default-features -- --nocapture --test-threads=1
+cargo +nightly test $@ --package local-integration-tests --features=local-integration-tests,picasso --no-default-features -- --nocapture --test-threads=1

--- a/code/utils/xcmp/awesome-xcmp.md
+++ b/code/utils/xcmp/awesome-xcmp.md
@@ -2,7 +2,7 @@
 
 Resources which allows to grasp  XCM. General understanding how bridges work will help too.
 
-## Terminology
+## Basics
 
 XCM - Cross Chain Message.
 
@@ -10,11 +10,13 @@ XCMP - XCM passing.
 
 XCMP can be upward (parachain to relay), downward(relay to parachain) and sibling(lateral, parachain to parachain).
 
+[Moonbeam: Cross-Consensus Messaging (XCM)](https://docs.moonbeam.network/builders/xcm/overview/)
+
 ## Conceptual
 
-<https://www.youtube.com/watch?v=XU6dAAQD9UE> - trust and XCMP
+[Polkadot's Cross-chain Message Passing Protocol: Shared Security and Polkadot's Design](https://www.youtube.com/watch?v=XU6dAAQD9UE)
 
-<https://docs.moonbeam.network/builders/xcm/overview/>
+[How XCM will actually be used with XCMP](https://forum.polkadot.network/t/how-xcm-will-actually-be-used-with-xcmp/190)
 
 ## How to setup XCMP
 


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue
* we do not test rococo in simulator, but it hast bugs different from kusama https://substrate.stackexchange.com/questions/5393/is-teleport-of-roc-from-rockmine-to-my-parachain-should-be-used-instead-of-reser
* some tests were broken after some runtime upgrades, fixed these
* some tests failed after fee changed

## Description
* fixed and unified multiasset limit config (each asset increase weigth which not yet calculated until v3)
* fixed weird Balances issue is that free balance minting is not equal free balance after (ED balance is not free)
* added rococo just to be built as deps for now by cachix (it takes 10 mintues to run any test - so prefer nix will cache it :) )
* started more resonable bounding test strategy for fees
* while waiting for rustc added some XCMP links :) 

