### PR TITLE
[CU-35txqkb] Removed AR Overwrite of ED

### DIFF
--- a/code/integration-tests/local-integration-tests/src/assets_integration.rs
+++ b/code/integration-tests/local-integration-tests/src/assets_integration.rs
@@ -15,7 +15,7 @@ fn updated_assets_registry_works_well_for_ratios() {
 			RawOrigin::Root.into(),
 			CurrencyId(42),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
-			Some(Rational64::from(10, 1)),
+			Rational64::from(10, 1),
 			None,
 		)
 		.unwrap();
@@ -23,7 +23,7 @@ fn updated_assets_registry_works_well_for_ratios() {
 			RawOrigin::Root.into(),
 			CurrencyId(123),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(4321)))),
-			Some(Rational64::from(10, 100)),
+			Rational64::from(10, 100),
 			None,
 		)
 		.unwrap();
@@ -46,8 +46,7 @@ fn registered_assets_with_smaller_than_native_price() {
 		AssetsRegistry::register_asset(
 			RawOrigin::Root.into(),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
-			42,
-			Some(Rational64::from(10, 1)),
+			Rational64::from(10, 1),
 			None,
 		)
 		.unwrap();
@@ -77,8 +76,7 @@ fn registered_assets_with_larger_than_native_price() {
 		AssetsRegistry::register_asset(
 			RawOrigin::Root.into(),
 			XcmAssetLocation(MultiLocation::new(1, X1(Parachain(666)))),
-			42,
-			Some(Rational64::from(10, 100)),
+			Rational64::from(10, 100),
 			None,
 		)
 		.unwrap();

--- a/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
+++ b/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
@@ -214,8 +214,7 @@ fn rockmine_shib_to_dali_transfer() {
 		AssetsRegistry::register_asset(
 			root.into(),
 			location.clone(),
-			1000,
-			Some(Rational64::from(15, 1000)),
+			Rational64::from(15, 1000),
 			Some(4),
 		)
 		.unwrap();
@@ -320,8 +319,7 @@ fn rockmine_stable_to_dali_transfer() {
 		AssetsRegistry::register_asset(
 			root.into(),
 			location.clone(),
-			1,
-			Some(ratio),
+			ratio,
 			Some(STABLE::EXPONENT),
 		)
 		.unwrap();
@@ -384,7 +382,7 @@ fn this_chain_statemine_transfers_back_and_forth_work() {
 	let relay_native_asset_amount = 3 * FEE_WEIGHT_THIS + 3 * FEE_NATIVE_KUSAMA;
 	let remote_asset_id = 3451561; // magic number to avoid zero defaults and easy to find
 	let foreign_asset_id_on_this =
-		register_statemine_asset(remote_asset_id, Some(Rational64::from(10, 100)));
+		register_statemine_asset(remote_asset_id, Rational64::from(10, 100));
 
 	statemine_side(TEN + relay_native_asset_amount, remote_asset_id);
 	let statemine_native_this_balance_1 =
@@ -570,10 +568,7 @@ fn statemine_side(this_parachain_account_init_amount: u128, statemine_asset_id: 
 	});
 }
 
-fn register_statemine_asset(
-	remote_asset_id: CommonAssetId,
-	ratio: Option<Rational64>,
-) -> CurrencyId {
+fn register_statemine_asset(remote_asset_id: CommonAssetId, ratio: Rational64) -> CurrencyId {
 	This::execute_with(|| {
 		use this_runtime::*;
 		let location = XcmAssetLocation::new(
@@ -590,7 +585,6 @@ fn register_statemine_asset(
 		AssetsRegistry::register_asset(
 			frame_system::RawOrigin::Root.into(),
 			location.clone(),
-			42,
 			ratio,
 			None,
 		)

--- a/code/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
+++ b/code/integration-tests/local-integration-tests/src/cross_chain_transfer.rs
@@ -140,7 +140,7 @@ fn transfer_this_native_to_sibling_overridden() {
 				1,
 				X1(Parachain(THIS_PARA_ID),)
 			)),
-			Some(rational!(1 / 1)),
+			rational!(1 / 1),
 			None,
 		));
 	});
@@ -190,7 +190,7 @@ fn transfer_non_native_reserve_asset_from_this_to_sibling() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(CurrencyId::PBLO.into()),)
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		));
 	});
