### PR TITLE
Prepend subsquid processor container tag with docker registry

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -694,7 +694,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
-          tags: subsquid-processor:latest
+          tags: ${{ env.DOCKER_REGISTRY_NAME }}/subsquid-processor:latest
           context: subsquid
           push: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 


### PR DESCRIPTION
Publish was missing the registry path for subsquid processor.