### PR TITLE
add Rational64 type (#31gy38v)

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -6100,6 +6100,7 @@ version = "0.1.0"
 dependencies = [
  "base58",
  "common",
+ "composable-support",
  "composable-tests-helpers",
  "composable-traits",
  "cumulus-pallet-aura-ext",
@@ -7295,6 +7296,7 @@ dependencies = [
 name = "pallet-assets-registry"
 version = "0.1.0"
 dependencies = [
+ "composable-support",
  "composable-traits",
  "cumulus-primitives-core",
  "frame-benchmarking",

--- a/code/integration-tests/local-integration-tests/Cargo.toml
+++ b/code/integration-tests/local-integration-tests/Cargo.toml
@@ -63,6 +63,7 @@ assets = { package = "pallet-assets", path = "../../parachain/frame/assets", def
 assets-registry = { package = "pallet-assets-registry", path = "../../parachain/frame/assets-registry", default-features = false, optional = true }
 call-filter = { package = "pallet-call-filter", path = "../../parachain/frame/call-filter", default-features = false }
 common = { path = "../../parachain/runtime/common", default-features = false }
+composable-support = { path = "../../parachain/frame/composable-support", default-features = false }
 composable-tests-helpers = { path = "../../parachain/frame/composable-tests-helpers", default-features = false }
 composable-traits = { path = "../../parachain/frame/composable-traits", default-features = false }
 currency-factory = { package = "pallet-currency-factory", path = "../../parachain/frame/currency-factory", default-features = false }

--- a/code/integration-tests/local-integration-tests/src/assets_integration.rs
+++ b/code/integration-tests/local-integration-tests/src/assets_integration.rs
@@ -1,5 +1,6 @@
 ///! tests that various assets integration scenarios work well
 use crate::{helpers::*, kusama_test_net::This, prelude::*};
+use composable_support::rational_64;
 use composable_traits::xcm::assets::XcmAssetLocation;
 
 use frame_system::RawOrigin;
@@ -15,7 +16,7 @@ fn updated_assets_registry_works_well_for_ratios() {
 			RawOrigin::Root.into(),
 			CurrencyId(42),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
-			Some(Rational64::from(10, 1)),
+			Some(rational_64!(10 / 1)),
 			None,
 		)
 		.unwrap();
@@ -23,7 +24,7 @@ fn updated_assets_registry_works_well_for_ratios() {
 			RawOrigin::Root.into(),
 			CurrencyId(123),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(4321)))),
-			Some(Rational64::from(10, 100)),
+			Some(rational_64!(10 / 100)),
 			None,
 		)
 		.unwrap();
@@ -47,7 +48,7 @@ fn registered_assets_with_smaller_than_native_price() {
 			RawOrigin::Root.into(),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
 			42,
-			Some(Rational64::from(10, 1)),
+			Some(rational_64!(10 / 1)),
 			None,
 		)
 		.unwrap();
@@ -78,7 +79,7 @@ fn registered_assets_with_larger_than_native_price() {
 			RawOrigin::Root.into(),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
 			42,
-			Some(Rational64::from(10, 100)),
+			Some(rational_64!(10 / 100)),
 			None,
 		)
 		.unwrap();

--- a/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
+++ b/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
@@ -1,4 +1,9 @@
-// //! Tests parachain to parachain xcm communication between Statemine and This.
+#![allow(
+	clippy::unwrap_used,
+	clippy::disallowed_methods // temporarily so clippy doesn't lose it's mind
+)]
+
+//! Tests parachain to parachain xcm communication between Statemine and This.
 
 pub const UNIT: Balance = 1_000_000_000_000;
 pub const TEN: Balance = 10 * UNIT;
@@ -10,7 +15,8 @@ pub const FEE_NATIVE_KUSAMA: Balance = 106_666_660;
 
 use crate::{assert_lt_by, helpers::simtest, kusama_test_net::*, prelude::*};
 use common::Balance;
-use composable_traits::{currency::Rational64, xcm::assets::XcmAssetLocation};
+use composable_support::{rational_64, types::rational::Rational64};
+use composable_traits::xcm::assets::XcmAssetLocation;
 use cumulus_primitives_core::ParaId;
 use frame_support::{
 	assert_ok, log,
@@ -76,11 +82,11 @@ fn transfer_native_from_statemine_to_this() {
 		let origin = Origin::signed(BOB.into());
 
 		assert_ok!(PolkadotXcm::reserve_transfer_assets(
-			origin.clone(),
-			Box::new(
-				VersionedMultiLocation::V1(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))))
-					.into()
-			),
+			origin,
+			Box::new(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X1(Parachain(THIS_PARA_ID))
+			))),
 			Box::new(Junction::AccountId32 { id: BOB, network: NetworkId::Any }.into().into()),
 			Box::new((MultiLocation::new(1, Here), bob_balance).into()),
 			0,
