### PR TITLE
Integration Tests: Re- enabling KSM XCM Tests & minor doc, clean code fixes

### DIFF
--- a/code/integration-tests/runtime-tests/test/tests/xcmp/test_configuration.json
+++ b/code/integration-tests/runtime-tests/test/tests/xcmp/test_configuration.json
@@ -1,5 +1,5 @@
 {
   "enabledTests": {
-    "enabled": false
+    "enabled": true
   }
 }

--- a/code/integration-tests/runtime-tests/test/tests/xcmp/transfers.ts
+++ b/code/integration-tests/runtime-tests/test/tests/xcmp/transfers.ts
@@ -13,9 +13,8 @@ import { u128 } from "@polkadot/types-codec";
 /**
  * Contains tests for the XCMP system.
  *
- * 1. Transferring funds from 'RelayChain (KSM)' to Picasso/Dali
+ * 1. Transferring (KSM) funds from 'RelayChain (Kusama)' to Picasso/Dali
  * 2. The other way around with KSM.
- * 3. Again from Picasso/Dali to RelayChain with PICA.
  */
 describe("[SHORT][LAUNCH] tx.xcmp Tests", function () {
   if (!testConfiguration.enabledTests.enabled) return;
@@ -54,10 +53,7 @@ describe("[SHORT][LAUNCH] tx.xcmp Tests", function () {
     });
     assetId = 4;
     ksmAssetID = api.createType("SafeRpcWrapper", assetId) as SafeRpcWrapper;
-  });
 
-  before("Providing assets for tests", async function () {
-    this.timeout(2 * 60 * 1000);
     await mintAssetsToWallet(api, walletAlice, walletAlice, [1]);
   });
 
@@ -75,7 +71,7 @@ describe("[SHORT][LAUNCH] tx.xcmp Tests", function () {
   describe("xcmPallet.reserveTransferAssets Success Test", function () {
     // Timeout set to 2 minutes
     this.timeout(10 * 60 * 1000);
-    it("Can transfer asset(kUSD) from relay chain(KSM) to Picasso", async function () {
+    it("Can transfer asset(KSM) from relay chain(Kusama) to Picasso", async function () {
       // Setting the destination chain to Picasso/Dali
       const destination = relayChainApiClient.createType("XcmVersionedMultiLocation", {
         V0: relayChainApiClient.createType("XcmV0MultiLocation", {
@@ -160,7 +156,7 @@ describe("[SHORT][LAUNCH] tx.xcmp Tests", function () {
     // Timeout set to 2 minutes
     this.timeout(10 * 60 * 1000);
 
-    it("Can transfer KSM from Picasso to relay chain", async function () {
+    it("Can transfer asset(KSM) from Picasso to relay chain(Kusama).", async function () {
       //Set amount to transfer
       const amountToTransfer = relayChainApiClient.createType("u128", 10000000000000);
 


### PR DESCRIPTION
## Issue

Would be great if i could create a ClickUp ticket, right?
XCM Integration Tests for Kusama test transfers were disabled last week due to an issue, that couldn't be reproduced.
Therefore re- enabling them here & hoping for the best.

## Additional Changes

The code comments were partially wrong / misleading, and there was a double `before` block. Which by current integration test standards we're trying to avoid.

## Checklist

~~- [ ] Updated the rust/typescript docs.~~
~~- [ ] Updated the `docs/`.~~