### PR TITLE
Added zlib to dev-shell to fix cargo nightly

### DIFF
--- a/dev-shells.nix
+++ b/dev-shells.nix
@@ -11,8 +11,11 @@
           buildInputs = base.buildInputs
             ++ (with pkgs; [ clang nodejs python3 yarn ])
             ++ (with self'.packages; [ rust-nightly ]);
-          LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath
-            (with pkgs; [ stdenv.cc.cc.lib llvmPackages.libclang.lib ]);
+          LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath (with pkgs; [
+            stdenv.cc.cc.lib
+            llvmPackages.libclang.lib
+            pkgs.zlib
+          ]);
           LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
           PROTOC = "${pkgs.protobuf}/bin/protoc";
           ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";


### PR DESCRIPTION
## Issue

Can't run things with cargo +nightly (i.e `SKIP_WASM_BUILD=1 bacon clippy -- --all --tests`)

## Additional Changes

Added zlib to dev-shell. Fix inspired by [this](https://github.com/oxalica/rust-overlay/issues/54#issuecomment-1223758506)

Concerns: bacon ran with `SKIP_WASM_BUILD=1 bacon clippy -- --all --tests` is reporting many things on main as errors with this fix, which does not match with CI (20 errors, 1918 warnings :face_with_spiral_eyes: )

Note, this is probably a naive fix - feel free to correct/roast