### PR TITLE
Remove SRE from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,10 +10,10 @@
 
 ## CI and deployment related files
 
-.github/ @ComposableFi/sre @ComposableFi/core
+.github/ @ComposableFi/nix @ComposableFi/core
 .github/CODEOWNERS @ComposableFi/core
-docker/ @ComposableFi/sre @ComposableFi/core
-Makefile @ComposableFi/sre @ComposableFi/core
+docker/ @ComposableFi/nix @ComposableFi/core
+Makefile @ComposableFi/nix @ComposableFi/core
 
 ## Parachain related files
 
@@ -43,10 +43,10 @@ README.md @ComposableFi/technical-writers @ComposableFi/core @ComposableFi/parac
 
 ## Frontend and Blockchain Integration
 frontend/ @ComposableFi/blockchain-integrations @ComposableFi/parachain-finance
-.github/workflows/frontend-pablo-eslint.yml @ComposableFi/sre @ComposableFi/blockchain-integrations
-.github/workflows/frontend-pablo-tests.yml  @ComposableFi/sre  @ComposableFi/blockchain-integrations
-.github/workflows/frontend-picasso-eslint.yml  @ComposableFi/sre  @ComposableFi/blockchain-integrations
-.github/workflows/frontend-picasso-tests.yml  @ComposableFi/sre  @ComposableFi/blockchain-integrations
+.github/workflows/frontend-pablo-eslint.yml @ComposableFi/nix @ComposableFi/blockchain-integrations
+.github/workflows/frontend-pablo-tests.yml  @ComposableFi/nix  @ComposableFi/blockchain-integrations
+.github/workflows/frontend-picasso-eslint.yml  @ComposableFi/nix  @ComposableFi/blockchain-integrations
+.github/workflows/frontend-picasso-tests.yml  @ComposableFi/nix  @ComposableFi/blockchain-integrations
 
 ## Runtime Integration Tests
 
@@ -60,10 +60,10 @@ flake.nix @ComposableFi/nix
 flake.lock @ComposableFi/nix
 Dockerfile @ComposableFi/nix
 composable.code-workspace @ComposableFi/nix
-.hadolint.yaml @ComposableFi/sre @ComposableFi/nix
+.hadolint.yaml @ComposableFi/nix @ComposableFi/nix
 .envrc @ComposableFi/nix
-.dockerignore @ComposableFi/sre @ComposableFi/nix
-.gitignore @ComposableFi/sre @ComposableFi/nix
+.dockerignore @ComposableFi/nix @ComposableFi/nix
+.gitignore @ComposableFi/nix @ComposableFi/nix
 
 rust-toolchain.toml @ComposableFi/nix @ComposableFi/core
 
@@ -74,8 +74,8 @@ composablejs/ @ComposableFi/parachain
 
 rfcs/ @ComposableFi/developers
 docs/ @ComposableFi/developers @ComposableFi/technical-writers
-scripts/ @ComposableFi/developers @ComposableFi/sre
-code/utils/ @ComposableFi/developers @ComposableFi/sre @ComposableFi/testers
+scripts/ @ComposableFi/developers @ComposableFi/nix
+code/utils/ @ComposableFi/developers @ComposableFi/nix @ComposableFi/testers
 .remarkrc @ComposableFi/developers
 .taplo.toml @ComposableFi/nix @ComposableFi/parachain-leads
 Makefile.toml @ComposableFi/developers @ComposableFi/testers


### PR DESCRIPTION
Since basically the Nix team maintains this, might as well remove it.