@@ -111,7 +117,7 @@ fn transfer_usdt_from_statemine_to_this() {
 		let root = frame_system::RawOrigin::Root;
 
 		Assets::force_create(
-			root.clone().into(),
+			root.into(),
 			statemine_asset_id as u32,
 			MultiAddress::Id(ALICE.into()),
 			true,
@@ -133,11 +139,11 @@ fn transfer_usdt_from_statemine_to_this() {
 		use statemine_runtime::*;
 		let origin = Origin::signed(BOB.into());
 		assert_ok!(PolkadotXcm::limited_reserve_transfer_assets(
-			origin.clone(),
-			Box::new(
-				VersionedMultiLocation::V1(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))))
-					.into()
-			),
+			origin,
+			Box::new(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X1(Parachain(THIS_PARA_ID))
+			))),
 			Box::new(Junction::AccountId32 { id: BOB, network: NetworkId::Any }.into().into()),
 			Box::new(
 				(X2(PalletInstance(50), GeneralIndex(statemine_asset_id)), usdt_transfer_amount)
@@ -179,7 +185,7 @@ fn rockmine_shib_to_dali_transfer() {
 		let root = frame_system::RawOrigin::Root;
 
 		Assets::force_create(
-			root.clone().into(),
+			root.into(),
 			statemine_asset_id,
 			MultiAddress::Id(ALICE.into()),
 			true,
@@ -200,22 +206,19 @@ fn rockmine_shib_to_dali_transfer() {
 		log::info!(target: "bdd", "	and USDT on Dali registered");
 		use this_runtime::*;
 		let root = frame_system::RawOrigin::Root;
-		let location = XcmAssetLocation::new(
-			MultiLocation::new(
-				1,
-				X3(
-					Parachain(topology::common_good_assets::ID),
-					PalletInstance(50),
-					GeneralIndex(statemine_asset_id as u128),
-				),
-			)
-			.into(),
-		);
+		let location = XcmAssetLocation::new(MultiLocation::new(
+			1,
+			X3(
+				Parachain(topology::common_good_assets::ID),
+				PalletInstance(50),
+				GeneralIndex(statemine_asset_id as u128),
+			),
+		));
 		AssetsRegistry::register_asset(
 			root.into(),
-			location.clone(),
+			location,
 			1000,
-			Some(Rational64::from(15, 1000)),
+			Some(rational_64!(15 / 1000)),
 			Some(4),
 		)
 		.unwrap();
@@ -238,11 +241,11 @@ fn rockmine_shib_to_dali_transfer() {
 		use statemine_runtime::*;
 		let origin = Origin::signed(BOB.into());
 		assert_ok!(PolkadotXcm::limited_reserve_transfer_assets(
-			origin.clone(),
-			Box::new(
-				VersionedMultiLocation::V1(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))))
-					.into()
-			),
+			origin,
+			Box::new(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X1(Parachain(THIS_PARA_ID))
+			))),
 			Box::new(Junction::AccountId32 { id: BOB, network: NetworkId::Any }.into().into()),
 			Box::new(
 				(X2(PalletInstance(50), GeneralIndex(statemine_asset_id as u128)), transfer_amount)
@@ -283,7 +286,7 @@ fn rockmine_stable_to_dali_transfer() {
 		let root = frame_system::RawOrigin::Root;
 
 		Assets::force_create(
-			root.clone().into(),
+			root.into(),
 			statemine_asset_id,
 			MultiAddress::Id(ALICE.into()),
 			true,
@@ -304,22 +307,24 @@ fn rockmine_stable_to_dali_transfer() {
 		log::info!(target: "bdd", "	and STABLE on Dali registered");
 		use this_runtime::*;
 		let root = frame_system::RawOrigin::Root;
-		let location = XcmAssetLocation::new(
-			MultiLocation::new(
-				1,
-				X3(
-					Parachain(topology::common_good_assets::ID),
-					PalletInstance(50),
-					GeneralIndex(STABLE::ID),
-				),
-			)
-			.into(),
-		);
-		let ratio = Rational64::from(STABLE::ONE as u64 * 15, 1000 * PICA::ONE as u64);
+		let location = XcmAssetLocation::new(MultiLocation::new(
+			1,
+			X3(
+				Parachain(topology::common_good_assets::ID),
+				PalletInstance(50),
+				GeneralIndex(STABLE::ID),
+			),
+		));
+
+		let ratio = Rational64::new(
+			STABLE::units(15).try_into().expect("should be less than u64::MAX"),
+			PICA::units(1000).try_into().expect("should be less than u64::MAX"),
+		)
+		.expect("denominator is non-zero; qed;");
 
 		AssetsRegistry::register_asset(
 			root.into(),
-			location.clone(),
+			location,
 			1,
 			Some(ratio),
 			Some(STABLE::EXPONENT),
@@ -343,11 +348,11 @@ fn rockmine_stable_to_dali_transfer() {
 		use statemine_runtime::*;
 		let origin = Origin::signed(BOB.into());
 		assert_ok!(PolkadotXcm::limited_reserve_transfer_assets(
-			origin.clone(),
-			Box::new(
-				VersionedMultiLocation::V1(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))))
-					.into()
-			),
+			origin,
+			Box::new(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X1(Parachain(THIS_PARA_ID))
+			))),
 			Box::new(Junction::AccountId32 { id: BOB, network: NetworkId::Any }.into().into()),
 			Box::new(
 				(X2(PalletInstance(50), GeneralIndex(statemine_asset_id as u128)), transfer_amount)
@@ -384,7 +389,7 @@ fn this_chain_statemine_transfers_back_and_forth_work() {
 	let relay_native_asset_amount = 3 * FEE_WEIGHT_THIS + 3 * FEE_NATIVE_KUSAMA;
 	let remote_asset_id = 3451561; // magic number to avoid zero defaults and easy to find
 	let foreign_asset_id_on_this =
-		register_statemine_asset(remote_asset_id, Some(Rational64::from(10, 100)));
+		register_statemine_asset(remote_asset_id, Some(rational_64!(10 / 100)));
 
 	statemine_side(TEN + relay_native_asset_amount, remote_asset_id);
 	let statemine_native_this_balance_1 =
@@ -470,7 +475,7 @@ fn this_chain_side(relay_native_asset_amount: u128, foreign_asset_id_on_this: Cu
 					1,
 					X2(
 						Parachain(topology::common_good_assets::ID),
-						Junction::AccountId32 { network: NetworkId::Any, id: BOB.into() }
+						Junction::AccountId32 { network: NetworkId::Any, id: BOB }
 					)
 				)
 				.into()
@@ -497,7 +502,7 @@ fn statemine_setup_assets(
 	other_total: Balance,
 	foreign_chain_account: AccountId,
 	this_parachain_account_init_amount: Balance,
-) -> () {
+) {
 	use statemine_runtime::*;
 	Statemine::execute_with(|| {
 		let origin = Origin::signed(ALICE.into());
@@ -515,7 +520,7 @@ fn statemine_setup_assets(
 		assert_eq!(native_for_alice, Balances::balance(&AccountId::from(ALICE)),);
 
 		assert_ok!(Assets::mint(
-			origin.clone(),
+			origin,
 			statemine_asset_id,
 			MultiAddress::Id(ALICE.into()),
 			other_total
@@ -546,11 +551,11 @@ fn statemine_side(this_parachain_account_init_amount: u128, statemine_asset_id: 
 		let origin = Origin::signed(ALICE.into());
 
 		assert_ok!(PolkadotXcm::reserve_transfer_assets(
-			origin.clone(),
-			Box::new(
-				VersionedMultiLocation::V1(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))))
-					.into()
-			),
+			origin,
+			Box::new(VersionedMultiLocation::V1(MultiLocation::new(
+				1,
+				X1(Parachain(THIS_PARA_ID))
+			))),
 			Box::new(Junction::AccountId32 { id: BOB, network: NetworkId::Any }.into().into()),
 			Box::new(
 				(X2(PalletInstance(50), GeneralIndex(statemine_asset_id as u128)), TEN).into()
@@ -576,28 +581,26 @@ fn register_statemine_asset(
 ) -> CurrencyId {
 	This::execute_with(|| {
 		use this_runtime::*;
-		let location = XcmAssetLocation::new(
-			MultiLocation::new(
-				1,
-				X3(
-					Parachain(topology::common_good_assets::ID),
-					PalletInstance(50),
-					GeneralIndex(remote_asset_id as u128),
-				),
-			)
-			.into(),
-		);
+		let location = XcmAssetLocation::new(MultiLocation::new(
+			1,
+			X3(
+				Parachain(topology::common_good_assets::ID),
+				PalletInstance(50),
+				GeneralIndex(remote_asset_id as u128),
+			),
+		));
 		AssetsRegistry::register_asset(
 			frame_system::RawOrigin::Root.into(),
-			location.clone(),
+			location,
 			42,
 			ratio,
 			None,
 		)
 		.unwrap();
-		let location = XcmAssetLocation::new(
-			MultiLocation::new(1, X1(Parachain(topology::common_good_assets::ID))).into(),
-		);
+		let location = XcmAssetLocation::new(MultiLocation::new(
+			1,
+			X1(Parachain(topology::common_good_assets::ID)),
+		));
 		AssetsRegistry::set_min_fee(
 			frame_system::RawOrigin::Root.into(),
 			ParaId::from(topology::common_good_assets::ID),

--- a/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
+++ b/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
@@ -316,7 +316,7 @@ fn rockmine_stable_to_dali_transfer() {
 			),
 		));
 
-		let ratio = Rational64::new(
+		let ratio = Rational64::try_new(
 			STABLE::units(15).try_into().expect("should be less than u64::MAX"),
 			PICA::units(1000).try_into().expect("should be less than u64::MAX"),
 		)

--- a/code/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
+++ b/code/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
@@ -1,19 +1,14 @@
-use crate::{
-	assert_lt_by,
-	helpers::*,
-	kusama_test_net::{KusamaRelay, Sibling, This, PICA, SIBLING_PARA_ID, THIS_PARA_ID},
-	prelude::*,
-};
 use codec::Encode;
 use common::{AccountId, Balance};
-use composable_traits::{currency::RangeId, rational};
-
+use composable_support::rational_64;
+use composable_traits::currency::RangeId;
+use frame_support::{
+	assert_ok, log, traits::fungibles::Inspect as MultiInspect,
+	weights::constants::WEIGHT_PER_MILLIS,
+};
 use frame_system::RawOrigin;
-
 use num_traits::Zero;
 use orml_traits::currency::MultiCurrency;
-
-use frame_support::{assert_ok, log, weights::constants::WEIGHT_PER_MILLIS};
 use primitives::currency::*;
 use sp_runtime::{assert_eq_error_rate, traits::AccountIdConversion, MultiAddress};
 use xcm::latest::prelude::*;
@@ -21,7 +16,12 @@ use xcm_builder::ParentIsPreset;
 use xcm_emulator::TestExt;
 use xcm_executor::{traits::Convert, XcmExecutor};
 
-use frame_support::traits::fungibles::Inspect as MultiInspect;
+use crate::{
+	assert_lt_by,
+	helpers::*,
+	kusama_test_net::{KusamaRelay, Sibling, This, PICA, SIBLING_PARA_ID, THIS_PARA_ID},
+	prelude::*,
+};
 
 #[test]
 fn reserve_transfer_from_relay_alice_bob() {
@@ -140,7 +140,7 @@ fn transfer_this_native_to_sibling_overridden() {
 				1,
 				X1(Parachain(THIS_PARA_ID),)
 			)),
-			Some(rational!(1 / 1)),
+			Some(rational_64!(1 / 1)),
 			None,
 		));
 	});
@@ -190,7 +190,7 @@ fn transfer_non_native_reserve_asset_from_this_to_sibling() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(CurrencyId::PBLO.into()),)
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		));
 	});
@@ -235,7 +235,7 @@ fn transfer_non_native_reserve_asset_from_this_to_sibling_by_local_id_overridden
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(CurrencyId::PBLO.into()),)
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		));
 	});
@@ -288,7 +288,7 @@ fn this_native_transferred_from_sibling_to_native_is_not_enough() {
 			root.into(),
 			location.clone(),
 			1000,
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();
@@ -986,7 +986,7 @@ fn sibling_trap_assets_works() {
 			RawOrigin::Root.into(),
 			any_asset,
 			remote,
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None
 		));
 		(balance, sibling_non_native_amount)
@@ -1062,7 +1062,7 @@ fn sibling_shib_to_transfer() {
 			root.into(),
 			sibling_asset_id,
 			location,
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			Some(SHIB::EXPONENT),
 		)
 		.expect("Asset already in Currency Factory; QED");
@@ -1092,7 +1092,7 @@ fn sibling_shib_to_transfer() {
 			root.into(),
 			location,
 			1000,
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			Some(SHIB::EXPONENT),
 		)
 		.expect("Asset details are valid; QED");

--- a/code/integration-tests/local-integration-tests/src/errors.rs
+++ b/code/integration-tests/local-integration-tests/src/errors.rs
@@ -5,6 +5,7 @@ use crate::{
 };
 
 use common::Balance;
+use composable_support::rational_64;
 use composable_traits::currency::{
 	AssetDataMutate, AssetExistentialDepositInspect, AssetRatioInspect,
 };
@@ -145,7 +146,7 @@ fn cannot_reserver_transfer_assets_when_fee_and_non_fee_has_different_origin() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();
@@ -162,7 +163,7 @@ fn cannot_reserver_transfer_assets_when_fee_and_non_fee_has_different_origin() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(123_666)),
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();
@@ -224,7 +225,7 @@ fn transfer_existing_asset_but_with_relevant_outgoing_fee_by_local_id() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();
@@ -275,7 +276,7 @@ fn cannot_transfer_away_if_min_fee_is_not_defined() {
 				1,
 				X2(Parachain(SIBLING_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();
@@ -311,7 +312,7 @@ fn cannot_transfer_away_if_min_fee_is_not_defined() {
 					1,
 					X2(
 						Parachain(SIBLING_PARA_ID),
-						Junction::AccountId32 { network: NetworkId::Any, id: alice().into() },
+						Junction::AccountId32 { network: NetworkId::Any, id: alice() },
 					),
 				)
 				.into(),
@@ -341,7 +342,7 @@ fn cannot_reserver_transfer_assets_from_self() {
 				0,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Some(rational_64!(1 / 1)),
 			None,
 		)
 		.unwrap();

--- a/code/integration-tests/local-integration-tests/src/kusama_test_net.rs
+++ b/code/integration-tests/local-integration-tests/src/kusama_test_net.rs
@@ -70,7 +70,7 @@ decl_test_network! {
 fn default_parachains_host_configuration() -> HostConfiguration<BlockNumber> {
 	HostConfiguration {
 		minimum_validation_upgrade_delay: 5,
-		validation_upgrade_cooldown: 5u32,
+		validation_upgrade_cooldown: 5_u32,
 		validation_upgrade_delay: 5,
 		code_retention_period: 1200,
 		max_code_size: MAX_CODE_SIZE,

--- a/code/integration-tests/local-integration-tests/src/lib.rs
+++ b/code/integration-tests/local-integration-tests/src/lib.rs
@@ -39,6 +39,7 @@
 #[cfg(test)]
 pub fn env_logger_init() {
 	use std::sync::Once;
+	// FIXME: This cell is unnecessary, as the log crate already does this internally.
 	static START: Once = Once::new();
 	START.call_once(|| {
 		let _ = env_logger::builder()

--- a/code/integration-tests/local-integration-tests/src/prelude.rs
+++ b/code/integration-tests/local-integration-tests/src/prelude.rs
@@ -6,8 +6,7 @@ pub use common::{
 	AccountId,
 };
 pub use composable_traits::{
-	currency::{AssetExistentialDepositInspect, AssetRatioInspect, CurrencyFactory, Rational64},
-	rational,
+	currency::{AssetExistentialDepositInspect, AssetRatioInspect, CurrencyFactory},
 	xcm::assets::XcmAssetLocation,
 };
 pub use cumulus_primitives_core::ParaId;

--- a/code/parachain/frame/assets-registry/Cargo.toml
+++ b/code/parachain/frame/assets-registry/Cargo.toml
@@ -20,7 +20,9 @@ package = "parity-scale-codec"
 version = "3.0.0"
 
 [dependencies]
+composable-support = { default-features = false, path = "../composable-support" }
 composable-traits = { path = "../composable-traits", default-features = false }
+
 cumulus-primitives-core = { git = "https://github.com/paritytech/cumulus", default-features = false, branch = "polkadot-v0.9.27" }
 frame-benchmarking = { default-features = false, optional = true, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 frame-support = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
@@ -47,6 +49,7 @@ std = [
   "codec/std",
   "log/std",
   "composable-traits/std",
+  "composable-support/std",
   "scale-info/std",
   "frame-support/std",
   "frame-system/std",

--- a/code/parachain/frame/assets-registry/src/benchmarking.rs
+++ b/code/parachain/frame/assets-registry/src/benchmarking.rs
@@ -2,11 +2,13 @@
 //! positive side effects
 
 use super::*;
-use crate::{self as pallet_assets_registry, prelude::*};
+use crate as pallet_assets_registry;
 
 #[allow(unused_imports)]
 use crate::Pallet as AssetsRegistry;
-use composable_traits::{currency::Rational64, rational, xcm::assets::XcmAssetLocation};
+use codec::{Decode, Encode};
+use composable_support::rational_64;
+use composable_traits::xcm::assets::XcmAssetLocation;
 use frame_benchmarking::{benchmarks, impl_benchmark_test_suite};
 use frame_system::RawOrigin;
 use sp_std::prelude::*;
@@ -21,7 +23,7 @@ benchmarks! {
 	register_asset {
 		let location = T::ForeignAssetId::decode(&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..]).unwrap();
 		let ed = 42_u64.into();
-		let ratio = rational!(42 / 123);
+		let ratio = rational_64!(42 / 123);
 		let decimals = 3;
 
 	}: _(RawOrigin::Root, location, ed, Some(ratio), Some(decimals))
@@ -29,14 +31,15 @@ benchmarks! {
 	update_asset {
 		let location = T::ForeignAssetId::decode(&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..]).unwrap();
 		let ed = 42_u64.into();
-		let ratio = rational!(42 / 123);
+		let ratio = rational_64!(42 / 123);
+		let new_ratio = rational_64!(42/ 456);
 		let decimals = 3;
 
 		AssetsRegistry::<T>::register_asset(RawOrigin::Root.into(), location.clone(), ed, Some(ratio), Some(decimals)).unwrap();
 
 		let local_asset_id = AssetsRegistry::<T>::from_foreign_asset(location.clone()).unwrap();
 
-	}: _(RawOrigin::Root, local_asset_id, location, Some(rational!(42 / 123)), Some(3))
+	}: _(RawOrigin::Root, local_asset_id, location, Some(new_ratio), Some(3))
 
 	set_min_fee {
 		let target_parachain_id = 100_u32.into();

--- a/code/parachain/frame/assets-registry/src/prelude.rs
+++ b/code/parachain/frame/assets-registry/src/prelude.rs
@@ -1,9 +1,6 @@
 pub use composable_traits::{
 	assets::Asset,
-	currency::{
-		AssetExistentialDepositInspect, AssetRatioInspect, BalanceLike, Exponent,
-		Rational64 as Rational,
-	},
+	currency::{AssetExistentialDepositInspect, AssetRatioInspect, BalanceLike, Exponent},
 	defi::Ratio,
 	xcm::assets::{ForeignMetadata, RemoteAssetRegistryInspect, RemoteAssetRegistryMutate},
 };

--- a/code/parachain/frame/assets-registry/src/tests.rs
+++ b/code/parachain/frame/assets-registry/src/tests.rs
@@ -1,9 +1,8 @@
 use crate::{prelude::*, runtime::*, Error};
 use codec::{Decode, Encode};
+use composable_support::rational_64;
 use composable_traits::{
 	assets::Asset,
-	currency::Rational64,
-	rational,
 	xcm::assets::{ForeignMetadata, RemoteAssetRegistryInspect, XcmAssetLocation},
 };
 use frame_support::{assert_noop, assert_ok};
@@ -26,7 +25,7 @@ fn set_metadata() {
 			RawOrigin::Root.into(),
 			XcmAssetLocation::RELAY_NATIVE,
 			42,
-			Some(rational!(42 / 123)),
+			Some(rational_64!(42 / 123)),
 			Some(4)
 		));
 		let asset_id = System::events()
@@ -47,7 +46,7 @@ fn set_metadata() {
 
 		assert_eq!(
 			<AssetsRegistry as AssetRatioInspect>::get_ratio(asset_id),
-			Some(rational!(42 / 123)),
+			Some(rational_64!(42 / 123)),
 		);
 
 		assert_eq!(
@@ -67,7 +66,7 @@ fn register_asset() {
 		)
 		.unwrap();
 		let ed = 42_u64.into();
-		let ratio = rational!(42 / 123);
+		let ratio = rational_64!(42 / 123);
 		let decimals = 3;
 
 		assert_eq!(AssetsRegistry::from_foreign_asset(location.clone()), None);
@@ -106,7 +105,7 @@ fn update_asset() {
 		)
 		.unwrap();
 		let ed = 42_u64.into();
-		let ratio = rational!(42 / 123);
+		let ratio = rational_64!(42 / 123);
 		let decimals = 3;
 
 		assert_ok!(AssetsRegistry::register_asset(
@@ -125,7 +124,7 @@ fn update_asset() {
 		assert_eq!(AssetsRegistry::asset_ratio(local_asset_id), Some(ratio));
 
 		let new_decimals = 12;
-		let new_ratio = rational!(100500 / 666);
+		let new_ratio = rational_64!(42 / 456);
 		assert_ok!(AssetsRegistry::update_asset(
 			Origin::root(),
 			local_asset_id,
@@ -175,7 +174,7 @@ fn get_foreign_assets_list_should_work() {
 		)
 		.unwrap();
 		let ed = 42_u64.into();
-		let ratio = rational!(42 / 123);
+		let ratio = rational_64!(42 / 123);
 		let decimals = 3;
 
 		let foreign_assets = AssetsRegistry::get_foreign_assets_list();

--- a/code/parachain/frame/composable-support/src/math/safe.rs
+++ b/code/parachain/frame/composable-support/src/math/safe.rs
@@ -5,9 +5,11 @@ use sp_runtime::{
 	ArithmeticError,
 };
 
-/// Thin wrapper around [`multiply_by_rational`], transforming any errors into [`ArithmeticError`]
-/// for easier use in pallets and Dispatch-related contexts. See [`multiply_by_rational`] for more
-/// information.
+/// Thin wrapper around [`multiply_by_rational_with_rounding`], transforming any errors into
+/// [`ArithmeticError`] for easier use in pallets and Dispatch-related contexts. See
+/// [`multiply_by_rational_with_rounding`] for more information.
+///
+/// Computes a * b / c, rounding down.
 ///
 /// Note: [`multiply_by_rational`] clamps `c` at a minimum of `1`, which can be confusing.
 /// [`safe_multiply_by_rational`] instead returns a divide by zero error if `c == 0`.

--- a/code/parachain/frame/composable-support/src/types/const_assertions.rs
+++ b/code/parachain/frame/composable-support/src/types/const_assertions.rs
@@ -1,4 +1,4 @@
-//! Workarounds for generic_const_exprs on stable rust.
+//! Workarounds for `generic_const_exprs` on stable rust.
 //!
 //! See https://github.com/rust-lang/rust/issues/76560 for more information.
 
@@ -10,15 +10,18 @@
 /// # Examples
 ///
 /// ```rust
-/// // a convoluted implementation of a non-zero u64
+/// # use composable_support::types::const_assertions::AssertNonZero;
+///
+/// // a custom implementation of a non-zero u64
 /// pub struct NonZeroU64(u64);
 ///
 /// impl NonZeroU64 {
 ///     pub const fn new<const N: u64>() -> Self {
-///         // this will raise a const_err:
+///         // this will raise a const_err if N is 0:
+///         //
 ///         // error[E0080]: evaluation of `composable_support::types::rational::AssertNonZero::<0>::OK` failed
 ///         // attempt to compute `0_u8 - 1_u8`, which would overflow
-///         let _ = AssertNonZero::<D>::OK;
+///         let _ = AssertNonZero::<N>::OK;
 ///         
 ///         Self(N)
 ///     }

--- a/code/parachain/frame/composable-support/src/types/const_assertions.rs
+++ b/code/parachain/frame/composable-support/src/types/const_assertions.rs
@@ -1,0 +1,31 @@
+//! Workarounds for generic_const_exprs on stable rust.
+//!
+//! See https://github.com/rust-lang/rust/issues/76560 for more information.
+
+/// Asserts that the parameter `X` is non-zero.
+///
+/// Since generic_const_exprs isn't stable yet, this check can't be done in the type system -
+/// instead, the check is pushed to the evaluation of an associated const (AssertNonZero::OK).
+///
+/// # Examples
+///
+/// ```rust
+/// // a convoluted implementation of a non-zero u64
+/// pub struct NonZeroU64(u64);
+///
+/// impl NonZeroU64 {
+///     pub const fn new<const N: u64>() -> Self {
+///         // this will raise a const_err:
+///         // error[E0080]: evaluation of `composable_support::types::rational::AssertNonZero::<0>::OK` failed
+///         // attempt to compute `0_u8 - 1_u8`, which would overflow
+///         let _ = AssertNonZero::<D>::OK;
+///         
+///         Self(N)
+///     }
+/// }
+/// ```
+pub struct AssertNonZero<const X: u64>;
+
+impl<const X: u64> AssertNonZero<X> {
+	pub const OK: u8 = 0 - !(X > 0) as u8;
+}

--- a/code/parachain/frame/composable-support/src/types/mod.rs
+++ b/code/parachain/frame/composable-support/src/types/mod.rs
@@ -1,5 +1,7 @@
 //! Definitions for types used throughout the Composable Rust project
 
+pub mod rational;
+
 use codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::RuntimeDebug;

--- a/code/parachain/frame/composable-support/src/types/mod.rs
+++ b/code/parachain/frame/composable-support/src/types/mod.rs
@@ -1,5 +1,6 @@
 //! Definitions for types used throughout the Composable Rust project
 
+pub mod const_assertions;
 pub mod rational;
 
 use codec::{Decode, Encode, MaxEncodedLen};

--- a/code/parachain/frame/composable-support/src/types/rational.rs
+++ b/code/parachain/frame/composable-support/src/types/rational.rs
@@ -1,0 +1,145 @@
+use core::num::NonZeroU64;
+
+use codec::{Decode, Encode, MaxEncodedLen};
+use frame_support::RuntimeDebug;
+use scale_info::TypeInfo;
+
+#[derive(
+	Copy,
+	Clone,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	RuntimeDebug,
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	TypeInfo,
+)]
+/// Represents a [rational number], with 64 bit numbers for the numerator and denominator.
+///
+/// [rational number]: https://en.wikipedia.org/wiki/Rational_number
+pub struct Rational64 {
+	n: u64,
+	d: NonZeroU64,
+}
+
+impl Rational64 {
+	pub const fn new(n: u64, d: u64) -> Option<Self> {
+		match NonZeroU64::new(d) {
+			Some(d) => Some(Self { n, d }),
+			None => None,
+		}
+	}
+
+	pub const fn n(&self) -> u64 {
+		self.n
+	}
+
+	pub const fn d(&self) -> NonZeroU64 {
+		self.d
+	}
+}
+
+/// Used to construct a [`Rational64`] from literals. This will fail at compile time if the
+/// denominator is zero.
+///
+/// # Example
+///
+/// ```rust
+/// # use composable_support::{rational_64, types::rational::Rational64};
+/// const VALID: Rational64 = rational_64!(100 / 1);
+/// ```
+///
+/// ```rust,compile_fail
+/// # use composable_support::{rational_64, types::rational::Rational64};
+/// const INVALID: Rational64 = rational_64!(100 / 0);
+/// ```
+#[macro_export]
+macro_rules! rational_64 {
+	($n:literal / $d:literal) => {{
+		const RATIONAL64: Rational64 = match Rational64::new($n, $d) {
+			Some(rational) => rational,
+			None => panic!("denominator cannot be zero"),
+		};
+		RATIONAL64
+	}};
+}
+
+impl Rational64 {
+	/// The smallest representation of `1` as a ratio; `1:1`.
+	pub const ONE: Self = rational_64!(1 / 1);
+}
+
+#[cfg(test)]
+mod test {
+	use frame_support::assert_err;
+
+	use super::*;
+
+	mod encode {
+		use super::*;
+
+		#[test]
+		fn encode_is_same_as_u128() {
+			// asserts that Rational64 encodes the same as a u128 built from the numerator and
+			// denominator (in little endian, since that's the encoding that SCALE uses)
+
+			let rational = rational_64!(0x01_02_03_04 / 0x05_06_07_08);
+
+			let rational_encoded = rational.encode();
+
+			let u128_representation = u128::from_le_bytes(
+				[0x01_02_03_04_u64.to_le_bytes(), 0x05_06_07_08_u64.to_le_bytes()]
+					.concat()
+					.try_into()
+					.expect("8 + 8 = 16"),
+			);
+
+			let u128_representation_encoded = u128_representation.encode();
+
+			assert_eq!(rational_encoded, u128_representation_encoded);
+		}
+
+		#[test]
+		fn max_encoded_len_same_as_u128() {
+			assert_eq!(u128::max_encoded_len(), Rational64::max_encoded_len())
+		}
+	}
+
+	mod decode {
+		use super::*;
+
+		#[test]
+		fn all_zeros_fails() {
+			// asserts that decoding fails when both n and d are zero (i.e. the entirety of the
+			// input is zeros)
+
+			// 0:0
+			let bytes = [0_u8; 16];
+
+			assert_err!(
+				<Rational64 as Decode>::decode(&mut bytes.as_slice()),
+				// codec errors aren't typed so this is the best we can do
+				codec::Error::from("cannot create non-zero number from 0")
+					.chain("Could not decode `Rational64::d`")
+			);
+		}
+
+		#[test]
+		fn zero_denominator_fails() {
+			// asserts that decoding fails when d is zero
+
+			// 1:0
+			let bytes = [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0];
+
+			assert_err!(
+				<Rational64 as Decode>::decode(&mut bytes.as_slice()),
+				// codec errors aren't typed so this is the best we can do
+				codec::Error::from("cannot create non-zero number from 0")
+					.chain("Could not decode `Rational64::d`")
+			);
+		}
+	}
+}

--- a/code/parachain/frame/composable-support/src/types/rational.rs
+++ b/code/parachain/frame/composable-support/src/types/rational.rs
@@ -59,10 +59,11 @@ impl Rational64 {
 #[macro_export]
 macro_rules! rational_64 {
 	($n:literal / $d:literal) => {{
-		const RATIONAL64: Rational64 = match Rational64::new($n, $d) {
-			Some(rational) => rational,
-			None => panic!("denominator cannot be zero"),
-		};
+		const RATIONAL64: $crate::types::rational::Rational64 =
+			match $crate::types::rational::Rational64::new($n, $d) {
+				Some(rational) => rational,
+				None => panic!("denominator cannot be zero"),
+			};
 		RATIONAL64
 	}};
 }

--- a/code/parachain/frame/composable-traits/src/currency.rs
+++ b/code/parachain/frame/composable-traits/src/currency.rs
@@ -147,6 +147,7 @@ pub trait MathBalance:
 	+ Copy
 {
 }
+
 impl<
 		T: PartialOrd
 			+ Zero
@@ -162,4 +163,12 @@ impl<
 {
 }
 
-pub trait AssetIdLike = FullCodec + MaxEncodedLen + Copy + Eq + PartialEq + Debug + TypeInfo;
+pub trait AssetIdLike:
+	FullCodec + MaxEncodedLen + Copy + Eq + PartialEq + Debug + TypeInfo
+{
+}
+
+impl<T> AssetIdLike for T where
+	T: FullCodec + MaxEncodedLen + Copy + Eq + PartialEq + Debug + TypeInfo
+{
+}

--- a/code/parachain/frame/composable-traits/src/lib.rs
+++ b/code/parachain/frame/composable-traits/src/lib.rs
@@ -33,12 +33,6 @@
 	trivial_numeric_casts,
 	unused_extern_crates
 )]
-#![allow(incomplete_features)]
-#![feature(associated_type_defaults)] // https://github.com/Rust-for-Linux/linux/issues/2
-#![feature(trait_alias)] // complete
-#![feature(const_trait_impl)] // https://github.com/Rust-for-Linux/linux/issues/2
-#![feature(const_convert)] // that is just const fn for into/from - easy
-#![feature(adt_const_params)] // avoids write own serde and bit shifts for Rational64
 
 pub mod account_proxy;
 pub mod airdrop;

--- a/code/parachain/frame/composable-traits/src/xcm/assets.rs
+++ b/code/parachain/frame/composable-traits/src/xcm/assets.rs
@@ -1,5 +1,6 @@
 //! Interfaces to managed assets
 use codec::{Decode, Encode, MaxEncodedLen};
+use composable_support::types::rational::Rational64;
 use frame_support::{dispatch::DispatchResult, pallet_prelude::ConstU32, WeakBoundedVec};
 use polkadot_parachain::primitives::Id;
 use scale_info::TypeInfo;
@@ -8,10 +9,7 @@ use serde::{Deserialize, Serialize};
 use sp_std::vec::Vec;
 use xcm::latest::MultiLocation;
 
-use crate::{
-	assets::Asset,
-	currency::{Exponent, Rational64},
-};
+use crate::{assets::Asset, currency::Exponent};
 
 /// works only with concrete assets
 #[derive(Debug, Encode, Decode, Clone, PartialEq, Eq, TypeInfo)]

--- a/code/parachain/frame/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/cosmwasm/Cargo.toml
@@ -26,13 +26,16 @@ sp-std = { default-features = false, git = "https://github.com/paritytech/substr
 
 composable-support = { path = "../composable-support", default-features = false }
 cosmwasm-minimal-std = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "ee37ee8263cbcd249e163da47065980cbe426c47", default-features = false, features = [
-  "iterator", "stargate"
+  "iterator",
+  "stargate",
 ] }
 cosmwasm-vm = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "ee37ee8263cbcd249e163da47065980cbe426c47", default-features = false, features = [
-  "iterator", "stargate"
+  "iterator",
+  "stargate",
 ] }
 cosmwasm-vm-wasmi = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "ee37ee8263cbcd249e163da47065980cbe426c47", default-features = false, features = [
-  "iterator", "stargate"
+  "iterator",
+  "stargate",
 ] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.14", default-features = false }

--- a/code/xcvm/evm/foundry.toml
+++ b/code/xcvm/evm/foundry.toml
@@ -1,6 +1,6 @@
 [profile.default]
-src = 'src'
-out = 'out'
 libs = ['lib', 'node_modules']
+out = 'out'
+src = 'src'
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
Below are the originally planned changes. Since #2118 was merged, this PR is now simply replacing the `Rational64` type from #2118.

> Adds the `Rational64` type from #2118. This refactor was possible to almost entirely isolate from #2118, which will make both this type and the original PR easier to review. Consider this PR a precursor to #2118.
>
> TODO:
>  - [x] Replace usage of `Ratio` with `Rational64`.
> 
> Additional changes:
>  - Fixed a few tests that were failing after the migration to `Rational64`, copied from #2118.
>  - Fixed some clippy errors in a few test files as it was quite noisy and made it difficult to see where the actual issues were. (Mostly [useless_conversion](https://rust-lang.github.io/rust-clippy/master/index.html#useless_conversion) and [redundant_clone](https://rust-lang.github.io/rust-clippy/master/index.html#redundant_clone))
>    - Similar to above, I also (temporarily) `#[allow()]`'d the use of `.unwrap()` in those same files for the same reason.
> 
> https://app.clickup.com/t/31gy38v