### PR TITLE
Fixed nix docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ To learn more about our ecosystem, vision, and product specifics - visit our [bo
 
 ## Nix
 
-We use [`nix`](https://nixos.org/) in order to reproducibly build all of our packages. [Check out our Nix docs here in order to build our packages](https://docs.composable.finance/nix).
+We use [`nix`](https://nixos.org/) in order to reproducibly build all of our packages. [Check out our Nix docs here in order to build our packages](https://docs.composable.finance/nix.html).


### PR DESCRIPTION
## Issue
N/A

## Description
The link to our Nix docs in our readme does not work. This fixes it.