### PR TITLE
Include `pallet-ibc` in dali runtime #NX-37

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -718,14 +718,37 @@ dependencies = [
 [[package]]
 name = "beefy-light-client"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
 dependencies = [
- "beefy-light-client-primitives",
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "beefy-primitives",
  "ckb-merkle-mountain-range",
  "derive_more",
  "frame-support",
- "light-client-common",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "pallet-beefy-mmr",
+ "pallet-mmr",
+ "parity-scale-codec",
+ "rs_merkle",
+ "sp-core",
+ "sp-core-hashing",
+ "sp-mmr-primitives",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+]
+
+[[package]]
+name = "beefy-light-client"
+version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+dependencies = [
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "beefy-primitives",
+ "ckb-merkle-mountain-range",
+ "derive_more",
+ "frame-support",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "pallet-beefy-mmr",
  "pallet-mmr",
  "parity-scale-codec",
@@ -741,12 +764,28 @@ dependencies = [
 [[package]]
 name = "beefy-light-client-primitives"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "beefy-primitives",
+ "ckb-merkle-mountain-range",
+ "derive_more",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "rs_merkle",
+ "sp-core",
+ "sp-mmr-primitives",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+]
+
+[[package]]
+name = "beefy-light-client-primitives"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "beefy-primitives",
  "ckb-merkle-mountain-range",
  "derive_more",
- "light-client-common",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "rs_merkle",
  "sp-core",
@@ -1607,6 +1646,7 @@ dependencies = [
  "pablo-runtime-api",
  "pallet-assets 1.0.0",
  "pallet-crowdloan-rewards",
+ "pallet-ibc 0.0.1 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "pallet-transaction-payment-rpc",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
@@ -3187,6 +3227,9 @@ dependencies = [
  "frame-system-rpc-runtime-api",
  "hex",
  "hex-literal",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-runtime-api",
  "lending-runtime-api",
  "orml-tokens",
  "orml-traits",
@@ -3212,6 +3255,8 @@ dependencies = [
  "pallet-dutch-auction",
  "pallet-fnft",
  "pallet-governance-registry",
+ "pallet-ibc 0.0.1 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "pallet-ibc-ping",
  "pallet-identity",
  "pallet-indices",
  "pallet-lending",
@@ -3862,9 +3907,9 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9663d381d07ae25dc88dbdf27df458faa83a9b25336bcac83d5e452b5fc9d3"
+checksum = "4e884668cd0c7480504233e951174ddc3b382f7c2666e3b7310b5c4e7b0c37f9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -4607,6 +4652,27 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-primitives"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "finality-grandpa",
+ "frame-support",
+ "hash-db",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-storage 6.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-trie",
+]
+
+[[package]]
+name = "grandpa-light-client-primitives"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "anyhow",
@@ -4614,7 +4680,7 @@ dependencies = [
  "finality-grandpa",
  "frame-support",
  "hash-db",
- "light-client-common",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "sp-core",
  "sp-finality-grandpa",
@@ -4628,14 +4694,35 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-verifier"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "anyhow",
+ "finality-grandpa",
+ "frame-support",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "hash-db",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "primitive-types",
+ "sp-finality-grandpa",
+ "sp-io",
+ "sp-runtime",
+ "sp-state-machine",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+]
+
+[[package]]
+name = "grandpa-light-client-verifier"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "anyhow",
  "finality-grandpa",
  "frame-support",
- "grandpa-light-client-primitives",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "hash-db",
- "light-client-common",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "primitive-types",
  "sp-finality-grandpa",
@@ -4998,9 +5085,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.23.1"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59df7c4e19c950e6e0e868dcc0a300b09a9b88e9ec55bd879ca819087a77355d"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http",
  "hyper 0.14.23",
@@ -5052,12 +5139,38 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.15.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "derive_more",
+ "flex-error",
+ "ibc-derive 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ics23",
+ "num-traits",
+ "parity-scale-codec",
+ "primitive-types",
+ "prost 0.11.3",
+ "safe-regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-proto",
+ "time 0.3.17",
+ "tracing",
+ "uint",
+]
+
+[[package]]
+name = "ibc"
+version = "0.15.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "derive_more",
  "flex-error",
- "ibc-derive",
- "ibc-proto",
+ "ibc-derive 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "ics23",
  "num-traits",
  "parity-scale-codec",
@@ -5078,6 +5191,18 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro-crate 1.2.1",
+ "proc-macro2 1.0.47",
+ "quote 1.0.21",
+ "syn 1.0.105",
+]
+
+[[package]]
+name = "ibc-derive"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "convert_case 0.6.0",
@@ -5090,12 +5215,35 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "base58",
+ "frame-support",
+ "hex",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "ripemd",
+ "scale-info",
+ "serde",
+ "sha2 0.10.6",
+ "sha3",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-runtime-interface",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+]
+
+[[package]]
+name = "ibc-primitives"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "base58",
  "frame-support",
  "hex",
- "ibc",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "ripemd",
  "scale-info",
@@ -5113,6 +5261,18 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.18.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "base64 0.13.1",
+ "bytes 1.3.0",
+ "prost 0.11.3",
+ "serde",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "ibc-proto"
+version = "0.18.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "base64 0.13.1",
@@ -5123,14 +5283,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ibc-runtime-api"
+version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "pallet-ibc 0.0.1 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+]
+
+[[package]]
+name = "ics07-tendermint"
+version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "bytes 1.3.0",
+ "flex-error",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ics23",
+ "prost 0.11.3",
+ "serde",
+ "serde_json",
+ "subtle-encoding",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "tendermint-proto",
+ "time 0.3.17",
+]
+
+[[package]]
 name = "ics07-tendermint"
 version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "bytes 1.3.0",
  "flex-error",
- "ibc",
- "ibc-proto",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "ics23",
  "prost 0.11.3",
  "serde",
@@ -5145,20 +5337,47 @@ dependencies = [
 [[package]]
 name = "ics10-grandpa"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "finality-grandpa",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "grandpa-light-client-verifier 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "primitive-types",
+ "prost 0.11.3",
+ "prost-build 0.11.4",
+ "prost-types 0.11.2",
+ "serde",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-runtime",
+ "sp-trie",
+ "tendermint",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "ics10-grandpa"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "anyhow",
  "derive_more",
  "finality-grandpa",
- "grandpa-light-client-primitives",
- "grandpa-light-client-verifier",
- "ibc",
- "ibc-proto",
- "light-client-common",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "grandpa-light-client-verifier 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "primitive-types",
  "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost-build 0.11.4",
  "prost-types 0.11.2",
  "serde",
  "sp-core",
@@ -5172,21 +5391,49 @@ dependencies = [
 [[package]]
 name = "ics11-beefy"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
 dependencies = [
  "anyhow",
- "beefy-light-client",
- "beefy-light-client-primitives",
+ "beefy-light-client 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "beefy-primitives",
  "bytes 1.3.0",
  "derive_more",
- "ibc",
- "ibc-proto",
- "light-client-common",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "parity-scale-codec",
  "primitive-types",
  "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost-build 0.11.4",
+ "prost-types 0.11.2",
+ "serde",
+ "sp-mmr-primitives",
+ "sp-runtime",
+ "sp-storage 6.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+ "tendermint",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "ics11-beefy"
+version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+dependencies = [
+ "anyhow",
+ "beefy-light-client 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "beefy-primitives",
+ "bytes 1.3.0",
+ "derive_more",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "parity-scale-codec",
+ "primitive-types",
+ "prost 0.11.3",
+ "prost-build 0.11.4",
  "prost-types 0.11.2",
  "serde",
  "sp-mmr-primitives",
@@ -5425,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.5.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88c5561171189e69df9d98bcf18fd5f9558300f7ea7b801eb8a0fd748bd8745"
+checksum = "11b0d96e660696543b251e58030cf9787df56da39dab19ad60eae7353040917e"
 
 [[package]]
 name = "is-terminal"
@@ -6674,12 +6921,28 @@ dependencies = [
 [[package]]
 name = "light-client-common"
 version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "hash-db",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "parity-scale-codec",
+ "primitive-types",
+ "serde",
+ "sp-storage 6.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+]
+
+[[package]]
+name = "light-client-common"
+version = "0.1.0"
 source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
 dependencies = [
  "anyhow",
  "derive_more",
  "hash-db",
- "ibc",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "parity-scale-codec",
  "primitive-types",
  "serde",
@@ -8279,8 +8542,8 @@ dependencies = [
  "frame-support",
  "frame-system",
  "hex",
- "ibc",
- "ibc-primitives",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "lazy_static",
  "libsecp256k1",
  "log 0.4.17",
@@ -8290,7 +8553,7 @@ dependencies = [
  "pallet-assets 1.0.0",
  "pallet-balances",
  "pallet-governance-registry",
- "pallet-ibc",
+ "pallet-ibc 0.0.1 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "pallet-timestamp",
  "parity-scale-codec",
  "parity-wasm 0.45.0",
@@ -8571,25 +8834,71 @@ dependencies = [
 [[package]]
 name = "pallet-ibc"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
 dependencies = [
- "beefy-light-client-primitives",
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "cumulus-primitives-core",
  "derive_more",
  "finality-grandpa",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "grandpa-light-client-primitives",
- "ibc",
- "ibc-derive",
- "ibc-primitives",
- "ibc-proto",
- "ics07-tendermint",
- "ics10-grandpa",
- "ics11-beefy",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "hex",
+ "hex-literal",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-derive 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ics07-tendermint 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ics10-grandpa 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ics11-beefy 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
  "ics23",
- "light-client-common",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "log 0.4.17",
+ "pallet-ibc-ping",
+ "pallet-timestamp",
+ "parachain-info",
+ "parity-scale-codec",
+ "prost 0.11.3",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sha2 0.10.6",
+ "simple-iavl",
+ "sp-core",
+ "sp-finality-grandpa",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "sp-trie",
+ "tendermint",
+ "tendermint-light-client-verifier",
+ "tendermint-proto",
+]
+
+[[package]]
+name = "pallet-ibc"
+version = "0.0.1"
+source = "git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6#c80e2b203ecfb1925b0330aafba0f736c99fa5f6"
+dependencies = [
+ "beefy-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "cumulus-primitives-core",
+ "derive_more",
+ "finality-grandpa",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "grandpa-light-client-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-derive 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ibc-proto 0.18.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ics07-tendermint 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ics10-grandpa 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ics11-beefy 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
+ "ics23",
+ "light-client-common 0.1.0 (git+https://github.com/ComposableFi/centauri/?rev=c80e2b203ecfb1925b0330aafba0f736c99fa5f6)",
  "log 0.4.17",
  "parachain-info",
  "parity-scale-codec",
@@ -8604,6 +8913,24 @@ dependencies = [
  "sp-trie",
  "tendermint-light-client-verifier",
  "tendermint-proto",
+]
+
+[[package]]
+name = "pallet-ibc-ping"
+version = "0.0.1"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "ibc 0.15.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "ibc-primitives 0.1.0 (git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355)",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-runtime",
+ "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
 ]
 
 [[package]]
@@ -11428,9 +11755,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e330bf1316db56b12c2bcfa399e8edddd4821965ea25ddb2c134b610b1c1c604"
+checksum = "276470f7f281b0ed53d2ae42dd52b4a8d08853a3c70e7fe95882acbb98a6ae94"
 dependencies = [
  "bytes 1.3.0",
  "heck 0.4.0",
@@ -11806,11 +12133,10 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e060280438193c554f654141c9ea9417886713b7acd75974c85b18a69a88e0b"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
@@ -13555,9 +13881,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d8a765117b237ef233705cc2cc4c6a27fccd46eea6ef0c8c6dae5f3ef407f8"
+checksum = "001cf62ece89779fd16105b5f515ad0e5cedcd5440d3dd806bb067978e7c3608"
 dependencies = [
  "bitvec",
  "cfg-if 1.0.0",
@@ -13569,9 +13895,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcd47b380d8c4541044e341dcd9475f55ba37ddc50c908d945fc036a8642496"
+checksum = "303959cf613a6f6efd19ed4b4ad5bf79966a13352716299ad532cfb115f4205c"
 dependencies = [
  "proc-macro-crate 1.2.1",
  "proc-macro2 1.0.47",
@@ -13697,9 +14023,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff55dc09d460954e9ef2fa8a7ced735a964be9981fd50e870b2b3b0705e14964"
+checksum = "d9512ffd81e3a3503ed401f79c33168b9148c75038956039166cd750eaa037c3"
 dependencies = [
  "secp256k1-sys",
 ]
@@ -13798,9 +14124,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
+checksum = "e326c9ec8042f1b5da33252c8a37e9ffbd2c9bef0155215b6e6c80c790e05f91"
 dependencies = [
  "serde_derive",
 ]
@@ -13824,9 +14150,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
+checksum = "42a3df25b0713732468deadad63ab9da1f1fd75a48a15024b50363f128db627e"
 dependencies = [
  "proc-macro2 1.0.47",
  "quote 1.0.21",
@@ -14150,6 +14476,17 @@ dependencies = [
  "sp-keyring",
  "sp-runtime",
  "substrate-simnode",
+]
+
+[[package]]
+name = "simple-iavl"
+version = "0.1.0"
+source = "git+https://github.com/ComposableFi/centauri?rev=c7d2f2d812074850c3b5ab7e42fa582f72582355#c7d2f2d812074850c3b5ab7e42fa582f72582355"
+dependencies = [
+ "bytes 1.3.0",
+ "ics23",
+ "sha2 0.10.6",
+ "tendermint",
 ]
 
 [[package]]
@@ -17175,9 +17512,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.5"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
 dependencies = [
  "webpki",
 ]
@@ -17722,7 +18059,7 @@ version = "0.1.0"
 dependencies = [
  "fixed",
  "prost 0.11.3",
- "prost-build 0.11.3",
+ "prost-build 0.11.4",
  "prost-types 0.11.2",
  "xcvm-core",
 ]

--- a/code/parachain/node/Cargo.toml
+++ b/code/parachain/node/Cargo.toml
@@ -38,6 +38,7 @@ lending-runtime-api = { path = "../frame/lending/runtime-api" }
 pablo-rpc = { path = "../frame/pablo/rpc" }
 pablo-runtime-api = { path = "../frame/pablo/runtime-api" }
 
+pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355" }
 
 # FRAME Dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }

--- a/code/parachain/node/src/chain_spec/dali.rs
+++ b/code/parachain/node/src/chain_spec/dali.rs
@@ -2,6 +2,8 @@ use common::{AccountId, AuraId, Balance};
 use dali_runtime::GenesisConfig;
 
 use super::{Extensions, ParaId};
+use pallet_ibc::pallet::AssetConfig;
+use primitives::currency::CurrencyId;
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
 pub type ChainSpec = sc_service::GenericChainSpec<GenesisConfig, Extensions>;
@@ -77,5 +79,8 @@ pub fn genesis_config(
 		vesting: Default::default(),
 		lending: Default::default(),
 		liquidations: Default::default(),
+		ibc: dali_runtime::IbcConfig {
+			assets: vec![AssetConfig { id: CurrencyId::from(1), denom: b"UNIT".to_vec() }],
+		},
 	}
 }

--- a/code/parachain/runtime/dali/Cargo.toml
+++ b/code/parachain/runtime/dali/Cargo.toml
@@ -144,6 +144,13 @@ orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 # simnode support
 simnode-apis = { package = "simnode-runtime-apis", git = "https://github.com/polytope-labs/substrate-simnode", default-features = false, branch = "polkadot-v0.9.27" }
 
+# IBC support
+pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355", default-features = false }
+ibc = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355", default-features = false }
+pallet-ibc-ping = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355", default-features = false }
+ibc-primitives = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355", default-features = false }
+ibc-runtime-api = { git = "https://github.com/ComposableFi/centauri", rev = "c7d2f2d812074850c3b5ab7e42fa582f72582355", default-features = false }
+
 [dev-dependencies]
 frame-benchmarking = { package = "frame-benchmarking", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
 
@@ -207,6 +214,7 @@ runtime-benchmarks = [
   "pallet-staking-rewards/runtime-benchmarks",
   "cosmwasm/runtime-benchmarks",
   "asset-tx-payment/runtime-benchmarks",
+  "pallet-ibc/runtime-benchmarks",
 ]
 std = [
   "assets-registry/std",
@@ -293,4 +301,9 @@ std = [
   "cosmwasm/std",
   "cosmwasm-runtime-api/std",
   "asset-tx-payment/std",
+  "ibc/std",
+  "pallet-ibc/std",
+  "pallet-ibc-ping/std",
+  "ibc-primitives/std",
+  "ibc-runtime-api/std",
 ]

--- a/scripts/zombienet/default.nix
+++ b/scripts/zombienet/default.nix
@@ -21,6 +21,8 @@ in with prelude; rec {
   mkCollator = { name ? "alice", command, rpc_port ? null, ws_port ? null }:
     {
       command = command;
+      args =
+        [ "--wasmtime-instantiation-strategy=recreate-instance-copy-on-write" ];
       env = [{
         name = "RUST_LOG";
         value =


### PR DESCRIPTION
Most of the code was copied from the `centauri` repo. Some parts are incompatible with the current repo, so I tried to rewrite them, leaving the old code version for comparison. 