### PR TITLE
hyperspace-parachain: trigger subxt_codegen conditionally

### DIFF
--- a/code/centauri/hyperspace/parachain/build.rs
+++ b/code/centauri/hyperspace/parachain/build.rs
@@ -13,9 +13,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::env;
+
 #[tokio::main]
 async fn main() -> color_eyre::Result<()> {
-	subxt_codegen::build_script("ws://127.0.0.1:9944", "polkadot").await?;
-	subxt_codegen::build_script("ws://127.0.0.1:9188", "parachain").await?;
+	// only trigger the subxt code generation in case it's requested
+	// through an environment variable.
+	if env::var("SUBXT_CODEGEN").is_ok() {
+		subxt_codegen::build_script("ws://127.0.0.1:9944", "polkadot").await?;
+		subxt_codegen::build_script("ws://127.0.0.1:9188", "parachain").await?;
+	}
 	Ok(())
 }


### PR DESCRIPTION
Only trigger the subxt code generation in case it's requested through an environment variable (SUBXT_CODEGEN).

Tried getting rid of the build.rs file directly here: https://github.com/ComposableFi/composable/pull/2060

However, David pointed out that because `hyperspace`, `hyperspace-parachain` and the `parachain` all are
different binaries their `OUT_DIR` will differ. We want to ensure that the generated code isn't removed between steps.

By doing this _hack_, we are able to generate the code only when we need to (running the integration-tests for instance). But this isn't needed
when compiling or checking the entire project for other reasons (running unit tests for example).