### PR TITLE
start replacing github rules with mergify to scale monorepo

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,8 @@ pull_request_rules:
       - and:
         - "#approved-reviews-by>=2"
         - base=main
+        - not:
+          - title~=#wip
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,12 +1,17 @@
 queue_rules:
  - name: default
    allow_inplace_checks: false
-   conditions: []
+   conditions: 
+     - and:
+       - not:
+         - title~=#wip
 
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - base=main
+      - and:
+        - "#approved-reviews-by>=2"
+        - base=main
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,18 +2,16 @@ queue_rules:
  - name: default
    allow_inplace_checks: false
    conditions: 
-     - and:
-       - not:
-         - title~=#wip
+     - not:
+       - title~="#wip"
 
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - and:
-        - "#approved-reviews-by>=2"
-        - base=main
-        - not:
-          - title~=#wip
+      - "#approved-reviews-by>=2"
+      - base=main
+      - not:
+        - title~="#wip"
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,16 +2,14 @@ queue_rules:
   - name: default
     allow_inplace_checks: false
     conditions:
-      - not:
-          - title~="#wip"
+      - -title~="#wip"
 
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - "#approved-reviews-by>=2"
       - base=main
-      - not:
-          - title~="#wip"
+      - -title~="#wip"
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,9 +1,9 @@
 queue_rules:
- - name: default
-   allow_inplace_checks: false
-   conditions: 
-     - not:
-       - title~="#wip"
+  - name: default
+    allow_inplace_checks: false
+    conditions:
+      - not:
+          - title~="#wip"
 
 pull_request_rules:
   - name: Automatic merge on approval
@@ -11,7 +11,7 @@ pull_request_rules:
       - "#approved-reviews-by>=2"
       - base=main
       - not:
-        - title~="#wip"
+          - title~="#wip"
     actions:
       queue:
         name: default


### PR DESCRIPTION
Signed-off-by: Dzmitry Lahoda <dzmitry@lahoda.pro>

## Issue

Basic to expand monorepo(rfc?) for many teams which want to develop faster.

Monorepo does not mean all must use same tooling, same nix, same merge rules, same security level.

```
Configuration changed. This pull request must be merged manually — 1 potential rule
⚠️ The configuration has been changed, queue and merge actions are ignored. ⚠️
```

## Notes

why hash tags instead of tags? sure people can use both - just encoded one variant of tagging (twitter tags are right, gh tags are clumsy)

## Checklist

- all PR merged as before with semantics for rules
- PRs with #wip title are not queued