### PR TITLE
feat: make `nix develop` about 100x faster

### DIFF
--- a/code/integration-tests/local-integration-tests/Cargo.toml
+++ b/code/integration-tests/local-integration-tests/Cargo.toml
@@ -109,12 +109,12 @@ xcm-executor = { git = "https://github.com/paritytech/polkadot", default-feature
 
 # added on top of runtime for emulation of network
 kusama-runtime = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
-rococo-runtime = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
 parachains-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27" }
 paste = "1.0.6"
 polkadot-core-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
 polkadot-runtime-parachains = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
+rococo-runtime = { git = "https://github.com/paritytech/polkadot", default-features = false, branch = "release-v0.9.27" }
 statemine-runtime = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.27" }
 xcm-emulator = { git = "https://github.com/shaunxw/xcm-simulator", rev = "ab5cd6c5fabe6ddda52ed6803ee1bf54c258fefe", default-features = false }
 

--- a/code/parachain/frame/composable-maths/Cargo.toml
+++ b/code/parachain/frame/composable-maths/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.0.1"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dev-dependencies]
-proptest = "1.0"
 composable-tests-helpers = { path = "../composable-tests-helpers" }
+proptest = "1.0"
 
 [dependencies]
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }

--- a/code/xcvm/cosmwasm/contracts/asset-registry/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/asset-registry/Cargo.toml
@@ -20,8 +20,8 @@ library = []
 [dependencies]
 cosmwasm-std = "1.0.0"
 cw-storage-plus = "0.14.0"
-cw2 = "0.14.0"
 cw-utils = "0.14.0"
+cw2 = "0.14.0"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }
 thiserror = { version = "1.0.31" }

--- a/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
@@ -23,9 +23,9 @@ library = []
 [dependencies]
 cosmwasm-std = { version = "1.0.0" }
 cw-storage-plus = "0.13.2"
-cw20 = "0.14.0"
-cw2 = "0.14.0"
 cw-utils = "0.14.0"
+cw2 = "0.14.0"
+cw20 = "0.14.0"
 num = "0.4"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }

--- a/code/xcvm/cosmwasm/contracts/router/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/router/Cargo.toml
@@ -20,9 +20,9 @@ library = []
 [dependencies]
 cosmwasm-std = "1.0.0"
 cw-storage-plus = "0.14.0"
-cw20 = "0.14.0"
-cw2 = "0.14.0"
 cw-utils = "0.14.0"
+cw2 = "0.14.0"
+cw20 = "0.14.0"
 hex = "0.4"
 schemars = "0.8.8"
 serde = { version = "1.0.137", default-features = false, features = ["derive"] }

--- a/flake.nix
+++ b/flake.nix
@@ -1284,37 +1284,36 @@
 
             developers = developers-minimal.overrideAttrs (base: {
               buildInputs = base.buildInputs ++ [
-                  pkgs.bacon
-                  pkgs.google-cloud-sdk
-                  pkgs.grub2
-                  pkgs.jq
-                  pkgs.lldb
-                  pkgs.llvmPackages_latest.bintools
-                  pkgs.llvmPackages_latest.lld
-                  pkgs.llvmPackages_latest.llvm
-                  pkgs.nix-tree
-                  pkgs.nixpkgs-fmt
-                  pkgs.openssl
-                  pkgs.openssl.dev
-                  pkgs.pkg-config
-                  pkgs.qemu
-                  pkgs.rnix-lsp
-                  pkgs.taplo
-                  pkgs.xorriso
-                  pkgs.zlib.out
-                  pkgs.nix-tree
-                  pkgs.nixfmt
-                  pkgs.rnix-lsp
-                  pkgs.nodePackages.typescript
-                  pkgs.nodePackages.typescript-language-server
-                  packages.subxt
-                ] ++ docs-renders;
+                pkgs.bacon
+                pkgs.google-cloud-sdk
+                pkgs.grub2
+                pkgs.jq
+                pkgs.lldb
+                pkgs.llvmPackages_latest.bintools
+                pkgs.llvmPackages_latest.lld
+                pkgs.llvmPackages_latest.llvm
+                pkgs.nix-tree
+                pkgs.nixpkgs-fmt
+                pkgs.openssl
+                pkgs.openssl.dev
+                pkgs.pkg-config
+                pkgs.qemu
+                pkgs.rnix-lsp
+                pkgs.taplo
+                pkgs.xorriso
+                pkgs.zlib.out
+                pkgs.nix-tree
+                pkgs.nixfmt
+                pkgs.rnix-lsp
+                pkgs.nodePackages.typescript
+                pkgs.nodePackages.typescript-language-server
+                packages.subxt
+              ] ++ docs-renders;
             });
-            
+
             developers-with-wasm-optimizer = developers.overrideAttrs (base: {
               buildInputs = base.buildInputs ++ [ packages.wasm-optimizer ];
             });
-            
 
             developers-xcvm = developers.overrideAttrs (base: {
               buildInputs = with packages;

--- a/flake.nix
+++ b/flake.nix
@@ -1283,8 +1283,7 @@
               });
 
             developers = developers-minimal.overrideAttrs (base: {
-              buildInputs = with packages;
-                base.buildInputs ++ [
+              buildInputs = base.buildInputs ++ [
                   pkgs.bacon
                   pkgs.google-cloud-sdk
                   pkgs.grub2
@@ -1306,13 +1305,16 @@
                   pkgs.nix-tree
                   pkgs.nixfmt
                   pkgs.rnix-lsp
-                  pkgs.subxt
                   pkgs.nodePackages.typescript
                   pkgs.nodePackages.typescript-language-server
-                  packages.rust-nightly
-                  packages.wasm-optimizer
+                  packages.subxt
                 ] ++ docs-renders;
             });
+            
+            developers-with-wasm-optimizer = developers.overrideAttrs (base: {
+              buildInputs = base.buildInputs ++ [ packages.wasm-optimizer ];
+            });
+            
 
             developers-xcvm = developers.overrideAttrs (base: {
               buildInputs = with packages;


### PR DESCRIPTION
## Description
Running `nix develop` was painfully slow before, because it rebuilt composable-deps almost every time. This was because of our inclusion of the `wasm-optimizer` package.

It is no longer part of the default `devShell`, instead it can be accessed through `nix develop ".#developers-with-wasm-optimizer"`