### PR TITLE
[No Ticket] Protect Picasso runtime from out of consensus modification

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -23,7 +23,7 @@ pull_request_rules:
           - approved-reviews-by=@ComposableFi/core
           - "#review-threads-unresolved=0"
       - base=main
-      - files~=^code/parachain/runtime/picasso/
+      - files~=^code\/parachain\/runtime\/picasso\/
     actions:
       queue:
         priority: high

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -14,3 +14,17 @@ pull_request_rules:
     actions:
       queue:
         name: default
+
+  # Any files in Picasso must be reviewed and approved by more than 3 reviewers plus core group
+  - name: Automatic merge on approval (Picasso Runtime)
+    conditions:
+      - and:
+          - "#approved-reviews-by>=3"
+          - approved-reviews-by=@ComposableFi/core
+          - "#review-threads-unresolved=0"
+      - base=main
+      - files~=^code/parachain/runtime/picasso/
+    actions:
+      queue:
+        priority: high
+        name: default


### PR DESCRIPTION
This is to protect Picasso runtime from being modified without consensus. Need a process to verify runtime changes so that we don't run into blockers at the time of release.