### PR TITLE
Release title to indicate RC or not

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -168,6 +168,9 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           body_path: release-artifacts/release.txt
+          # Every release is assumed to be a release candidate("RC") until a runtime upgrade is made,
+          # upon which this needs to be manually set to exclude "RC" postfix
+          name: v${{ env.COMPOSABLE_VERSION }}-RC
           tag_name: v${{ env.COMPOSABLE_VERSION }}
           target_commitish: ${{ steps.fetch_commit_sha.outputs.sha }}
           files: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -171,6 +171,7 @@ jobs:
           # Every release is assumed to be a release candidate("RC") until a runtime upgrade is made,
           # upon which this needs to be manually set to exclude "RC" postfix
           name: v${{ env.COMPOSABLE_VERSION }}-RC
+          prerelease: true
           tag_name: v${{ env.COMPOSABLE_VERSION }}
           target_commitish: ${{ steps.fetch_commit_sha.outputs.sha }}
           files: |


### PR DESCRIPTION
External parties must be able to distinguish between live releases with runtime upgrades made vs not.