### PR TITLE
#done make Picasso runtime PRs more strict (because people click through in reviews instead of carefully reading)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -22,7 +22,7 @@ pull_request_rules:
           - "#approved-reviews-by>=2"
           - approved-reviews-by=@ComposableFi/core
       - base=main    
-      - files ~= ^code\/parachain\/runtime\/picasso\/(lib\.rs|governance\.rs)
+      - files ~= ^code\/parachain\/runtime\/picasso\/(lib\.rs|governance\.rs|xcmp\.rs)
       - -title~="#wip"
     actions:
       queue:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -13,3 +13,17 @@ pull_request_rules:
     actions:
       queue:
         name: default
+        
+  - name: Automatic merge on approval (Picasso Runtime)
+    conditions:
+      - or:
+        - "#approved-reviews-by>=3"     
+        - and:
+          - "#approved-reviews-by>=2"
+          - approved-reviews-by=@ComposableFi/core
+      - base=main    
+      - files ~= ^code\/parachain\/runtime\/picasso\/(lib\.rs|governance\.rs)
+      - -title~="#wip"
+    actions:
+      queue:
+        name: default   


### PR DESCRIPTION
For runtime of Picasso, specifically lib.rs and governance.rs, we require not 2, but **3** reviewers **OR** require 2 but when one of reviewers from core team (assume most experienced in the substrate) to avoid adding security issues and not approved pallets to Picasso. So it just makes review one minimal step stricter for some files.