### PR TITLE
Transfers bugfixes

### DIFF
--- a/frontend/apps/picasso/components/Atom/Label.tsx
+++ b/frontend/apps/picasso/components/Atom/Label.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import {
   Typography,
   useTheme,
@@ -19,7 +19,7 @@ export type LabelProps = {
   balanceLabelProps?: {
     label?: string;
     LabelTypographyProps?: TypographyProps;
-    balanceText?: string;
+    balanceText?: string | ReactNode;
     BalanceTypographyProps?: TypographyProps;
   };
 } & BoxProps;
@@ -70,13 +70,17 @@ export const Label: React.FC<LabelProps> = ({
             >
               {balanceLabelProps.label}
             </Typography>
-            <Typography
-              variant="inputLabel"
-              ml={0.5}
-              {...balanceLabelProps.BalanceTypographyProps}
-            >
-              {balanceLabelProps.balanceText}
-            </Typography>
+            {typeof balanceLabelProps.balanceText === "string" ? (
+              <Typography
+                variant="inputLabel"
+                ml={0.5}
+                {...balanceLabelProps.BalanceTypographyProps}
+              >
+                {balanceLabelProps.balanceText}
+              </Typography>
+            ) : (
+              balanceLabelProps.balanceText
+            )}
           </Box>
         )}
     </Box>

--- a/frontend/apps/picasso/components/Molecules/BigNumberInput/hooks.ts
+++ b/frontend/apps/picasso/components/Molecules/BigNumberInput/hooks.ts
@@ -33,9 +33,7 @@ export function useValidation({
 
   const validate: (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => void = (
-    event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-  ) => {
+  ) => void = (event) => {
     const eventValue = event.target.value;
 
     if (!eventValue.length) {

--- a/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
+++ b/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
@@ -106,7 +106,7 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bignrValue]);
 
-  // Update internal value based on external amount changes. (post transfer hooks, etc)
+  // Update internal value based on external amount changes. (post transfer hooks, etc.)
   useEffect(() => {
     if (!amount.eq(bignrValue)) {
       setValue(amount);

--- a/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
+++ b/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
@@ -17,7 +17,10 @@ import BigNumber from "bignumber.js";
 export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   disabled,
 }) => {
-  const updateAmount = useStore((state) => state.transfers.updateAmount);
+  const updateAmount = useStore(
+    (state) => state.transfers.updateAmount,
+    () => true
+  );
   const amount = useStore((state) => state.transfers.amount);
   const { balance, tokenId } = useExistentialDeposit();
   const { from, fromProvider, to } = useTransfer();
@@ -31,7 +34,6 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   );
   const tokens = useStore((state) => state.substrateTokens.tokens);
   const existentialDeposit = tokens[selectedToken].existentialDeposit[from];
-  const decimals = tokens[selectedToken].decimals[from] ?? Number(0);
   const keepAlive = useStore((state) => state.transfers.keepAlive);
   const { validate, hasError, stringValue, bignrValue, setValue } =
     useValidation({
@@ -45,7 +47,10 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
     fee: fee.partialFee,
     token: feeToken,
   };
-  const setFormError = useStore((state) => state.transfers.setFormError);
+  const setFormError = useStore(
+    (state) => state.transfers.setFormError,
+    () => true
+  );
 
   const handleMaxClick = () => {
     callbackGate(
@@ -78,24 +83,28 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   useEffect(() => {
     // On network or token change, reset the amount
     setValue(new BigNumber(0));
-  }, [from, to, selectedToken]);
+  }, [from, to, selectedToken, setValue]);
 
   useEffect(() => {
     setFormError(hasError);
-  }, [hasError]);
+  }, [hasError, setFormError]);
 
   // Update the amount based on user input
   useEffect(() => {
     if (!bignrValue.eq(amount)) {
       updateAmount(bignrValue);
     }
-  }, [bignrValue.toString()]);
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bignrValue]);
 
   // Update internal value based on external amount changes. (post transfer hooks, etc)
   useEffect(() => {
     if (!amount.eq(bignrValue)) {
       setValue(amount);
     }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [amount.toString()]);
 
   return (

--- a/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
+++ b/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
@@ -7,12 +7,20 @@ import {
   subscribeDefaultTransferToken,
   subscribeTokenOptions,
 } from "@/stores/defi/polkadot/transfers/subscribers";
-import { FC, useEffect } from "react";
+import React, { FC, useEffect } from "react";
 import { useValidation } from "@/components/Molecules/BigNumberInput/hooks";
-import { Typography } from "@mui/material";
+import { Tooltip, Typography } from "@mui/material";
 import { calculateTransferAmount } from "@/defi/polkadot/pallets/Transfer";
 import { useTransfer } from "@/defi/polkadot/hooks";
 import BigNumber from "bignumber.js";
+import { SUBSTRATE_NETWORKS } from "@/defi/polkadot/Networks";
+import {
+  HelpCenterOutlined,
+  HelpOutlined,
+  InfoOutlined,
+  InfoTwoTone,
+  QuestionMark,
+} from "@mui/icons-material";
 
 export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   disabled,
@@ -119,7 +127,24 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
           },
           balanceLabelProps: {
             label: "Balance:",
-            balanceText: humanBalance(balance) + " " + tokenId.toUpperCase(),
+            balanceText: (
+              <>
+                <Typography variant="inputLabel" ml={0.5}>
+                  {humanBalance(balance) + " " + tokens[tokenId].symbol}
+                </Typography>
+                <Tooltip
+                  arrow
+                  placement="top"
+                  title={`${balance.toFixed()} ${tokens[tokenId].symbol}`}
+                  color="primary"
+                  sx={{
+                    fontSize: "01rem",
+                  }}
+                >
+                  <InfoTwoTone />
+                </Tooltip>
+              </>
+            ),
           },
         }}
         ButtonProps={{

--- a/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
+++ b/frontend/apps/picasso/components/Organisms/Transfer/AmountTokenDropdown.tsx
@@ -13,14 +13,7 @@ import { Tooltip, Typography } from "@mui/material";
 import { calculateTransferAmount } from "@/defi/polkadot/pallets/Transfer";
 import { useTransfer } from "@/defi/polkadot/hooks";
 import BigNumber from "bignumber.js";
-import { SUBSTRATE_NETWORKS } from "@/defi/polkadot/Networks";
-import {
-  HelpCenterOutlined,
-  HelpOutlined,
-  InfoOutlined,
-  InfoTwoTone,
-  QuestionMark,
-} from "@mui/icons-material";
+import { InfoTwoTone } from "@mui/icons-material";
 
 export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   disabled,
@@ -45,10 +38,12 @@ export const AmountTokenDropdown: FC<{ disabled: boolean }> = ({
   const keepAlive = useStore((state) => state.transfers.keepAlive);
   const fee = useStore((state) => state.transfers.fee);
   const feeToken = useStore((state) => state.transfers.feeToken);
-  const sourceGas = {
-    fee: fee.partialFee,
-    token: feeToken,
-  };
+  const sourceGas = useMemo(() => {
+    return {
+      fee: fee.partialFee,
+      token: feeToken,
+    };
+  }, [fee.partialFee, feeToken]);
   const setFormError = useStore(
     (state) => state.transfers.setFormError,
     () => true

--- a/frontend/apps/picasso/defi/config.ts
+++ b/frontend/apps/picasso/defi/config.ts
@@ -45,9 +45,9 @@ export const TRANSFER_ASSET_LIST: AllowedTransferList = {
     statemine: ["usdt"],
   },
   statemine: {
-    picasso: ["usdt"],
+    picasso: ["usdt", "ksm"],
     kusama: [],
     karura: [],
     statemine: [],
-  }
+  },
 };

--- a/frontend/apps/picasso/defi/config.ts
+++ b/frontend/apps/picasso/defi/config.ts
@@ -22,12 +22,32 @@ export const DEFI_CONFIG = {
 };
 
 export type AllowedTransferList = {
-  [key in SubstrateNetworkId]: Array<TokenId>;
+  [key in SubstrateNetworkId]: Record<SubstrateNetworkId, Array<TokenId>>;
 };
 
 export const TRANSFER_ASSET_LIST: AllowedTransferList = {
-  kusama: ["ksm"],
-  karura: ["ksm", "ausd", "kusd", "kar"],
-  picasso: ["ksm", "kusd", "ausd", "kar", "usdt"],
-  statemine: ["usdt"],
+  karura: {
+    picasso: ["ksm", "ausd", "kusd", "kar"],
+    kusama: [],
+    karura: [],
+    statemine: [],
+  },
+  kusama: {
+    picasso: ["ksm"],
+    kusama: [],
+    karura: [],
+    statemine: [],
+  },
+  picasso: {
+    picasso: [],
+    kusama: ["ksm"],
+    karura: ["ksm", "ausd", "kusd", "kar"],
+    statemine: ["usdt"],
+  },
+  statemine: {
+    picasso: ["usdt"],
+    kusama: [],
+    karura: [],
+    statemine: [],
+  }
 };

--- a/frontend/apps/picasso/defi/polkadot/pallets/Assets/picasso.ts
+++ b/frontend/apps/picasso/defi/polkadot/pallets/Assets/picasso.ts
@@ -13,13 +13,16 @@ export async function picassoAssetsList(
 ): Promise<PicassoRpcAsset[]> {
   try {
     const assetsList = await api.rpc.assets.listAssets();
-    return assetsList.map(asset => {
+    return assetsList.map((asset) => {
       return {
         name: asset.name.toUtf8(),
         id: new BigNumber(asset.id.toString()),
-        decimals: asset.decimals.toNumber(),
+        decimals:
+          asset.name.toUtf8().toUpperCase() !== "USDT"
+            ? asset.decimals.toNumber()
+            : 6, // TODO: Temporary assign 6 decimals to USDT until RPC is ready
         foreignId: asset.foreignId,
-        existentialDeposit: null
+        existentialDeposit: null,
       };
     });
   } catch (err) {

--- a/frontend/apps/picasso/defi/polkadot/pallets/Transfer.ts
+++ b/frontend/apps/picasso/defi/polkadot/pallets/Transfer.ts
@@ -74,8 +74,11 @@ export function calculateTransferAmount({
     ? amountToTransfer.minus(sourceGas.fee)
     : amountToTransfer;
   // Is account going to be removed after transfer?
-  const willReap = balance.minus(amountMinusGas).lt(sourceExistentialDeposit);
-
+  const willReap = balance
+    .minus(gasTokenEqSelected ? sourceGas.fee : ZERO)
+    .minus(amountToTransfer)
+    .minus(sourceExistentialDeposit)
+    .lt(sourceExistentialDeposit);
   // If we should keep alive, deduct existential deposit from the amount to transfer
   // NOTE: This should happen only if amount is MAX balance.
   const requiredKeepAliveValue =

--- a/frontend/apps/picasso/pages/transfers/index.tsx
+++ b/frontend/apps/picasso/pages/transfers/index.tsx
@@ -30,7 +30,8 @@ import { pipe } from "fp-ts/function";
 import { option } from "fp-ts";
 
 const Transfers: NextPage = () => {
-  const { amount, setAmount, from, balance, transfer, to } = useTransfer();
+  const { setAmount, from, balance, transfer, to } = useTransfer();
+  const amount = useStore((state) => state.transfers.amount);
   const allProviders = useAllParachainProviders();
 
   const tokens = useStore((state) => state.substrateTokens.tokens);

--- a/frontend/apps/picasso/pages/transfers/index.tsx
+++ b/frontend/apps/picasso/pages/transfers/index.tsx
@@ -52,6 +52,7 @@ const Transfers: NextPage = () => {
 
   const hasPendingTransfer = hasPendingXcmTransfer || hasPendingXTokensTransfer;
   const getBalance = useStore((state) => state.substrateBalances.getBalance);
+  const hasFormError = useStore((state) => state.transfers.hasFormError);
 
   useEffect(() => {
     if (
@@ -141,7 +142,8 @@ const Transfers: NextPage = () => {
               amount.gt(balance) ||
               amount.lte(minValue ?? 0) ||
               !hasEnoughGasFee ||
-              hasPendingTransfer
+              hasPendingTransfer ||
+              hasFormError
             }
             fullWidth
             onClick={transfer}

--- a/frontend/apps/picasso/stores/defi/polkadot/balances/PolkadotBalancesUpdater.tsx
+++ b/frontend/apps/picasso/stores/defi/polkadot/balances/PolkadotBalancesUpdater.tsx
@@ -7,20 +7,20 @@ import {
   ParachainId,
   RelayChainId,
   useDotSamaContext,
-  useEagerConnect
+  useEagerConnect,
 } from "substrate-react";
 
 import {
   subscribeKaruraBalance,
   subscribeNativeBalance,
   subscribePicassoBalanceByAssetId,
-  subscribeStatemineBalance
+  subscribeStatemineBalance,
 } from "@/defi/polkadot/pallets/Balances";
 import { TokenMetadata } from "../tokens/slice";
 import { SUBSTRATE_NETWORKS } from "@/defi/polkadot/Networks";
 import {
   karuraAssetsList,
-  picassoAssetsList
+  picassoAssetsList,
 } from "@/defi/polkadot/pallets/Assets";
 import { VoidFn } from "@polkadot/api/types";
 import { AcalaPrimitivesCurrencyCurrencyId } from "@acala-network/types/interfaces/types-lookup";
@@ -32,7 +32,7 @@ const PolkadotBalancesUpdater = () => {
   useEagerConnect("picasso");
   useEagerConnect("karura");
 
-  const isLoaded = useStore(state => state.substrateTokens.isLoaded);
+  const isLoaded = useStore((state) => state.substrateTokens.isLoaded);
 
   const updateTokens = useStore(
     ({ substrateTokens }) => substrateTokens.updateTokens
@@ -52,7 +52,7 @@ const PolkadotBalancesUpdater = () => {
     selectedAccount,
     parachainProviders,
     relaychainProviders,
-    connectedAccounts
+    connectedAccounts,
   } = useDotSamaContext();
 
   /**
@@ -85,7 +85,7 @@ const PolkadotBalancesUpdater = () => {
   }, [
     parachainProviders,
     relaychainProviders.kusama.parachainApi,
-    updateTokens
+    updateTokens,
   ]);
 
   const picassoBalanceSubscriber = useCallback(
@@ -101,11 +101,11 @@ const PolkadotBalancesUpdater = () => {
             api,
             account.address,
             tokenMetadata,
-            balance => {
+            (balance) => {
               updateBalance({
                 network: chainId as SubstrateNetworkId,
                 tokenId: tokenMetadata.id,
-                balance
+                balance,
               });
             }
           );
@@ -139,7 +139,7 @@ const PolkadotBalancesUpdater = () => {
               chainId,
               SUBSTRATE_NETWORKS[chainId as SubstrateNetworkId].tokenId,
               updateBalance
-            ).then(subscription => {
+            ).then((subscription) => {
               subscriptionList.push(subscription);
             });
           }
@@ -148,7 +148,7 @@ const PolkadotBalancesUpdater = () => {
 
       return function unsubNativeBalances() {
         console.log("Clearing Native Subscriptions. ", subscriptionList.length);
-        return subscriptionList.forEach(x => {
+        return subscriptionList.forEach((x) => {
           x?.();
         });
       };
@@ -161,7 +161,7 @@ const PolkadotBalancesUpdater = () => {
     selectedAccount,
     connectedAccounts,
     updateBalance,
-    clearBalance
+    clearBalance,
   ]);
 
   // Subscribe non-native token balances
@@ -177,8 +177,8 @@ const PolkadotBalancesUpdater = () => {
     }
 
     Object.entries(parachainProviders).forEach(([chainId, chain]) =>
-      callbackGate(api => {
-        Object.values(tokens).forEach(asset => {
+      callbackGate((api) => {
+        Object.values(tokens).forEach((asset) => {
           switch (chainId) {
             case "picasso":
               if (SUBSTRATE_NETWORKS.picasso.tokenId !== asset.id) {
@@ -200,11 +200,11 @@ const PolkadotBalancesUpdater = () => {
                   api,
                   connectedAccounts.karura[selectedAccount].address,
                   asset,
-                  balance => {
+                  (balance) => {
                     updateBalance({
                       network: chainId as SubstrateNetworkId,
                       tokenId: asset.id,
-                      balance
+                      balance,
                     });
                   }
                 );
@@ -216,11 +216,11 @@ const PolkadotBalancesUpdater = () => {
                 connectedAccounts.statemine[selectedAccount].address,
                 asset,
                 chainId,
-                balance => {
+                (balance) => {
                   updateBalance({
                     network: chainId as SubstrateNetworkId,
                     tokenId: asset.id,
-                    balance
+                    balance,
                   });
                 }
               );
@@ -230,7 +230,7 @@ const PolkadotBalancesUpdater = () => {
         });
 
         return () => {
-          unsubList.forEach(unsub => {
+          unsubList.forEach((unsub) => {
             unsub.then((call: any) => call?.());
           });
         };

--- a/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/destinationMultiLocation.ts
+++ b/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/destinationMultiLocation.ts
@@ -58,7 +58,11 @@ export const subscribeDestinationMultiLocation = async (
       }
 
       // Picasso to Kusama needs recipient in MultiLocation
-      if (sourceChain === "picasso" && targetChain === "kusama" && recipient) {
+      if (
+        sourceChain === "picasso" &&
+        ["kusama", "statemine"].includes(targetChain) &&
+        recipient
+      ) {
         // Set destination. Should have 2 Junctions, first to parent and then to wallet
         set(
           <XcmVersionedMultiLocation>api.createType(

--- a/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/multiAsset.ts
+++ b/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/multiAsset.ts
@@ -5,7 +5,6 @@ import {
   XcmVersionedMultiAsset,
   XcmVersionedMultiAssets,
 } from "@acala-network/types/interfaces/types-lookup";
-import { toChainIdUnit } from "shared";
 
 export const subscribeMultiAsset = async (allProviders: AllProviders) => {
   return useStore.subscribe(
@@ -47,35 +46,56 @@ export const subscribeMultiAsset = async (allProviders: AllProviders) => {
       }
 
       if (from === "statemine") {
-        set(
-          <XcmVersionedMultiAssets>api.createType("XcmVersionedMultiAssets", {
-            V1: [
-              {
-                id: {
-                  Concrete: {
-                    parents: 0,
-                    interior: {
-                      X2: [
-                        {
-                          PalletInstance: 50,
-                        },
-                        {
-                          GeneralIndex:
-                            useStore.getState().substrateTokens.tokens[
-                              selectedToken
-                            ].chainId.statemine,
-                        },
-                      ],
+        if (selectedToken === "usdt") {
+          set(
+            <XcmVersionedMultiAssets>api.createType("XcmVersionedMultiAssets", {
+              V1: [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 0,
+                      interior: {
+                        X2: [
+                          {
+                            PalletInstance: 50,
+                          },
+                          {
+                            GeneralIndex:
+                              useStore.getState().substrateTokens.tokens[
+                                selectedToken
+                              ].chainId.statemine,
+                          },
+                        ],
+                      },
                     },
                   },
+                  fun: {
+                    Fungible: amountToTransfer.toString(),
+                  },
                 },
-                fun: {
-                  Fungible: amountToTransfer.toString(),
+              ],
+            })
+          );
+        }
+        if (selectedToken === "ksm") {
+          set(
+            <XcmVersionedMultiAssets>api.createType("XcmVersionedMultiAssets", {
+              V1: [
+                {
+                  id: {
+                    Concrete: {
+                      parents: 1,
+                      interior: "Here",
+                    },
+                  },
+                  fun: {
+                    Fungible: amountToTransfer.toString(),
+                  },
                 },
-              },
-            ],
-          })
-        );
+              ],
+            })
+          );
+        }
       }
 
       if (from === "karura" && to === "picasso") {

--- a/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/tokenOptions.ts
+++ b/frontend/apps/picasso/stores/defi/polkadot/transfers/subscribers/tokenOptions.ts
@@ -5,7 +5,10 @@ import { TokenOption } from "@/stores/defi/polkadot/transfers/transfers";
 import { useStore } from "@/stores/root";
 import { TokenMetadata } from "@/stores/defi/polkadot/tokens/slice";
 
-function extractOptions(from: SubstrateNetworkId): TokenOption[] {
+function extractOptions(
+  from: SubstrateNetworkId,
+  to: SubstrateNetworkId
+): TokenOption[] {
   const list = useStore.getState().substrateTokens.tokens;
   const balances = useStore.getState().substrateBalances.balances;
   return Object.values(list).reduce(
@@ -19,7 +22,7 @@ function extractOptions(from: SubstrateNetworkId): TokenOption[] {
       const balance = balances[from][currentValue.id].balance;
 
       // only include allowed assets
-      if (!TRANSFER_ASSET_LIST[from].includes(currentValue.id)) {
+      if (!TRANSFER_ASSET_LIST[from][to].includes(currentValue.id)) {
         return previousValue;
       }
 
@@ -50,14 +53,18 @@ function setOptions(options: TokenOption[]) {
 
 export const subscribeTokenOptions = () => {
   return useStore.subscribe(
-    (store) => store.transfers.networks.from,
-    (from) => {
-      const options = extractOptions(from);
+    (store) => ({
+      from: store.transfers.networks.from,
+      to: store.transfers.networks.to,
+    }),
+    ({ from, to }) => {
+      const options = extractOptions(from, to);
 
       setOptions(options);
     },
     {
       fireImmediately: true,
+      equalityFn: (a, b) => a.from === b.from && a.to === b.to,
     }
   );
 };

--- a/frontend/apps/picasso/stores/defi/polkadot/transfers/transfers.ts
+++ b/frontend/apps/picasso/stores/defi/polkadot/transfers/transfers.ts
@@ -53,6 +53,7 @@ interface TransfersState {
   destinationMultiLocation: XcmVersionedMultiLocation | null;
   transferExtrinsic: null | ((...args: any[]) => any);
   multiAsset: SupportedTransferMultiAssets | null;
+  hasFormError: boolean;
 }
 
 export type SupportedTransferMultiAssets =
@@ -93,6 +94,7 @@ const initialState: TransfersState = {
   destinationMultiLocation: null,
   transferExtrinsic: null,
   multiAsset: null,
+  hasFormError: false,
 };
 
 interface TransferActions {
@@ -125,6 +127,7 @@ interface TransferActions {
     targetAddress: string | undefined
   ) => SubmittableExtrinsic<"promise"> | undefined;
   getTransferAmount: (api: ApiPromise) => u128;
+  setFormError: (value: boolean) => void;
 }
 
 export interface TransfersSlice {
@@ -332,6 +335,11 @@ export const createTransfersSlice: StoreSlice<TransfersSlice> = (set, get) => ({
       } catch {
         return;
       }
+    },
+    setFormError: (value) => {
+      set((state) => {
+        state.transfers.hasFormError = value;
+      });
     },
   },
 });

--- a/frontend/apps/picasso/stores/defi/polkadot/transfers/transfers.ts
+++ b/frontend/apps/picasso/stores/defi/polkadot/transfers/transfers.ts
@@ -256,7 +256,6 @@ export const createTransfersSlice: StoreSlice<TransfersSlice> = (set, get) => ({
           transferExtrinsic === null ||
           get().transfers.destinationMultiLocation === null
         ) {
-          console.warn("Shush");
           return; // bail if required params are not available.
         }
 

--- a/frontend/packages/wallet/components/ConnectionModal.tsx
+++ b/frontend/packages/wallet/components/ConnectionModal.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { DotSamaExtensionStatus, SupportedWalletId } from "substrate-react";
 import { Box, IconButton, Typography, useTheme } from "@mui/material";
-import { useCallback } from "react";
+import { Dispatch, useCallback } from "react";
 import { ConnectorType } from "bi-lib";
 import { ChevronLeft } from "@mui/icons-material";
 import { Modal } from "./Molecules/Modal";
@@ -15,9 +14,12 @@ import { useSnackbar } from "notistack";
 export type ConnectionModalProps = {
   closeConnectionModal: () => void;
   walletConnectStep: WalletConnectStep;
-  setWalletConnectStep: React.Dispatch<WalletConnectStep>;
+  setWalletConnectStep: Dispatch<WalletConnectStep>;
   isOpenConnectionModal: boolean;
-} & Omit<WalletProps, "connectedAccountNativeBalance" | "connectedWalletTransactions">;
+} & Omit<
+  WalletProps,
+  "connectedAccountNativeBalance" | "connectedWalletTransactions"
+>;
 
 function getTitle(walletStep: WalletConnectStep): string {
   switch (walletStep) {
@@ -106,7 +108,7 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
         key={wallet.walletId}
         onClick={(walletId: SupportedWalletId) => {
           onConnectPolkadotWallet(walletId)
-            .then((walletConnected) => {
+            .then((_walletConnected) => {
               setWalletConnectStep(WalletConnectStep.SelectDotsamaAccount);
             })
             .catch((err) => {
@@ -239,6 +241,7 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
             accounts={polkadotAccounts}
             selectedAccount={selectedPolkadotAccount}
             onSelect={onSelectPolkadotAccount}
+            closeConnectionModal={closeConnectionModal}
           />
         ) : null}
       </Box>

--- a/frontend/packages/wallet/components/ConnectionModal.tsx
+++ b/frontend/packages/wallet/components/ConnectionModal.tsx
@@ -108,7 +108,7 @@ export const ConnectionModal: React.FC<ConnectionModalProps> = ({
         key={wallet.walletId}
         onClick={(walletId: SupportedWalletId) => {
           onConnectPolkadotWallet(walletId)
-            .then((_walletConnected) => {
+            .then(() => {
               setWalletConnectStep(WalletConnectStep.SelectDotsamaAccount);
             })
             .catch((err) => {

--- a/frontend/packages/wallet/components/Molecules/Modal.tsx
+++ b/frontend/packages/wallet/components/Molecules/Modal.tsx
@@ -7,13 +7,13 @@ import {
   IconButton,
   useTheme,
 } from "@mui/material";
-import React from "react";
+import { FC } from "react";
 
 export type ModalProps = DialogProps & {
   dismissible?: boolean;
 };
 
-export const Modal: React.FC<ModalProps> = ({
+export const Modal: FC<ModalProps> = ({
   dismissible = false,
   children,
   open,

--- a/frontend/packages/wallet/components/Molecules/PolkadotAccountsSelection.tsx
+++ b/frontend/packages/wallet/components/Molecules/PolkadotAccountsSelection.tsx
@@ -2,7 +2,6 @@ import { Box, Button, useTheme } from "@mui/material";
 import { useState } from "react";
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { PolkadotAccountListItem } from "./PolkadotAccountListItem";
-import { closePolkadotModal } from "pablo/stores/ui/uiSlice";
 
 export const PolkadotAccountsSelection = ({
   accounts,

--- a/frontend/packages/wallet/components/Molecules/PolkadotAccountsSelection.tsx
+++ b/frontend/packages/wallet/components/Molecules/PolkadotAccountsSelection.tsx
@@ -2,23 +2,26 @@ import { Box, Button, useTheme } from "@mui/material";
 import { useState } from "react";
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { PolkadotAccountListItem } from "./PolkadotAccountListItem";
-import React from "react";
+import { closePolkadotModal } from "pablo/stores/ui/uiSlice";
 
 export const PolkadotAccountsSelection = ({
   accounts,
   onSelect,
   selectedAccount,
   disconnectWallet,
+  closeConnectionModal,
 }: {
   accounts: InjectedAccountWithMeta[];
   onSelect: (account: InjectedAccountWithMeta) => void;
   selectedAccount?: InjectedAccountWithMeta;
   disconnectWallet: (() => Promise<void>) | undefined;
+  closeConnectionModal: () => void;
 }) => {
   const theme = useTheme();
   const [selectedActiveAccount, setSelectedActiveAccount] = useState<
     InjectedAccountWithMeta | undefined
   >(selectedAccount);
+
   return (
     <>
       <Box
@@ -48,6 +51,7 @@ export const PolkadotAccountsSelection = ({
         onClick={() => {
           if (selectedActiveAccount) {
             onSelect(selectedActiveAccount);
+            closeConnectionModal();
           }
         }}
         sx={{ marginTop: theme.spacing(2) }}

--- a/frontend/packages/wallet/components/Wallet.tsx
+++ b/frontend/packages/wallet/components/Wallet.tsx
@@ -1,11 +1,16 @@
-import React from "react";
 import { useState } from "react";
 import { ConnectionStatus } from "./ConnectionStatus";
 import { ConnectionModal } from "./ConnectionModal";
 import { WalletViewModal } from "./WalletViewModal";
 import { ConnectorType } from "bi-lib";
 import { DotSamaExtensionStatus, SupportedWalletId } from "substrate-react";
-import { BlockchainNetwork, EthereumWallet, NetworkId, PolkadotWallet, WalletConnectStep } from "../types";
+import {
+  BlockchainNetwork,
+  EthereumWallet,
+  NetworkId,
+  PolkadotWallet,
+  WalletConnectStep,
+} from "../types";
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import BigNumber from "bignumber.js";
 
@@ -24,7 +29,7 @@ export type WalletProps = {
   isEthereumWalletActive: boolean;
   polkadotAccounts: Array<InjectedAccountWithMeta>;
   polkadotExtensionStatus: DotSamaExtensionStatus;
-  connectedWalletTransactions: Array<{ title: string; timestamp: number; }>;
+  connectedWalletTransactions: Array<{ title: string; timestamp: number }>;
   selectedPolkadotAccount: InjectedAccountWithMeta | undefined;
   supportedEthereumWallets: Array<EthereumWallet>;
   supportedPolkadotWallets: Array<PolkadotWallet>;
@@ -47,7 +52,7 @@ export const Wallet: React.FC<WalletProps> = ({
   supportedEthereumWallets,
   connectedAccountNativeBalance,
   connectedWalletTransactions,
-  ethereumConnectorInUse
+  ethereumConnectorInUse,
 }) => {
   const label =
     isEthereumWalletActive || polkadotExtensionStatus === "connected"
@@ -59,13 +64,13 @@ export const Wallet: React.FC<WalletProps> = ({
     WalletConnectStep.SelectNetwork
   );
 
-  const selectedPolkadotWallet = supportedPolkadotWallets.find(x => {
-    return x.walletId === localStorage.getItem("wallet-id")
+  const selectedPolkadotWallet = supportedPolkadotWallets.find((x) => {
+    return x.walletId === localStorage.getItem("wallet-id");
   });
 
-  const selectedEthereumWallet = supportedEthereumWallets.find(x => {
-    return x.walletId === ethereumConnectorInUse
-  })
+  const selectedEthereumWallet = supportedEthereumWallets.find((x) => {
+    return x.walletId === ethereumConnectorInUse;
+  });
 
   return (
     <>
@@ -115,11 +120,11 @@ export const Wallet: React.FC<WalletProps> = ({
         selectedPolkadotWallet={selectedPolkadotWallet}
         onDisconnectDotsamaWallet={onDisconnectDotsamaWallet}
         onDisconnectEthereum={onDisconnectEthereum}
-        ethereumNetwork={blockchainNetworksSupported.find(x => {
-          return x.networkId === NetworkId.Ethereum
+        ethereumNetwork={blockchainNetworksSupported.find((x) => {
+          return x.networkId === NetworkId.Ethereum;
         })}
-        polkadotNetwork={blockchainNetworksSupported.find(x => {
-          return x.networkId === NetworkId.Polkadot
+        polkadotNetwork={blockchainNetworksSupported.find((x) => {
+          return x.networkId === NetworkId.Polkadot;
         })}
         onConnectPolkadot={() => {
           setWalletConnectStep(WalletConnectStep.SelectedDotsamaWallet);
@@ -140,10 +145,9 @@ export const Wallet: React.FC<WalletProps> = ({
         connectedEthereumAccount={ethereumConnectedAccount}
         selectedPolkadotAccount={selectedPolkadotAccount}
         open={isOpenWalletViewModal}
-        onClose={(evt, reason) => {
+        onClose={(_evt, _reason) => {
           setIsOpenWalletViewModal(false);
         }}
-
       />
     </>
   );

--- a/frontend/packages/wallet/components/WalletViewModal.tsx
+++ b/frontend/packages/wallet/components/WalletViewModal.tsx
@@ -13,11 +13,10 @@ import {
   useMediaQuery,
   useTheme,
 } from "@mui/material";
-import React from "react";
 import Image from "next/image";
 import BigNumber from "bignumber.js";
 import { Badge } from "./Atoms/Badge";
-import { useState } from "react";
+import { FC, useState } from "react";
 import { PolkadotAccountView } from "./Molecules/PolkadotAccountView";
 import { BlockchainNetwork, EthereumWallet, PolkadotWallet } from "../types";
 import { EthereumAccountView } from "./Molecules/EthereumAccountView";
@@ -59,7 +58,7 @@ export type WalletViewProps = {
   onConnectEVM: () => void;
 } & DialogProps;
 
-export const WalletViewModal: React.FC<WalletViewProps> = ({
+export const WalletViewModal: FC<WalletViewProps> = ({
   balance,
   polkadotNetwork,
   ethereumNetwork,


### PR DESCRIPTION
## Issue 
https://app.clickup.com/t/34p59rd
https://app.clickup.com/t/3329km5
https://app.clickup.com/t/3pqjn4p
https://app.clickup.com/t/3u4b157
https://app.clickup.com/t/31evhex

## Description
- Fix some UX issue to properly update transfer input
- Fix wallet modal to be closed upon confirming an account
- Fix minValue requirements and error message passing from child/parent
- Update balance updater to (FORNOW) use 6 as decimals for USDT until RPC asset list is ready.
- Update asset mapping and allowed transfers to consider destination chain's supported asset.
- Enable KSM (Statemine => Picasso) and USDT (Picasso => Statemine) transfers. 