### PR TITLE
adds cli for generating runtime metadata

### DIFF
--- a/code/centauri/hyperspace/parachain/src/lib.rs
+++ b/code/centauri/hyperspace/parachain/src/lib.rs
@@ -84,7 +84,7 @@ pub struct ParachainClient<T: subxt::Config> {
 	pub client_id: Option<ClientId>,
 	/// Connection Id
 	pub connection_id: Option<ConnectionId>,
-	/// Commitment prefix
+	/// ICS-23 provable store commitment prefix
 	pub commitment_prefix: Vec<u8>,
 	/// Public key for relayer on chain
 	pub public_key: MultiSigner,
@@ -98,7 +98,7 @@ pub struct ParachainClient<T: subxt::Config> {
 	pub max_extrinsic_weight: u64,
 	/// Channels cleared for packet relay
 	pub channel_whitelist: Vec<(ChannelId, PortId)>,
-	/// Finality protocol
+	/// Finality protocol to use, eg Beefy, Grandpa
 	pub finality_protocol: FinalityProtocol,
 }
 

--- a/code/parachain/node/src/cli.rs
+++ b/code/parachain/node/src/cli.rs
@@ -2,6 +2,8 @@ use crate::chain_spec;
 use clap::Parser;
 use std::path::PathBuf;
 
+mod metadata;
+
 /// Sub-commands supported by the collator.
 #[derive(Debug, Parser)]
 pub enum Subcommand {
@@ -31,6 +33,9 @@ pub enum Subcommand {
 
 	/// Revert the chain to a previous state.
 	Revert(sc_cli::RevertCmd),
+
+	/// Writes the specified runtime's metadata to stdout.
+	Metadata(metadata::MetadataCmd),
 
 	/// Key management cli utilities
 	#[clap(subcommand)]

--- a/code/parachain/node/src/cli/metadata.rs
+++ b/code/parachain/node/src/cli/metadata.rs
@@ -1,0 +1,47 @@
+use clap::Parser;
+use sc_cli::{CliConfiguration, ImportParams, SharedParams, Error};
+use sp_api::{Metadata, ProvideRuntimeApi};
+use sp_blockchain::HeaderBackend;
+use sp_runtime::generic::BlockId;
+use std::{fmt::Debug, io, io::Write, sync::Arc};
+
+/// Command for exporting the metadata for a runtime.
+#[derive(Debug, Parser)]
+pub struct MetadataCmd {
+	#[allow(missing_docs)]
+	#[clap(flatten)]
+	pub shared_params: SharedParams,
+
+	#[allow(missing_docs)]
+	#[clap(flatten)]
+	pub import_params: ImportParams,
+}
+
+impl MetadataCmd {
+	pub fn run<B, C>(&self, client: Arc<C>) -> Result<(), Error>
+	where
+		B: sp_runtime::traits::Block,
+		C: ProvideRuntimeApi<B> + HeaderBackend<B> + Send + Sync + 'static,
+		C::Api: Metadata<B>,
+	{
+		let info = client.info();
+		let metadata = client
+			.runtime_api()
+			.metadata(&BlockId::Hash(info.best_hash))
+			.map_err(|err| Error::Application(Box::new(err)))?;
+
+		io::stdout().write_all(&metadata)?;
+
+		Ok(())
+	}
+}
+
+impl CliConfiguration for MetadataCmd {
+	fn shared_params(&self) -> &SharedParams {
+		&self.shared_params
+	}
+
+	fn import_params(&self) -> Option<&ImportParams> {
+		Some(&self.import_params)
+	}
+}

--- a/code/parachain/node/src/command.rs
+++ b/code/parachain/node/src/command.rs
@@ -224,6 +224,34 @@ pub fn run() -> Result<()> {
 				cmd.run(&*spec)
 			})
 		},
+		Some(Subcommand::Metadata(cmd)) => {
+			let runner = cli.create_runner(cmd)?;
+			runner.sync_run(|config| {
+				match config.chain_spec.id() {
+					id if id.contains("picasso") => {
+						let partials =
+							new_partial::<picasso_runtime::RuntimeApi, PicassoExecutor>(&config)?;
+						cmd.run(partials.client)?;
+					},
+					#[cfg(feature = "dali")]
+					id if id.contains("dali") => {
+						let partials =
+							new_partial::<dali_runtime::RuntimeApi, DaliExecutor>(&config)?;
+						cmd.run(partials.client)?;
+					},
+					#[cfg(feature = "composable")]
+					id if id.contains("composable") => {
+						let partials = new_partial::<
+							composable_runtime::RuntimeApi,
+							ComposableExecutor,
+						>(&config)?;
+						cmd.run(partials.client)?;
+					},
+					id => panic!("Unknown Chain: {}", id),
+				};
+				Ok(())
+			})
+		},
 		Some(Subcommand::Benchmark(cmd)) => {
 			let runner = cli.create_runner(cmd)?;
 


### PR DESCRIPTION
Use it like so: 

```bash
 ./code/target/release/composable metadata --chain=dali-dev > ./dali.metadata
 subxt codegen --file=dali.metadata | rustfmt --edition=2018 --emit=stdout > dali.rs
```