@@ -235,7 +235,7 @@ fn transfer_non_native_reserve_asset_from_this_to_sibling_by_local_id_overridden
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(CurrencyId::PBLO.into()),)
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		));
 	});
@@ -284,14 +284,8 @@ fn this_native_transferred_from_sibling_to_native_is_not_enough() {
 		let root = frame_system::RawOrigin::Root;
 		let location =
 			XcmAssetLocation::new(MultiLocation::new(1, X1(Parachain(THIS_PARA_ID))).into());
-		AssetsRegistry::register_asset(
-			root.into(),
-			location.clone(),
-			1000,
-			Some(Rational64::one()),
-			None,
-		)
-		.unwrap();
+		AssetsRegistry::register_asset(root.into(), location.clone(), Rational64::one(), None)
+			.unwrap();
 		System::events()
 			.iter()
 			.find_map(|x| match x.event {
@@ -986,7 +980,7 @@ fn sibling_trap_assets_works() {
 			RawOrigin::Root.into(),
 			any_asset,
 			remote,
-			Some(Rational64::one()),
+			Rational64::one(),
 			None
 		));
 		(balance, sibling_non_native_amount)
@@ -1052,7 +1046,7 @@ fn sibling_shib_to_transfer() {
 		log::info!(target: "bdd", "Given SHIB on sibling registered");
 		use sibling_runtime::*;
 		let sibling_asset_id =
-			CurrencyFactory::create(RangeId::TOKENS, 42).expect("Valid range and ED; QED");
+			CurrencyFactory::create(RangeId::TOKENS).expect("Valid range and ED; QED");
 		let root = frame_system::RawOrigin::Root;
 		let location = XcmAssetLocation(MultiLocation::new(
 			1,
@@ -1062,7 +1056,7 @@ fn sibling_shib_to_transfer() {
 			root.into(),
 			sibling_asset_id,
 			location,
-			Some(Rational64::one()),
+			Rational64::one(),
 			Some(SHIB::EXPONENT),
 		)
 		.expect("Asset already in Currency Factory; QED");
@@ -1091,8 +1085,7 @@ fn sibling_shib_to_transfer() {
 		AssetsRegistry::register_asset(
 			root.into(),
 			location,
-			1000,
-			Some(Rational64::one()),
+			Rational64::one(),
 			Some(SHIB::EXPONENT),
 		)
 		.expect("Asset details are valid; QED");

--- a/code/integration-tests/local-integration-tests/src/errors.rs
+++ b/code/integration-tests/local-integration-tests/src/errors.rs
@@ -5,17 +5,12 @@ use crate::{
 };
 
 use common::Balance;
-use composable_traits::currency::{
-	AssetDataMutate, AssetExistentialDepositInspect, AssetRatioInspect,
-};
+use composable_traits::currency::AssetRatioInspect;
 use orml_traits::MultiCurrency;
 use xcm::VersionedMultiAsset;
 
 /// under ED, but above Weight
-pub fn under_existential_deposit<
-	AssetsRegistry: AssetRatioInspect<AssetId = CurrencyId>
-		+ AssetExistentialDepositInspect<AssetId = CurrencyId, Balance = Balance>,
->(
+pub fn under_existential_deposit<AssetsRegistry: AssetRatioInspect<AssetId = CurrencyId>>(
 	asset_id: LocalAssetId,
 	_instruction_count: usize,
 ) -> Balance {
@@ -145,14 +140,10 @@ fn cannot_reserver_transfer_assets_when_fee_and_non_fee_has_different_origin() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		)
 		.unwrap();
-		<CurrencyFactory as AssetDataMutate>::update_existential_deposit(
-			CurrencyId(100500),
-			Some(42),
-		);
 		assert_ok!(Tokens::deposit(CurrencyId(100500), &alice().into(), 2 * transfer_amount));
 
 		AssetsRegistry::update_asset(
@@ -162,14 +153,10 @@ fn cannot_reserver_transfer_assets_when_fee_and_non_fee_has_different_origin() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(123_666)),
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		)
 		.unwrap();
-		<CurrencyFactory as AssetDataMutate>::update_existential_deposit(
-			CurrencyId(123_666),
-			Some(42),
-		);
 		assert_ok!(Tokens::deposit(CurrencyId(123_666), &alice().into(), 2 * transfer_amount));
 
 		let before = Assets::free_balance(CurrencyId::KSM, &alice().into());
@@ -224,14 +211,10 @@ fn transfer_existing_asset_but_with_relevant_outgoing_fee_by_local_id() {
 				1,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		)
 		.unwrap();
-		<CurrencyFactory as AssetDataMutate>::update_existential_deposit(
-			CurrencyId(100500),
-			Some(42),
-		);
 
 		assert_ok!(Tokens::deposit(CurrencyId(100500), &alice().into(), 2 * transfer_amount));
 
@@ -275,14 +258,10 @@ fn cannot_transfer_away_if_min_fee_is_not_defined() {
 				1,
 				X2(Parachain(SIBLING_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		)
 		.unwrap();
-		<CurrencyFactory as AssetDataMutate>::update_existential_deposit(
-			CurrencyId(100500),
-			Some(42),
-		);
 		assert_ok!(Tokens::deposit(CurrencyId(100500), &alice().into(), 2 * transfer_amount));
 
 		AssetsRegistry::set_min_fee(
@@ -341,14 +320,10 @@ fn cannot_reserver_transfer_assets_from_self() {
 				0,
 				X2(Parachain(THIS_PARA_ID), GeneralIndex(100500)),
 			)),
-			Some(Rational64::one()),
+			Rational64::one(),
 			None,
 		)
 		.unwrap();
-		<CurrencyFactory as AssetDataMutate>::update_existential_deposit(
-			CurrencyId(100500),
-			Some(42),
-		);
 
 		assert_ok!(Tokens::deposit(CurrencyId(100500), &alice().into(), 2 * transfer_amount));
 

--- a/code/parachain/frame/assets-registry/src/benchmarking.rs
+++ b/code/parachain/frame/assets-registry/src/benchmarking.rs
@@ -20,23 +20,21 @@ benchmarks! {
 
 	register_asset {
 		let location = T::ForeignAssetId::decode(&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..]).unwrap();
-		let ed = 42_u64.into();
 		let ratio = rational!(42 / 123);
 		let decimals = 3;
 
-	}: _(RawOrigin::Root, location, ed, Some(ratio), Some(decimals))
+	}: _(RawOrigin::Root, location, ratio, Some(decimals))
 
 	update_asset {
 		let location = T::ForeignAssetId::decode(&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..]).unwrap();
-		let ed = 42_u64.into();
 		let ratio = rational!(42 / 123);
 		let decimals = 3;
 
-		AssetsRegistry::<T>::register_asset(RawOrigin::Root.into(), location.clone(), ed, Some(ratio), Some(decimals)).unwrap();
+		AssetsRegistry::<T>::register_asset(RawOrigin::Root.into(), location.clone(), ratio, Some(decimals)).unwrap();
 
 		let local_asset_id = AssetsRegistry::<T>::from_foreign_asset(location.clone()).unwrap();
 
-	}: _(RawOrigin::Root, local_asset_id, location, Some(rational!(42 / 123)), Some(3))
+	}: _(RawOrigin::Root, local_asset_id, location, rational!(42 / 123), Some(3))
 
 	set_min_fee {
 		let target_parachain_id = 100_u32.into();

--- a/code/parachain/frame/assets-registry/src/tests.rs
+++ b/code/parachain/frame/assets-registry/src/tests.rs
@@ -25,8 +25,7 @@ fn set_metadata() {
 		assert_ok!(AssetsRegistry::register_asset(
 			RawOrigin::Root.into(),
 			XcmAssetLocation::RELAY_NATIVE,
-			42,
-			Some(rational!(42 / 123)),
+			rational!(42 / 123),
 			Some(4)
 		));
 		let asset_id = System::events()
@@ -66,7 +65,6 @@ fn register_asset() {
 			&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..],
 		)
 		.unwrap();
-		let ed = 42_u64.into();
 		let ratio = rational!(42 / 123);
 		let decimals = 3;
 
@@ -75,8 +73,7 @@ fn register_asset() {
 		assert_ok!(AssetsRegistry::register_asset(
 			Origin::root(),
 			location.clone(),
-			ed,
-			Some(ratio),
+			ratio,
 			Some(decimals)
 		));
 		let local_asset_id = AssetsRegistry::from_foreign_asset(location.clone()).unwrap();
@@ -86,13 +83,7 @@ fn register_asset() {
 		);
 
 		assert_noop!(
-			AssetsRegistry::register_asset(
-				Origin::root(),
-				location,
-				ed,
-				Some(ratio),
-				Some(decimals)
-			),
+			AssetsRegistry::register_asset(Origin::root(), location, ratio, Some(decimals)),
 			Error::<Runtime>::ForeignAssetAlreadyRegistered
 		);
 	})
@@ -105,15 +96,13 @@ fn update_asset() {
 			&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..],
 		)
 		.unwrap();
-		let ed = 42_u64.into();
 		let ratio = rational!(42 / 123);
 		let decimals = 3;
 
 		assert_ok!(AssetsRegistry::register_asset(
 			Origin::root(),
 			location.clone(),
-			ed,
-			Some(ratio),
+			ratio,
 			Some(decimals)
 		));
 
@@ -130,7 +119,7 @@ fn update_asset() {
 			Origin::root(),
 			local_asset_id,
 			location.clone(),
-			Some(new_ratio),
+			new_ratio,
 			Some(new_decimals)
 		));
 		assert_eq!(
@@ -174,7 +163,6 @@ fn get_foreign_assets_list_should_work() {
 			&mut &XcmAssetLocation::RELAY_NATIVE.encode()[..],
 		)
 		.unwrap();
-		let ed = 42_u64.into();
 		let ratio = rational!(42 / 123);
 		let decimals = 3;
 
@@ -185,8 +173,7 @@ fn get_foreign_assets_list_should_work() {
 		assert_ok!(AssetsRegistry::register_asset(
 			Origin::root(),
 			location.clone(),
-			ed,
-			Some(ratio),
+			ratio,
 			Some(decimals)
 		));
 

--- a/code/parachain/frame/assets/src/lib.rs
+++ b/code/parachain/frame/assets/src/lib.rs
@@ -292,8 +292,7 @@ pub mod pallet {
 			dest: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			// TODO: pass non zero from creators
-			let id = T::GenerateCurrencyId::create(RangeId::TOKENS, T::Balance::default())?;
+			let id = T::GenerateCurrencyId::create(RangeId::TOKENS)?;
 			let dest = T::Lookup::lookup(dest)?;
 			<Self as Mutate<T::AccountId>>::mint_into(id, &dest, amount)?;
 			Ok(().into())
@@ -311,7 +310,7 @@ pub mod pallet {
 			dest: <T::Lookup as StaticLookup>::Source,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
-			let id = T::GenerateCurrencyId::create(RangeId::TOKENS, T::Balance::default())?;
+			let id = T::GenerateCurrencyId::create(RangeId::TOKENS)?;
 			let governance_origin = T::Lookup::lookup(governance_origin)?;
 			T::GovernanceRegistry::set(id, SignedRawOrigin::Signed(governance_origin));
 			let dest = T::Lookup::lookup(dest)?;

--- a/code/parachain/frame/assets/src/mocks.rs
+++ b/code/parachain/frame/assets/src/mocks.rs
@@ -73,7 +73,7 @@ impl CurrencyFactory for CurrencyIdGenerator {
 	type AssetId = AssetId;
 	type Balance = Balance;
 
-	fn create(_: RangeId, _: Self::Balance) -> Result<Self::AssetId, sp_runtime::DispatchError> {
+	fn create(_: RangeId) -> Result<Self::AssetId, sp_runtime::DispatchError> {
 		Ok(1)
 	}
 

--- a/code/parachain/frame/composable-traits/src/currency.rs
+++ b/code/parachain/frame/composable-traits/src/currency.rs
@@ -20,9 +20,9 @@ pub trait CurrencyFactory {
 	type Balance;
 
 	/// permissionless creation of new transferable asset id
-	fn create(id: RangeId, ed: Self::Balance) -> Result<Self::AssetId, DispatchError>;
-	fn reserve_lp_token_id(ed: Self::Balance) -> Result<Self::AssetId, DispatchError> {
-		Self::create(RangeId::LP_TOKENS, ed)
+	fn create(id: RangeId) -> Result<Self::AssetId, DispatchError>;
+	fn reserve_lp_token_id() -> Result<Self::AssetId, DispatchError> {
+		Self::create(RangeId::LP_TOKENS)
 	}
 	/// Given a `u32` ID (within the range of `0` to `u32::MAX`) returns a unique `AssetId` reserved
 	/// by Currency Factory for the runtime.

--- a/code/parachain/frame/composable-traits/src/xcm/assets.rs
+++ b/code/parachain/frame/composable-traits/src/xcm/assets.rs
@@ -111,7 +111,7 @@ pub trait RemoteAssetRegistryMutate {
 	fn set_reserve_location(
 		asset_id: Self::AssetId,
 		location: Self::AssetNativeLocation,
-		ratio: Option<Rational64>,
+		ratio: Rational64,
 		decimals: Option<Exponent>,
 	) -> DispatchResult;
 

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -129,7 +129,7 @@ impl CurrencyFactory for CurrencyIdGenerator {
 	type AssetId = CurrencyId;
 	type Balance = Balance;
 
-	fn create(_: RangeId, _: Self::Balance) -> Result<Self::AssetId, sp_runtime::DispatchError> {
+	fn create(_: RangeId) -> Result<Self::AssetId, sp_runtime::DispatchError> {
 		Ok(CurrencyId(1))
 	}
 

--- a/code/parachain/frame/currency-factory/src/benchmarking.rs
+++ b/code/parachain/frame/currency-factory/src/benchmarking.rs
@@ -28,7 +28,7 @@ benchmarks! {
 	}: _(RawOrigin::Root, 100000000000000)
 	set_metadata {
 		currency_factory::Pallet::<T>::add_range(RawOrigin::Root.into(), 0).unwrap();
-		let asset_id = <currency_factory::Pallet::<T> as DeFiCurrencyFactory>::create(RangeId::from(0), T::Balance::default()).unwrap();
+		let asset_id = <currency_factory::Pallet::<T> as DeFiCurrencyFactory>::create(RangeId::from(0)).unwrap();
 		let metadata = BasicAssetMetadata::try_from(b"SMB", b"Symbol Name").unwrap();
 	}: {
 		currency_factory::Pallet::<T>::set_metadata(RawOrigin::Root.into(), asset_id,  metadata).unwrap();

--- a/code/parachain/frame/currency-factory/src/lib.rs
+++ b/code/parachain/frame/currency-factory/src/lib.rs
@@ -111,6 +111,10 @@ pub mod pallet {
 	pub type AssetIdRanges<T: Config> =
 		StorageValue<_, Ranges<T::AssetId>, ValueQuery, RangesOnEmpty<T>>;
 
+	#[pallet::storage]
+	#[pallet::getter(fn get_assets_ed)]
+	pub type AssetEd<T: Config> = StorageMap<_, Twox128, T::AssetId, T::Balance, OptionQuery>;
+
 	// technically that can be stored offchain, but other parachains do int on chain too (and some
 	// other blockchains) also may do routing for approved symbols based, not on ids, too
 	#[pallet::storage]

--- a/code/parachain/frame/currency-factory/src/lib.rs
+++ b/code/parachain/frame/currency-factory/src/lib.rs
@@ -55,10 +55,7 @@ pub mod pallet {
 	};
 	use composable_traits::{
 		assets::BasicAssetMetadata,
-		currency::{
-			AssetExistentialDepositInspect, AssetIdLike, BalanceLike, CurrencyFactory, Exponent,
-			LocalAssets,
-		},
+		currency::{AssetIdLike, BalanceLike, CurrencyFactory, Exponent, LocalAssets},
 	};
 	use frame_support::{pallet_prelude::*, traits::EnsureOrigin, transactional, PalletId};
 	use frame_system::pallet_prelude::*;
@@ -114,10 +111,6 @@ pub mod pallet {
 	pub type AssetIdRanges<T: Config> =
 		StorageValue<_, Ranges<T::AssetId>, ValueQuery, RangesOnEmpty<T>>;
 
-	#[pallet::storage]
-	#[pallet::getter(fn get_assets_ed)]
-	pub type AssetEd<T: Config> = StorageMap<_, Twox128, T::AssetId, T::Balance, OptionQuery>;
-
 	// technically that can be stored offchain, but other parachains do int on chain too (and some
 	// other blockchains) also may do routing for approved symbols based, not on ids, too
 	#[pallet::storage]
@@ -160,14 +153,10 @@ pub mod pallet {
 			metadata: BasicAssetMetadata,
 		) -> DispatchResultWithPostInfo {
 			T::AddOrigin::ensure_origin(origin)?;
-			if AssetEd::<T>::get(asset_id).is_some() {
-				// note: if will decide to build route on symbol, than better to make second map
-				// from symbol to asset to check unique
-				AssetMetadata::<T>::insert(asset_id, metadata);
-				Ok(().into())
-			} else {
-				Err(Error::<T>::AssetNotFound.into())
-			}
+			// note: if will decide to build route on symbol, than better to make second map
+			// from symbol to asset to check unique
+			AssetMetadata::<T>::insert(asset_id, metadata);
+			Ok(().into())
 		}
 	}
 
@@ -176,9 +165,8 @@ pub mod pallet {
 		type Balance = T::Balance;
 
 		#[transactional]
-		fn create(id: RangeId, ed: Self::Balance) -> Result<Self::AssetId, DispatchError> {
+		fn create(id: RangeId) -> Result<Self::AssetId, DispatchError> {
 			let asset_id = AssetIdRanges::<T>::mutate(|range| range.increment(id))?;
-			AssetEd::<T>::insert(asset_id, ed);
 			Ok(asset_id)
 		}
 
@@ -198,24 +186,6 @@ pub mod pallet {
 		fn unique_asset_id_to_protocol_asset_id(unique_asset_id: Self::AssetId) -> u32 {
 			u32::try_from(unique_asset_id.into() % u32::MAX as u128)
 				.expect("u128 is made of u32 chunks")
-		}
-	}
-
-	impl<T: Config> AssetExistentialDepositInspect for Pallet<T> {
-		type AssetId = T::AssetId;
-		type Balance = T::Balance;
-
-		fn existential_deposit(asset_id: Self::AssetId) -> Result<Self::Balance, DispatchError> {
-			AssetEd::<T>::get(asset_id).ok_or_else(|| Error::<T>::AssetNotFound.into())
-		}
-	}
-
-	impl<T: Config> composable_traits::currency::AssetDataMutate for Pallet<T> {
-		type AssetId = T::AssetId;
-		type Balance = T::Balance;
-
-		fn update_existential_deposit(asset_id: Self::AssetId, ed: Option<Self::Balance>) {
-			AssetEd::<T>::set(asset_id, ed)
 		}
 	}
 

--- a/code/parachain/frame/currency-factory/src/tests.rs
+++ b/code/parachain/frame/currency-factory/src/tests.rs
@@ -44,7 +44,7 @@ proptest! {
 	) {
 		new_test_ext().execute_with(|| {
 			for _ in 0..30 {
-				let res = <CurrencyRanges as CurrencyFactory>::create(RangeId::from(range), 42);
+				let res = <CurrencyRanges as CurrencyFactory>::create(RangeId::from(range));
 				prop_assert_ok!(res);
 
 			}
@@ -59,7 +59,7 @@ proptest! {
 		new_test_ext().execute_with(|| {
 			let mut prev = None;
 			for _ in 0..i {
-				let res = <CurrencyRanges as CurrencyFactory>::create(RangeId::TOKENS, 42);
+				let res = <CurrencyRanges as CurrencyFactory>::create(RangeId::TOKENS);
 				prop_assert_ok!(res);
 				if let Some(prev) = prev {
 					prop_assert_eq!(prev + 1, res.unwrap())

--- a/code/parachain/frame/lending/src/helpers/market.rs
+++ b/code/parachain/frame/lending/src/helpers/market.rs
@@ -86,8 +86,7 @@ impl<T: Config> Pallet<T> {
 					.under_collateralized_warn_percent,
 				liquidators: config_input.updatable.liquidators,
 			};
-			// TODO: pass ED from API,
-			let debt_token_id = T::CurrencyFactory::reserve_lp_token_id(T::Balance::default())?;
+			let debt_token_id = T::CurrencyFactory::reserve_lp_token_id()?;
 
 			DebtTokenForMarket::<T>::insert(market_id, debt_token_id);
 			Markets::<T>::insert(market_id, market_config);

--- a/code/parachain/frame/pablo/src/dual_asset_constant_product.rs
+++ b/code/parachain/frame/pablo/src/dual_asset_constant_product.rs
@@ -39,7 +39,7 @@ impl<T: Config> DualAssetConstantProduct<T> {
 		);
 		ensure!(fee_config.fee_rate < Permill::one(), Error::<T>::InvalidFees);
 
-		let lp_token = T::CurrencyFactory::create(RangeId::LP_TOKENS, T::Balance::default())?;
+		let lp_token = T::CurrencyFactory::create(RangeId::LP_TOKENS)?;
 		// Add new pool
 		let pool_id =
 			PoolCount::<T>::try_mutate(|pool_count| -> Result<T::PoolId, DispatchError> {

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -763,7 +763,7 @@ pub mod pallet {
 			match token_id {
 				x if x == T::PicaAssetId::get() => Ok(T::XPicaAssetId::get()),
 				x if x == T::PbloAssetId::get() => Ok(T::XPbloAssetId::get()),
-				_ => Ok(T::CurrencyFactory::create(RangeId::XTOKEN_ASSETS, T::Balance::default())?),
+				_ => Ok(T::CurrencyFactory::create(RangeId::XTOKEN_ASSETS)?),
 			}
 		}
 
@@ -778,7 +778,7 @@ pub mod pallet {
 			match token_id {
 				x if x == T::PicaAssetId::get() => Ok(T::PicaStakeFinancialNftCollectionId::get()),
 				x if x == T::PbloAssetId::get() => Ok(T::PbloStakeFinancialNftCollectionId::get()),
-				_ => Ok(T::CurrencyFactory::create(RangeId::FNFT_ASSETS, T::Balance::default())?),
+				_ => Ok(T::CurrencyFactory::create(RangeId::FNFT_ASSETS)?),
 			}
 		}
 

--- a/code/parachain/frame/vault/src/lib.rs
+++ b/code/parachain/frame/vault/src/lib.rs
@@ -675,7 +675,7 @@ pub mod pallet {
 				);
 
 				let lp_token_id = {
-					T::CurrencyFactory::create(RangeId::LP_TOKENS, T::Balance::zero())
+					T::CurrencyFactory::create(RangeId::LP_TOKENS)
 						.map_err(|_| Error::<T>::CannotCreateAsset)?
 				};
 

--- a/code/parachain/frame/vault/src/mocks/currency_factory.rs
+++ b/code/parachain/frame/vault/src/mocks/currency_factory.rs
@@ -79,7 +79,7 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		#[pallet::weight(10_000)]
 		pub fn create(_origin: OriginFor<T>, id: RangeId) -> DispatchResultWithPostInfo {
-			let currency_id = <Self as CurrencyFactory>::create(id, T::Balance::default())?;
+			let currency_id = <Self as CurrencyFactory>::create(id)?;
 			Self::deposit_event(Event::Created(currency_id));
 			Ok(().into())
 		}
@@ -89,7 +89,7 @@ pub mod pallet {
 		type AssetId = MockCurrencyId;
 		type Balance = T::Balance;
 
-		fn create(_: RangeId, _: Self::Balance) -> Result<Self::AssetId, DispatchError> {
+		fn create(_: RangeId) -> Result<Self::AssetId, DispatchError> {
 			let lp_token_id = CurrencyCounter::<T>::mutate(|c| {
 				*c += 1;
 				*c

--- a/code/parachain/runtime/common/src/fees.rs
+++ b/code/parachain/runtime/common/src/fees.rs
@@ -128,10 +128,6 @@ mod commons_sense {
 	impl AssetRatioInspect for Dummy {
 		type AssetId = CurrencyId;
 	}
-	impl AssetExistentialDepositInspect for Dummy {
-		type AssetId = CurrencyId;
-		type Balance = Balance;
-	}
 
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	#[test]


### PR DESCRIPTION
## Issue

[[CU-35txqkb]](https://app.clickup.com/t/35txqkb)
[[CU-35txtwh]](https://app.clickup.com/t/35txtwh)

## Additional Changes

* `WellKnownForeignToNativePriceConverter::to_asset_balance()` now returns `None` instead of `Balance::one()` when encountering an `ArithmeticError` 
* Currency Factory no longer accepts or tracks ED when creating or storing assets. Given that the storage map for ED was independent of any other storage items, it should not need any storage migrations when getting removed.