### PR TITLE
Picasso - Release 1 - Fix failing test case in picasso

### DIFF
--- a/frontend/apps/picasso/tests/organisms/statsOverviewTab.test.tsx
+++ b/frontend/apps/picasso/tests/organisms/statsOverviewTab.test.tsx
@@ -8,6 +8,6 @@ test("renders Network Tabs", () => {
   render(<StatsOverviewTabStory />);
   expect(screen.getByText("Picasso market cap")).toBeInTheDocument();
   expect(screen.getByText("Picasso circulating supply")).toBeInTheDocument();
-  expect(screen.getByText("0 PICA")).toBeInTheDocument();
+  expect(screen.getByText("0")).toBeInTheDocument();
   expect(screen.getByText("$0.00")).toBeInTheDocument();
 });


### PR DESCRIPTION
There is a failing test case that was not updated after changing the design element of picasso circulating supply in stats page. 

This PR fixes that. 