### PR TITLE
Ben/pablo tests suite refine rewrite (#390y0vn)

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -9294,7 +9294,6 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
- "sp-keyring",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
  "syn 1.0.105",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -3292,6 +3292,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",
@@ -9282,6 +9283,7 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "pallet-currency-factory",
+ "pallet-pablo",
  "pallet-staking-rewards",
  "pallet-timestamp",
  "parity-scale-codec",
@@ -9293,6 +9295,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
+ "syn 1.0.105",
 ]
 
 [[package]]
@@ -10183,6 +10186,7 @@ dependencies = [
  "sp-consensus-aura",
  "sp-core",
  "sp-inherents",
+ "sp-io",
  "sp-offchain",
  "sp-runtime",
  "sp-session",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -1834,6 +1834,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
+ "sp-keyring",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
 ]
@@ -9293,6 +9294,7 @@ dependencies = [
  "sp-arithmetic",
  "sp-core",
  "sp-io",
+ "sp-keyring",
  "sp-runtime",
  "sp-std 4.0.0 (git+https://github.com/ComposableFi/substrate?rev=9bdc51acad943bd07fae159f59564a1b464d33b5)",
  "syn 1.0.105",

--- a/code/parachain/frame/composable-tests-helpers/Cargo.toml
+++ b/code/parachain/frame/composable-tests-helpers/Cargo.toml
@@ -18,6 +18,7 @@ scale-info = { version = "2.1.1", default-features = false, features = [
 ] }
 serde = { version = "1.0.136", optional = true }
 sp-arithmetic = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+sp-keyring = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 

--- a/code/parachain/frame/composable-tests-helpers/src/lib.rs
+++ b/code/parachain/frame/composable-tests-helpers/src/lib.rs
@@ -1,2 +1,15 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_runtime::AccountId32;
+
 pub mod test;
+
+pub const ALICE: AccountId32 = AccountId32::new([
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+]);
+pub const BOB: AccountId32 = AccountId32::new([
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+]);
+pub const CHARLIE: AccountId32 = AccountId32::new([
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+]);

--- a/code/parachain/frame/composable-tests-helpers/src/lib.rs
+++ b/code/parachain/frame/composable-tests-helpers/src/lib.rs
@@ -1,18 +1,38 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use sp_keyring::sr25519::Keyring;
 use sp_runtime::AccountId32;
 
 pub mod test;
 
-pub const ALICE: AccountId32 = AccountId32::new([
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
-]);
-pub const BOB: AccountId32 = AccountId32::new([
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
-]);
-pub const CHARLIE: AccountId32 = AccountId32::new([
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
-]);
-pub const DAVE: AccountId32 = AccountId32::new([
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
-]);
+// pub const ALICE: AccountId32 = AccountId32::new([
+// 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+// ]);
+// pub const BOB: AccountId32 = AccountId32::new([
+// 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2,
+// ]);
+// pub const CHARLIE: AccountId32 = AccountId32::new([
+// 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
+// ]);
+// pub const DAVE: AccountId32 = AccountId32::new([
+// 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
+// ]);
+
+macro_rules! keyring_accounts {
+	($([$who:ident $Who:ident])+) => {
+		$(
+			pub fn $who() -> AccountId32 {
+				Keyring::$Who.to_account_id()
+			}
+		)+
+	};
+}
+
+keyring_accounts! {
+	[alice Alice]
+	[bob Bob]
+	[charlie Charlie]
+	[dave Dave]
+	[eve Eve]
+	[ferdie Ferdie]
+}

--- a/code/parachain/frame/composable-tests-helpers/src/lib.rs
+++ b/code/parachain/frame/composable-tests-helpers/src/lib.rs
@@ -13,3 +13,6 @@ pub const BOB: AccountId32 = AccountId32::new([
 pub const CHARLIE: AccountId32 = AccountId32::new([
 	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
 ]);
+pub const DAVE: AccountId32 = AccountId32::new([
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4,
+]);

--- a/code/parachain/frame/composable-tests-helpers/src/test/block.rs
+++ b/code/parachain/frame/composable-tests-helpers/src/test/block.rs
@@ -46,7 +46,6 @@ where
 	frame_system::Pallet::<Runtime>::initialize(
 		&next_block,
 		header.parent_hash(),
-		// &[0u8; 32].into(),
 		&Default::default(),
 	);
 

--- a/code/parachain/frame/pablo/Cargo.toml
+++ b/code/parachain/frame/pablo/Cargo.toml
@@ -33,15 +33,22 @@ sp-io = { default-features = false, git = "https://github.com/paritytech/substra
 sp-runtime = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 sp-std = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 
+composable-tests-helpers = { path = "../composable-tests-helpers", optional = true }
+pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27", optional = true }
+
 [dev-dependencies]
 composable-tests-helpers = { path = "../composable-tests-helpers" }
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "504d11bd1af3613a0e66b47b99713675e9b6bd10" }
 orml-traits = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "504d11bd1af3613a0e66b47b99713675e9b6bd10" }
+pablo = { package = "pallet-pablo", path = ".", features = ["testing"] }
 pallet-currency-factory = { path = "../currency-factory" }
 pallet-staking-rewards = { path = "../staking-rewards" }
 pallet-timestamp = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 proptest = { version = "1.0" }
+
+[build-dependencies]
+syn = { version = "1.0.105", features = ["parsing", "full"] }
 
 [features]
 default = ["std"]
@@ -65,3 +72,4 @@ std = [
   "composable-maths/std",
   "rust_decimal/std",
 ]
+testing = ["composable-tests-helpers", "pallet-timestamp"]

--- a/code/parachain/frame/pablo/build.rs
+++ b/code/parachain/frame/pablo/build.rs
@@ -1,0 +1,197 @@
+#![allow(clippy::disallowed_methods)] // temporarilly
+
+use std::{env, fmt::Write, fs, iter, path::PathBuf};
+
+use syn::{Generics, Item, ItemFn, ItemMod, ReturnType, Signature, Visibility};
+
+fn main() {
+	aggregate_tests("testing");
+}
+
+pub fn aggregate_tests(tests_module_path: &str) {
+	if env::var_os("SKIP_TESTS_BUILD_SCRIPT").is_some() {
+		println!("cargo:rerun-if-env-changed=SKIP_TESTS_BUILD_SCRIPT");
+		return
+	}
+
+	let dest_path = PathBuf::from(
+		env::var_os("OUT_DIR").expect("OUT_DIR environment variable should be present"),
+	)
+	.join("testing.rs");
+
+	// "testing"
+	let ast = match read_module_file(vec![tests_module_path.to_string()]) {
+		Ok(ast) => ast,
+		Err(path) => {
+			println!("cargo:rerun-if-changed=src/{path}*");
+			return
+		},
+	};
+
+	let Ok(test_fns) = ast
+			.items
+			.into_iter()
+			.filter_map(|item| to_output(item, "testing".to_string()))
+			.collect::<Result<Vec<_>, _>>()
+		else {
+			println!("cargo:rerun-if-changed=src/{tests_module_path}*");
+			return;
+		};
+
+	fs::write(
+		dest_path,
+		format!(
+			"
+				#[macro_export]
+				macro_rules! tests {{
+					(mod $crate_name:ident<$Runtime:ty>) => {{
+						mod $crate_name {{
+							{}
+						}}
+					}}
+				}}
+			",
+			// pub use tests;
+			test_fns
+				.into_iter()
+				.fold(String::new(), |acc, curr| acc + &curr.print(tests_module_path.to_string())),
+		),
+	)
+	.unwrap();
+
+	println!("cargo:rerun-if-changed=src/{tests_module_path}*");
+}
+
+fn read_module_file(paths: Vec<String>) -> Result<syn::File, String> {
+	let path = format!("src/{}.rs", paths.join("/"));
+
+	let Ok(content) = fs::read_to_string(&path) else {
+	    return Err(path);
+    };
+
+	let Ok(ast) = syn::parse_file(&content) else {
+	    return Err(path);
+    };
+
+	Ok(ast)
+}
+
+// TODO(benluelo): Rename this?
+enum AccumulatedTests {
+	Mod(String, Vec<AccumulatedTests>),
+	Fn(String),
+}
+
+impl AccumulatedTests {
+	fn print(self, crate_name: String) -> String {
+		fn print_inner(output: AccumulatedTests, parent_mods: &mut Vec<String>) -> String {
+			match output {
+				AccumulatedTests::Mod(ident, content) => {
+					let mut output = String::new();
+
+					output.write_fmt(format_args!("mod {ident} {{")).unwrap();
+
+					parent_mods.push(ident.clone());
+
+					output = content
+						.into_iter()
+						.fold(output, |acc, output| acc + &print_inner(output, parent_mods));
+
+					// temporary check
+					assert_eq!(parent_mods.pop().unwrap(), ident);
+
+					output.write_char('}').unwrap();
+
+					output
+				},
+				AccumulatedTests::Fn(ident) => format!(
+					"
+					#[test] fn {ident}() {{
+						::sp_io::TestExternalities::default().execute_with(|| {{
+							$crate{}::{ident}::<$Runtime>();
+						}})
+					}}",
+					parent_mods
+						.iter()
+						.map(|path_segment| format!("::{path_segment}"))
+						.collect::<String>()
+				),
+			}
+		}
+
+		print_inner(self, &mut vec![crate_name])
+	}
+}
+
+fn to_output(item: Item, root_dir: String) -> Option<Result<AccumulatedTests, String>> {
+	to_output_inner(item, vec![root_dir])
+}
+
+// TODO(benluelo): Pass attrs through, maybe check for non-test/cfg(test) fns/mods?
+fn to_output_inner(
+	item: Item,
+	current_paths: Vec<String>,
+) -> Option<Result<AccumulatedTests, String>> {
+	match item {
+		Item::Fn(item_fn) => match item_fn {
+			ItemFn {
+				attrs,
+				vis: Visibility::Public(_),
+				sig:
+					Signature {
+						constness: None,
+						asyncness: None,
+						unsafety: None,
+						abi: None,
+						ident,
+						fn_token: _,
+						generics: Generics { lt_token: _, params, gt_token: _, where_clause: _ },
+						paren_token: _,
+						inputs,
+						variadic: None,
+						output: ReturnType::Default,
+						..
+					},
+				block: _,
+			} if attrs.is_empty() && inputs.is_empty() && params.len() == 1 =>
+				Some(Ok(AccumulatedTests::Fn(ident.to_string()))),
+			_ => None,
+		},
+		Item::Mod(ItemMod {
+			attrs,
+			vis: Visibility::Public(_),
+			mod_token: _,
+			ident,
+			content,
+			semi: _,
+		}) if attrs.is_empty() => {
+			let current_paths_with_self = current_paths
+				.into_iter()
+				.chain(iter::once(ident.to_string()))
+				.collect::<Vec<_>>();
+
+			let content = match content {
+				// empty declaration, content is in another file
+				// TODO(benluelo): Support renamed module paths (path = "file.rs")
+				None => match read_module_file(current_paths_with_self.clone()) {
+					Ok(ok) => ok.items,
+					Err(path) => return Some(Err(path)),
+				},
+				Some((_, content)) => content,
+			};
+
+			Some(Ok(AccumulatedTests::Mod(
+				ident.to_string(),
+				match content
+					.into_iter()
+					.flat_map(|item| to_output_inner(item, current_paths_with_self.clone()))
+					.collect::<Result<Vec<_>, _>>()
+				{
+					Ok(ok) => ok,
+					Err(err) => return Some(Err(err)),
+				},
+			)))
+		},
+		_ => None,
+	}
+}

--- a/code/parachain/frame/pablo/build.rs
+++ b/code/parachain/frame/pablo/build.rs
@@ -23,7 +23,7 @@ pub fn aggregate_tests(tests_module_path: &str) {
 	let ast = match read_module_file(vec![tests_module_path.to_string()]) {
 		Ok(ast) => ast,
 		Err(path) => {
-			println!("cargo:rerun-if-changed=src/{path}*");
+			rerun_if_changed(&path, true);
 			return
 		},
 	};
@@ -34,7 +34,7 @@ pub fn aggregate_tests(tests_module_path: &str) {
 			.filter_map(|item| to_output(item, "testing".to_string()))
 			.collect::<Result<Vec<_>, _>>()
 		else {
-			println!("cargo:rerun-if-changed=src/{tests_module_path}*");
+			rerun_if_changed(tests_module_path, true);
 			return;
 		};
 
@@ -59,7 +59,11 @@ pub fn aggregate_tests(tests_module_path: &str) {
 	)
 	.unwrap();
 
-	println!("cargo:rerun-if-changed=src/{tests_module_path}*");
+	rerun_if_changed(tests_module_path, true);
+}
+
+fn rerun_if_changed(path: &str, glob: bool) {
+	println!("cargo:rerun-if-changed=src/{}{}", path, if glob { "*" } else { "" });
 }
 
 fn read_module_file(paths: Vec<String>) -> Result<syn::File, String> {

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -10,6 +10,7 @@
 )]
 #![warn(clippy::unseparated_literal_suffix)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "testing", macro_use)]
 #![warn(
 	bad_style,
 	bare_trait_objects,
@@ -31,12 +32,20 @@
 )]
 pub use pallet::*;
 
+#[cfg(feature = "testing")]
+include!(concat!(env!("OUT_DIR"), "/testing.rs"));
+
 #[cfg(test)]
 mod mock;
 #[cfg(test)]
-mod mock_fnft;
+mod mock_fnft; // TODO(benluelo): DELETE!
 #[cfg(test)]
 mod test;
+
+#[cfg(feature = "testing")]
+pub mod testing;
+#[cfg(feature = "testing")]
+pub use testing::*;
 
 pub mod weights;
 

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -164,8 +164,10 @@ impl pablo::Config for Test {
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	let mut storage =
-		frame_system::GenesisConfig::default().build_storage::<Test>().expect("success");
+	// let mut storage =
+	// 	frame_system::GenesisConfig::default().build_storage::<Test>().expect("success");
 
-	storage.into()
+	// storage.into()
+
+	sp_io::TestExternalities::default()
 }

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -1,22 +1,20 @@
 #![cfg(test)]
 
 use crate as pablo;
-use composable_tests_helpers::test::currency;
+use composable_tests_helpers::{test::currency, ALICE};
 use frame_support::{
-	ord_parameter_types,
-	pallet_prelude::GenesisBuild,
-	parameter_types,
+	ord_parameter_types, parameter_types,
 	traits::{EitherOfDiverse, Everything},
 	PalletId,
 };
 use frame_system::{self as system, EnsureRoot, EnsureSignedBy};
-use orml_traits::{parameter_type_with_key, LockIdentifier};
+use orml_traits::parameter_type_with_key;
 use sp_arithmetic::traits::Zero;
 use sp_core::H256;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, ConvertInto, IdentityLookup},
-	Permill,
+	AccountId32, Permill,
 };
 
 pub type CurrencyId = u128;
@@ -41,12 +39,11 @@ frame_support::construct_runtime!(
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic,
 	{
-		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
-		Pablo: pablo::{Pallet, Call, Storage, Event<T>},
-		LpTokenFactory: pallet_currency_factory::{Pallet, Storage, Event<T>},
-		Tokens: orml_tokens::{Pallet, Call, Storage, Config<T>, Event<T>},
-		Timestamp: pallet_timestamp::{Pallet, Call, Storage},
-		StakingRewards: pallet_staking_rewards::{Pallet, Storage, Call, Event<T>},
+		System: frame_system,
+		Pablo: pablo,
+		LpTokenFactory: pallet_currency_factory,
+		Tokens: orml_tokens,
+		Timestamp: pallet_timestamp,
 	}
 );
 
@@ -63,18 +60,7 @@ parameter_types! {
 	pub const SS58Prefix: u8 = 42;
 }
 
-pub type AccountId = u128;
-
-#[allow(dead_code)]
-pub static ALICE: AccountId = 1;
-#[allow(dead_code)]
-pub static BOB: AccountId = 2;
-#[allow(dead_code)]
-pub static CHARLIE: AccountId = 3;
-#[allow(dead_code)]
-pub static DAVE: AccountId = 4;
-#[allow(dead_code)]
-pub static CURVE_ADMIN_FEE_ACC_ID: AccountId = 5;
+pub type AccountId = AccountId32;
 
 impl system::Config for Test {
 	type BaseCallFilter = Everything;
@@ -152,48 +138,6 @@ impl pallet_timestamp::Config for Test {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const StakingRewardsPalletId: PalletId = PalletId(*b"stk_rwrd");
-	pub const StakingRewardsLockId: LockIdentifier = *b"stk_lock";
-	pub const MaxStakingDurationPresets: u32 = 10;
-	pub const MaxRewardConfigsPerPool: u32 = 10;
-	pub const PicaAssetId : CurrencyId = 1;
-	pub const PbloAssetId : CurrencyId = 2;
-	pub const XPicaAssetId: CurrencyId = 101;
-	pub const XPbloAssetId: CurrencyId = 102;
-	pub const PicaStakeFinancialNftCollectionId: CurrencyId = 1001;
-	pub const PbloStakeFinancialNftCollectionId: CurrencyId = 1001;
-	// REVIEW(benluelo): Use a better value for this?
-	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
-}
-
-impl pallet_staking_rewards::Config for Test {
-	type Event = Event;
-	type Balance = Balance;
-	type AssetId = CurrencyId;
-	type FinancialNft = pablo::mock_fnft::MockFnft;
-	type FinancialNftInstanceId = u64;
-	type CurrencyFactory = LpTokenFactory;
-	type Assets = Tokens;
-	type UnixTime = Timestamp;
-	type ReleaseRewardsPoolsBatchSize = frame_support::traits::ConstU8<13>;
-	type PalletId = StakingRewardsPalletId;
-	type MaxStakingDurationPresets = MaxStakingDurationPresets;
-	type MaxRewardConfigsPerPool = MaxRewardConfigsPerPool;
-	type RewardPoolCreationOrigin = EnsureRoot<Self::AccountId>;
-	type RewardPoolUpdateOrigin = EnsureRoot<Self::AccountId>;
-	type PicaAssetId = PicaAssetId;
-	type XPicaAssetId = XPicaAssetId;
-	type PbloAssetId = PbloAssetId;
-	type XPbloAssetId = XPbloAssetId;
-	type PicaStakeFinancialNftCollectionId = PicaStakeFinancialNftCollectionId;
-	type PbloStakeFinancialNftCollectionId = PbloStakeFinancialNftCollectionId;
-	type WeightInfo = ();
-	type LockId = StakingRewardsLockId;
-	type TreasuryAccount = TreasuryAccountId;
-	type ExistentialDeposits = ExistentialDeposits;
-}
-
 ord_parameter_types! {
 	pub const RootAccount: AccountId = ALICE;
 }
@@ -222,8 +166,6 @@ impl pablo::Config for Test {
 pub fn new_test_ext() -> sp_io::TestExternalities {
 	let mut storage =
 		frame_system::GenesisConfig::default().build_storage::<Test>().expect("success");
-	pallet_staking_rewards::GenesisConfig::<Test>::default()
-		.assimilate_storage(&mut storage)
-		.expect("success");
+
 	storage.into()
 }

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate as pablo;
-use composable_tests_helpers::{test::currency, ALICE};
+use composable_tests_helpers::{alice, test::currency};
 use frame_support::{
 	ord_parameter_types, parameter_types,
 	traits::{EitherOfDiverse, Everything},
@@ -139,7 +139,7 @@ impl pallet_timestamp::Config for Test {
 }
 
 ord_parameter_types! {
-	pub const RootAccount: AccountId = ALICE;
+	pub const RootAccount: AccountId = alice();
 }
 
 impl pablo::Config for Test {

--- a/code/parachain/frame/pablo/src/test/common_test_functions.rs
+++ b/code/parachain/frame/pablo/src/test/common_test_functions.rs
@@ -5,6 +5,7 @@ use crate::{
 	PoolConfiguration::DualAssetConstantProduct,
 	PoolInitConfiguration,
 };
+use composable_tests_helpers::{ALICE, BOB};
 use composable_traits::dex::AssetAmount;
 use frame_support::{
 	assert_noop, assert_ok,
@@ -62,10 +63,10 @@ pub fn common_add_remove_lp(
 		false
 	));
 	assert_last_event::<Test, _>(|e| {
-		matches!(e.event,
+		matches!(&e.event,
 			mock::Event::Pablo(crate::Event::LiquidityAdded { who, pool_id, /* base_amount, quote_amount, */ .. })
-			if who == ALICE
-			&& pool_id == actual_pool_id
+			if who == &ALICE
+			&& pool_id == &actual_pool_id
 			// && base_amount == first_asset_amount
 			// && quote_amount == second_asset_amount
 		)
@@ -92,10 +93,10 @@ pub fn common_add_remove_lp(
 		false
 	));
 	assert_last_event::<Test, _>(|e| {
-		matches!(e.event,
+		matches!(&e.event,
 		mock::Event::Pablo(crate::Event::LiquidityAdded { who, pool_id, /* base_amount, quote_amount, */  .. })
-		if who == BOB
-			&& pool_id == actual_pool_id
+		if who == &BOB
+			&& pool_id == &actual_pool_id
 			// && base_amount == next_first_asset_amount
 			// && quote_amount == next_second_asset_amount
 		)

--- a/code/parachain/frame/pablo/src/test/common_test_functions.rs
+++ b/code/parachain/frame/pablo/src/test/common_test_functions.rs
@@ -5,7 +5,7 @@ use crate::{
 	PoolConfiguration::DualAssetConstantProduct,
 	PoolInitConfiguration,
 };
-use composable_tests_helpers::{ALICE, BOB};
+use composable_tests_helpers::{alice, bob};
 use composable_traits::dex::AssetAmount;
 use frame_support::{
 	assert_noop, assert_ok,
@@ -50,13 +50,13 @@ pub fn common_add_remove_lp(
 	);
 	let pair = get_pair(init_config);
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(pair[0], &ALICE, first_asset_amount));
-	assert_ok!(Tokens::mint_into(pair[1], &ALICE, second_asset_amount));
+	assert_ok!(Tokens::mint_into(pair[0], &alice(), first_asset_amount));
+	assert_ok!(Tokens::mint_into(pair[1], &alice(), second_asset_amount));
 
 	System::set_block_number(System::block_number() + 1);
 	// Add the liquidity
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(ALICE),
+		Origin::signed(alice()),
 		actual_pool_id,
 		BTreeMap::from([(pair[0], first_asset_amount), (pair[1], second_asset_amount)]),
 		0,
@@ -65,7 +65,7 @@ pub fn common_add_remove_lp(
 	assert_last_event::<Test, _>(|e| {
 		matches!(&e.event,
 			mock::Event::Pablo(crate::Event::LiquidityAdded { who, pool_id, /* base_amount, quote_amount, */ .. })
-			if who == &ALICE
+			if who == &alice()
 			&& pool_id == &actual_pool_id
 			// && base_amount == first_asset_amount
 			// && quote_amount == second_asset_amount
@@ -77,16 +77,16 @@ pub fn common_add_remove_lp(
 		DualAssetConstantProduct(pool) => pool.lp_token,
 	};
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(pair[0], &BOB, next_first_asset_amount));
-	assert_ok!(Tokens::mint_into(pair[1], &BOB, next_second_asset_amount));
+	assert_ok!(Tokens::mint_into(pair[0], &bob(), next_first_asset_amount));
+	assert_ok!(Tokens::mint_into(pair[1], &bob(), next_second_asset_amount));
 
-	let lp = Tokens::balance(lp_token, &BOB);
+	let lp = Tokens::balance(lp_token, &bob());
 	assert_eq!(lp, 0_u128);
 
 	System::set_block_number(System::block_number() + 1);
 	// Add the liquidity
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(BOB),
+		Origin::signed(bob()),
 		actual_pool_id,
 		BTreeMap::from([(pair[0], next_first_asset_amount), (pair[1], next_second_asset_amount)]),
 		0,
@@ -95,21 +95,21 @@ pub fn common_add_remove_lp(
 	assert_last_event::<Test, _>(|e| {
 		matches!(&e.event,
 		mock::Event::Pablo(crate::Event::LiquidityAdded { who, pool_id, /* base_amount, quote_amount, */  .. })
-		if who == &BOB
+		if who == &bob()
 			&& pool_id == &actual_pool_id
 			// && base_amount == next_first_asset_amount
 			// && quote_amount == next_second_asset_amount
 		)
 	});
-	let lp = Tokens::balance(lp_token, &BOB);
+	let lp = Tokens::balance(lp_token, &bob());
 	assert!(expected_lp_check(next_first_asset_amount, next_second_asset_amount, lp));
 	assert_ok!(Pablo::remove_liquidity(
-		Origin::signed(BOB),
+		Origin::signed(bob()),
 		actual_pool_id,
 		lp,
 		BTreeMap::from([(pair[0], 0_u128), (pair[1], 0_u128)]),
 	));
-	let lp = Tokens::balance(lp_token, &BOB);
+	let lp = Tokens::balance(lp_token, &bob());
 	// all lp tokens must have been burnt
 	assert_eq!(lp, 0_u128);
 }
@@ -155,8 +155,8 @@ pub fn common_add_lp_with_min_mint_amount(
 	let [first_asset, second_asset] = get_pair(init_config);
 
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(first_asset, &ALICE, init_first_asset_amount));
-	assert_ok!(Tokens::mint_into(second_asset, &ALICE, init_second_asset_amount));
+	assert_ok!(Tokens::mint_into(first_asset, &alice(), init_first_asset_amount));
+	assert_ok!(Tokens::mint_into(second_asset, &alice(), init_second_asset_amount));
 
 	let assets_with_amounts = BTreeMap::from([
 		(first_asset, init_first_asset_amount),
@@ -165,7 +165,7 @@ pub fn common_add_lp_with_min_mint_amount(
 
 	// Add the liquidity, min amount = 0
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(ALICE),
+		Origin::signed(alice()),
 		pool_id,
 		assets_with_amounts.clone(),
 		0,
@@ -173,11 +173,11 @@ pub fn common_add_lp_with_min_mint_amount(
 	));
 
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(first_asset, &BOB, first_asset_amount));
-	assert_ok!(Tokens::mint_into(second_asset, &BOB, second_asset_amount));
+	assert_ok!(Tokens::mint_into(first_asset, &bob(), first_asset_amount));
+	assert_ok!(Tokens::mint_into(second_asset, &bob(), second_asset_amount));
 
-	let alice_lp = Tokens::balance(lp_token, &ALICE);
-	let bob_lp = Tokens::balance(lp_token, &BOB);
+	let alice_lp = Tokens::balance(lp_token, &alice());
+	let bob_lp = Tokens::balance(lp_token, &bob());
 
 	assert_eq!(bob_lp, 0_u128, "BOB should not have any LP tokens");
 
@@ -192,7 +192,7 @@ pub fn common_add_lp_with_min_mint_amount(
 	// Add the liquidity, but expect more lp tokens, hence errors
 	assert_noop!(
 		Pablo::add_liquidity(
-			Origin::signed(BOB),
+			Origin::signed(bob()),
 			pool_id,
 			assets_with_amounts.clone(),
 			min_mint_amount + 1,
@@ -203,7 +203,7 @@ pub fn common_add_lp_with_min_mint_amount(
 
 	// Add liquidity with min_mint_amount
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(BOB),
+		Origin::signed(bob()),
 		pool_id,
 		assets_with_amounts,
 		min_mint_amount,
@@ -223,12 +223,12 @@ pub fn common_remove_lp_failure(
 		.expect("pool creation failed");
 	let pair = get_pair(init_config);
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(pair[0], &ALICE, init_base_amount));
-	assert_ok!(Tokens::mint_into(pair[1], &ALICE, init_quote_amount));
+	assert_ok!(Tokens::mint_into(pair[0], &alice(), init_base_amount));
+	assert_ok!(Tokens::mint_into(pair[1], &alice(), init_quote_amount));
 
 	// Add the liquidity
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(ALICE),
+		Origin::signed(alice()),
 		pool_id,
 		BTreeMap::from([(pair[0], init_base_amount), (pair[1], init_quote_amount)]),
 		0,
@@ -240,24 +240,24 @@ pub fn common_remove_lp_failure(
 		DualAssetConstantProduct(pool) => pool.lp_token,
 	};
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(pair[0], &BOB, base_amount));
-	assert_ok!(Tokens::mint_into(pair[1], &BOB, quote_amount));
+	assert_ok!(Tokens::mint_into(pair[0], &bob(), base_amount));
+	assert_ok!(Tokens::mint_into(pair[1], &bob(), quote_amount));
 
-	let lp = Tokens::balance(lp_token, &BOB);
+	let lp = Tokens::balance(lp_token, &bob());
 	assert_eq!(lp, 0_u128);
 	// Add the liquidity
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(BOB),
+		Origin::signed(bob()),
 		pool_id,
 		BTreeMap::from([(pair[0], base_amount), (pair[1], quote_amount)]),
 		0,
 		false
 	));
-	let lp = Tokens::balance(lp_token, &BOB);
+	let lp = Tokens::balance(lp_token, &bob());
 	// error as trying to redeem more tokens than lp
 	assert_noop!(
 		Pablo::remove_liquidity(
-			Origin::signed(BOB),
+			Origin::signed(bob()),
 			pool_id,
 			lp + 1,
 			BTreeMap::from([(pair[0], 0), (pair[1], 0)])
@@ -269,7 +269,7 @@ pub fn common_remove_lp_failure(
 	// error as expected values are more than actual redeemed values.
 	assert_noop!(
 		Pablo::remove_liquidity(
-			Origin::signed(BOB),
+			Origin::signed(bob()),
 			pool_id,
 			lp,
 			BTreeMap::from([
@@ -294,12 +294,12 @@ pub fn common_exchange_failure(
 	let pool_id =
 		Pablo::do_create_pool(init_config, Some(lp_token_id)).expect("pool creation failed");
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(init_first_amount.asset_id, &ALICE, init_first_amount.amount));
-	assert_ok!(Tokens::mint_into(init_second_amount.asset_id, &ALICE, init_second_amount.amount));
+	assert_ok!(Tokens::mint_into(init_first_amount.asset_id, &alice(), init_first_amount.amount));
+	assert_ok!(Tokens::mint_into(init_second_amount.asset_id, &alice(), init_second_amount.amount));
 
 	// Add the liquidity
 	assert_ok!(Pablo::add_liquidity(
-		Origin::signed(ALICE),
+		Origin::signed(alice()),
 		pool_id,
 		BTreeMap::from([
 			(init_first_amount.asset_id, init_first_amount.amount),
@@ -310,11 +310,11 @@ pub fn common_exchange_failure(
 	));
 
 	// Mint the tokens
-	assert_ok!(Tokens::mint_into(init_first_amount.asset_id, &BOB, exchange_first_amount.amount));
+	assert_ok!(Tokens::mint_into(init_first_amount.asset_id, &bob(), exchange_first_amount.amount));
 	// error as trying to swap more value than balance
 	assert_noop!(
 		Pablo::swap(
-			Origin::signed(BOB),
+			Origin::signed(bob()),
 			pool_id,
 			AssetAmount::new(exchange_first_amount.asset_id, exchange_first_amount.amount + 1),
 			AssetAmount::new(init_second_amount.asset_id, 0),
@@ -326,7 +326,7 @@ pub fn common_exchange_failure(
 	// error as the expected value is more that input
 	assert_noop!(
 		Pablo::swap(
-			Origin::signed(BOB),
+			Origin::signed(bob()),
 			pool_id,
 			AssetAmount::new(exchange_first_amount.asset_id, exchange_first_amount.amount),
 			AssetAmount::new(init_second_amount.asset_id, dbg!(init_second_amount.amount + 1)),
@@ -362,9 +362,9 @@ mod create {
 			System::set_block_number(1);
 			let pool_weights = dual_asset_pool_weights(BTC, Permill::from_percent(50), USDT);
 			assert_ok!(Pablo::create(
-				Origin::signed(ALICE),
+				Origin::signed(alice()),
 				PoolInitConfiguration::DualAssetConstantProduct {
-					owner: ALICE,
+					owner: alice(),
 					assets_weights: pool_weights.clone(),
 					fee: Permill::zero(),
 				},

--- a/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests.rs
+++ b/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests.rs
@@ -571,8 +571,10 @@ fn fees() {
 		let initial_btc = 1_00_u128 * unit;
 		let btc_price = 45_000_u128;
 		let initial_usdt = initial_btc * btc_price;
-		let lp_fee = Permill::from_float(0.05);
-		let owner_fee = Permill::from_float(0.01);
+		// 0.05
+		let lp_fee = Permill::from_percent(5);
+		// 0.01
+		let owner_fee = Permill::from_percent(1);
 		let pool_id = create_pool(BTC, USDT, initial_btc, initial_usdt, LP_TOKEN_ID, lp_fee, owner_fee);
 		let bob_usdt = 45_000_u128 * unit;
 		let quote_usdt = bob_usdt - lp_fee.mul_floor(bob_usdt);
@@ -621,7 +623,8 @@ fn staking_pool_test() {
 			BTC,
 			Permill::from_percent(50_u32),
 			USDT,
-			Permill::from_float(0.05),
+			// 0.05
+			Permill::from_percent(5),
 		);
 
 		let pool_id = Pablo::do_create_pool(pool_init_config, Some(LP_TOKEN_ID))
@@ -645,8 +648,8 @@ fn staking_pool_test() {
 		// });
 
 		let bob_usdt = 45_000_u128 * unit;
-		let trading_fee = Perbill::from_float(0.05).mul_floor(bob_usdt);
-		let protocol_fee = Perbill::from_float(0.2).mul_floor(trading_fee);
+		let trading_fee = Perbill::from_percent(5).mul_floor(bob_usdt);
+		let protocol_fee = Perbill::from_percent(20).mul_floor(trading_fee);
 		// Mint the tokens
 		assert_ok!(Tokens::mint_into(USDT, &BOB, bob_usdt));
 
@@ -672,7 +675,7 @@ fn staking_pool_test() {
 fn avoid_exchange_without_liquidity() {
 	new_test_ext().execute_with(|| {
 		let unit = 1_000_000_000_000_u128;
-		let lp_fee = Permill::from_float(0.05);
+		let lp_fee = Permill::from_percent(5);
 		let pool_init_config =
 			valid_pool_init_config(&ALICE, BTC, Permill::from_percent(50_u32), USDT, lp_fee);
 		System::set_block_number(1);
@@ -696,7 +699,7 @@ fn avoid_exchange_without_liquidity() {
 #[test]
 fn cannot_swap_between_wrong_pairs() {
 	new_test_ext().execute_with(|| {
-		let lp_fee = Permill::from_float(0.05);
+		let lp_fee = Permill::from_percent(5);
 		let pool_init_config =
 			valid_pool_init_config(&ALICE, BTC, Permill::from_percent(50_u32), USDT, lp_fee);
 
@@ -753,7 +756,8 @@ fn cannot_swap_between_wrong_pairs() {
 #[test]
 fn cannot_get_exchange_value_for_wrong_asset() {
 	new_test_ext().execute_with(|| {
-		let lp_fee = Permill::from_float(0.05);
+		// 0.05
+		let lp_fee = Permill::from_rational::<u32>(5, 100);
 		let pool_init_config =
 			valid_pool_init_config(&ALICE, BTC, Permill::from_percent(50_u32), USDT, lp_fee);
 		System::set_block_number(1);
@@ -928,7 +932,8 @@ proptest! {
 			initial_btc,
 			initial_usdt,
 			LP_TOKEN_ID,
-			Permill::from_float(0.025),
+			// 0.025
+			Permill::from_rational::<u32>(25, 1000),
 			Permill::zero(),
 		  );
 		  let pool = get_pool(pool_id);

--- a/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests.rs
+++ b/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests.rs
@@ -640,12 +640,6 @@ fn staking_pool_test() {
 			0,
 			false
 		));
-		// make sure a Staking pool is created.
-		// assert_has_event::<Test, _>(|e| {
-		// 	matches!(e.event,
-		//            mock::Event::StakingRewards(pallet_staking_rewards::Event::RewardPoolCreated {
-		// owner, .. })            if owner == Pablo::account_id(&pool_id) )
-		// });
 
 		let bob_usdt = 45_000_u128 * unit;
 		let trading_fee = Perbill::from_percent(5).mul_floor(bob_usdt);
@@ -660,14 +654,6 @@ fn staking_pool_test() {
 			AssetAmount::new(BTC, 0_u128),
 			false
 		));
-		// lp_fee is taken from quote
-		// from lp_fee 20 % (default) (as per owner_fee) goes to staking pool
-		// assert_has_event::<Test, _>(|e| {
-		//        println!("{:?}", e.event);
-		// 	matches!(e.event,
-		//            mock::Event::StakingRewards(pallet_staking_rewards::Event::RewardTransferred {
-		// from, reward_currency, reward_increment, ..})            if from == BOB &&
-		// reward_currency == USDT && reward_increment == protocol_fee) });
 	});
 }
 

--- a/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests_new.rs
+++ b/code/parachain/frame/pablo/src/test/dual_asset_constant_product_tests_new.rs
@@ -1,7 +1,12 @@
-use composable_tests_helpers::test::{
-	block::{next_block, process_and_progress_blocks},
-	currency::{BTC, USDT},
-	helper::RuntimeTrait,
+#![allow(clippy::disallowed_methods)]
+
+use composable_tests_helpers::{
+	test::{
+		block::{next_block, process_and_progress_blocks},
+		currency::{BTC, USDT},
+		helper::RuntimeTrait,
+	},
+	ALICE, BOB,
 };
 use frame_support::{
 	assert_ok,

--- a/code/parachain/frame/pablo/src/test/mod.rs
+++ b/code/parachain/frame/pablo/src/test/mod.rs
@@ -1,4 +1,4 @@
-mod common_test_functions;
+mod common_test_functions; // TODO(benluelo): Remove
 mod dual_asset_constant_product_tests;
 mod dual_asset_constant_product_tests_new;
 mod pablo_tests;

--- a/code/parachain/frame/pablo/src/test/mod.rs
+++ b/code/parachain/frame/pablo/src/test/mod.rs
@@ -2,3 +2,5 @@ mod common_test_functions;
 mod dual_asset_constant_product_tests;
 mod dual_asset_constant_product_tests_new;
 mod pablo_tests;
+
+tests! { mod pablo<crate::mock::Test> }

--- a/code/parachain/frame/pablo/src/test/pablo_tests.rs
+++ b/code/parachain/frame/pablo/src/test/pablo_tests.rs
@@ -11,7 +11,7 @@ use sp_runtime::Permill;
 
 mod create {
 
-	use composable_tests_helpers::ALICE;
+	use composable_tests_helpers::alice;
 
 	use crate::PoolInitConfigurationOf;
 
@@ -20,7 +20,7 @@ mod create {
 	#[test]
 	fn should_successfully_create_50_50_pool() {
 		new_test_ext().execute_with(|| {
-			let owner = ALICE;
+			let owner = alice();
 			let assets_weights = dual_asset_pool_weights(USDC, Permill::from_percent(50), USDT);
 			let fee = Permill::from_percent(1);
 			let pool_config = PoolInitConfigurationOf::<Test>::DualAssetConstantProduct {
@@ -37,7 +37,7 @@ mod create {
 mod simulate {
 	use super::*;
 
-	use composable_tests_helpers::{ALICE, BOB};
+	use composable_tests_helpers::{alice, bob};
 	use composable_traits::dex::Amm;
 	use frame_support::{bounded_btree_map, traits::fungibles::Mutate};
 	use sp_runtime::Permill;
@@ -53,9 +53,9 @@ mod simulate {
 			System::set_block_number(1);
 			let pool_id = Test::assert_extrinsic_event_with(
 				Pablo::create(
-					Origin::signed(ALICE),
+					Origin::signed(alice()),
 					PoolInitConfiguration::DualAssetConstantProduct {
-						owner: ALICE,
+						owner: alice(),
 						assets_weights: bounded_btree_map! {
 							USDT => Permill::from_percent(50),
 							USDC => Permill::from_percent(50),
@@ -69,11 +69,11 @@ mod simulate {
 				},
 			);
 
-			Tokens::mint_into(USDT, &BOB, 1_000_000_000_000_000).unwrap();
-			Tokens::mint_into(USDC, &BOB, 1_000_000_000_000_000).unwrap();
+			Tokens::mint_into(USDT, &bob(), 1_000_000_000_000_000).unwrap();
+			Tokens::mint_into(USDC, &bob(), 1_000_000_000_000_000).unwrap();
 
 			let add_simulation_result = <Pablo as Amm>::simulate_add_liquidity(
-				&BOB,
+				&bob(),
 				pool_id,
 				[(USDT, 100_000_000), (USDC, 100_000_000)].into_iter().collect(),
 			)
@@ -81,7 +81,7 @@ mod simulate {
 
 			let add_result = Test::assert_extrinsic_event_with(
 				Pablo::add_liquidity(
-					Origin::signed(BOB),
+					Origin::signed(bob()),
 					pool_id,
 					[(USDT, 100_000_000), (USDC, 100_000_000)].into_iter().collect(),
 					0,
@@ -96,7 +96,7 @@ mod simulate {
 			assert_eq!(add_simulation_result, add_result);
 
 			let remove_simulation_result = <Pablo as Amm>::simulate_remove_liquidity(
-				&BOB,
+				&bob(),
 				pool_id,
 				add_result,
 				[(USDT, 0), (USDC, 0)].into_iter().collect(),
@@ -105,7 +105,7 @@ mod simulate {
 
 			let remove_result = Test::assert_extrinsic_event_with(
 				Pablo::remove_liquidity(
-					Origin::signed(BOB),
+					Origin::signed(bob()),
 					pool_id,
 					add_result,
 					[(USDT, 0), (USDC, 0)].into_iter().collect(),

--- a/code/parachain/frame/pablo/src/test/pablo_tests.rs
+++ b/code/parachain/frame/pablo/src/test/pablo_tests.rs
@@ -11,6 +11,8 @@ use sp_runtime::Permill;
 
 mod create {
 
+	use composable_tests_helpers::ALICE;
+
 	use crate::PoolInitConfigurationOf;
 
 	use super::*;

--- a/code/parachain/frame/pablo/src/test/pablo_tests.rs
+++ b/code/parachain/frame/pablo/src/test/pablo_tests.rs
@@ -37,12 +37,13 @@ mod create {
 mod simulate {
 	use super::*;
 
+	use composable_tests_helpers::{ALICE, BOB};
 	use composable_traits::dex::Amm;
 	use frame_support::{bounded_btree_map, traits::fungibles::Mutate};
 	use sp_runtime::Permill;
 
 	use crate::{
-		mock::{new_test_ext, Origin, Pablo, System, Test, ALICE},
+		mock::{new_test_ext, Origin, Pablo, System, Test},
 		Event, PoolInitConfiguration,
 	};
 

--- a/code/parachain/frame/pablo/src/testing.rs
+++ b/code/parachain/frame/pablo/src/testing.rs
@@ -1,0 +1,297 @@
+#![allow(clippy::unwrap_used, clippy::disallowed_methods)]
+
+use std::collections::BTreeMap;
+
+use composable_support::math::safe::SafeAdd;
+use composable_tests_helpers::{
+	test::{
+		block::next_block,
+		currency::{Currency, PICA, USDT},
+		helper::RuntimeTrait,
+	},
+	ALICE, BOB,
+};
+use composable_traits::currency::BalanceLike;
+use frame_support::{
+	assert_noop, bounded_btree_map,
+	traits::{fungibles::Mutate, OriginTrait, TryCollect},
+};
+use frame_system::{pallet_prelude::OriginFor, Config as SystemConfig};
+use sp_arithmetic::Permill;
+use sp_runtime::{traits::Zero, AccountId32};
+
+use crate::{Config, Event, Pallet, PoolInitConfiguration};
+
+#[allow(clippy::upper_case_acronyms)]
+type KSM = Currency<4, 12>;
+
+// NOTE/FIXME(benluelo): These trait bounds can be simplified quite a bit once this issue is
+// resolved: https://github.com/rust-lang/rust/issues/20671#issuecomment-529752828
+//
+// Associated type constraints currently aren't resolved at the use site, but super traits (and
+// their associated type constraints) are! To work with this, we write some extra boilerplate here
+// to make the call site only require a simple `<Runtime: Trait>` constraint as opposed to repeating
+// the trait bounds on every function.
+
+/// This trait defines the constraints that pablo assumes from the runtime, allowing tests using
+/// this trait to bound the runtime to be run with any runtime thatr fits within these criteria.
+pub trait PabloRuntimeConstraints:
+	RuntimeTrait<Event<Self>>
+	+ SystemConfig<BlockNumber = Self::__SystemBlockNumber, AccountId = Self::__SystemAccountId>
+	+ Config<Balance = Self::__PabloBalance> // , AssetId = Self::__AssetId
+	+ pallet_timestamp::Config<Moment = Self::__TimestampMoment>
+{
+	// these associated types aren't intended to be used, they only exist for the reasons
+	// described above.
+	type __SystemBlockNumber: From<u32> + Into<u64> + SafeAdd;
+	type __SystemAccountId: From<AccountId32> + Clone;
+	type __TimestampMoment: From<u64>;
+	type __PabloBalance: BalanceLike + From<u128> + Zero;
+	// type __AssetId: Clone;
+}
+
+impl<T> PabloRuntimeConstraints for T
+where
+	T: RuntimeTrait<Event<Self>>,
+	Event<Self>: Into<<Self as SystemConfig>::Event>,
+	T: SystemConfig + Config + pallet_timestamp::Config,
+	<T as SystemConfig>::BlockNumber: From<u32> + Into<u64> + SafeAdd,
+	<T as SystemConfig>::AccountId: From<AccountId32> + Clone,
+	<T as Config>::Balance: BalanceLike + From<u128> + Zero,
+	// <T as Config>::AssetId,
+	<T as pallet_timestamp::Config>::Moment: From<u64>,
+{
+	type __SystemAccountId = <T as SystemConfig>::AccountId;
+	type __SystemBlockNumber = <T as SystemConfig>::BlockNumber;
+	type __TimestampMoment = <T as pallet_timestamp::Config>::Moment;
+	type __PabloBalance = <T as Config>::Balance;
+	// type __AssetId = <T as Config>::AssetId;
+}
+
+fn mint_assets<Runtime: PabloRuntimeConstraints>(
+	asset_id: impl Into<Runtime::AssetId>,
+	who: impl Into<Runtime::AccountId>,
+	amount: impl Into<<Runtime as Config>::Balance>,
+) {
+	<Runtime as Config>::Assets::mint_into(asset_id.into(), &who.into(), amount.into()).unwrap();
+}
+
+pub mod pool_creation {
+	use super::*;
+
+	pub fn create_new_constant_product_pool_1_1<Runtime: PabloRuntimeConstraints>(
+	) -> Runtime::PoolId {
+		next_block::<Pallet<Runtime>, Runtime>();
+
+		let asset_1_id = PICA::ID;
+		let asset_2_id = USDT::ID;
+
+		Runtime::assert_extrinsic_event_with(
+			Pallet::<Runtime>::create(
+				OriginFor::<Runtime>::root(),
+				PoolInitConfiguration::DualAssetConstantProduct {
+					owner: ALICE.into(),
+					assets_weights: bounded_btree_map! {
+						asset_1_id.into() => Permill::from_parts(500_000),
+						asset_2_id.into() => Permill::from_parts(500_000),
+					},
+					fee: Permill::from_parts(10_000),
+				},
+			),
+			|event| match event {
+				Event::PoolCreated { pool_id, .. } => Some(pool_id),
+				_ => None,
+			},
+		)
+	}
+
+	pub fn zero_fees_pool_1_4<Runtime: PabloRuntimeConstraints>() {
+		next_block::<Pallet<Runtime>, Runtime>();
+
+		let asset_1_id = PICA::ID;
+		let asset_2_id = USDT::ID;
+
+		let _pool_id = Runtime::assert_extrinsic_event_with(
+			Pallet::<Runtime>::create(
+				OriginFor::<Runtime>::root(),
+				PoolInitConfiguration::DualAssetConstantProduct {
+					owner: ALICE.into(),
+					assets_weights: bounded_btree_map! {
+						asset_1_id.into() => Permill::from_parts(500_000),
+						asset_2_id.into() => Permill::from_parts(500_000),
+					},
+					fee: Permill::zero(),
+				},
+			),
+			|event| match event {
+				Event::PoolCreated { pool_id, .. } => Some(pool_id),
+				_ => None,
+			},
+		);
+	}
+
+	pub fn pool_assets_cannot_be_the_same_1_6<Runtime: PabloRuntimeConstraints>() {
+		next_block::<Pallet<Runtime>, Runtime>();
+
+		let asset_1_id = PICA::ID;
+		let asset_2_id = PICA::ID;
+
+		assert_noop!(
+			Pallet::<Runtime>::create(
+				OriginFor::<Runtime>::root(),
+				PoolInitConfiguration::DualAssetConstantProduct {
+					owner: ALICE.into(),
+					assets_weights: bounded_btree_map! {
+						asset_1_id.into() => Permill::from_parts(500_000),
+						asset_2_id.into() => Permill::from_parts(500_000),
+					},
+					fee: Permill::zero(),
+				},
+			),
+			crate::Error::<Runtime>::InvalidPair,
+		);
+	}
+}
+
+pub mod providing_liquidity {
+	use super::*;
+
+	pub fn add_liquidity_to_1_1_pool_2_1<Runtime: PabloRuntimeConstraints>() {
+		next_block::<Pallet<Runtime>, Runtime>();
+
+		let pool_id = super::pool_creation::create_new_constant_product_pool_1_1::<Runtime>();
+
+		mint_assets::<Runtime>(PICA::ID, BOB, PICA::units(1_100_000));
+		mint_assets::<Runtime>(USDT::ID, BOB, USDT::units(1_100_000));
+
+		Runtime::assert_extrinsic_event(
+			Pallet::<Runtime>::add_liquidity(
+				OriginFor::<Runtime>::signed(BOB.into()),
+				pool_id,
+				[
+					(PICA::ID.into(), PICA::units(10_000).into()),
+					(USDT::ID.into(), USDT::units(10_000).into()),
+				]
+				.into_iter()
+				.collect(),
+				Zero::zero(),
+				true,
+			),
+			Event::<Runtime>::LiquidityAdded {
+				who: BOB.into(),
+				pool_id,
+				asset_amounts: [
+					(PICA::ID.into(), PICA::units(10_000).into()),
+					(USDT::ID.into(), USDT::units(10_000).into()),
+				]
+				.into_iter()
+				.collect(),
+				minted_lp: 19_999_999_993_470_955_u128.into(),
+			},
+		);
+	}
+}
+
+pub fn add_liquidity<Runtime: PabloRuntimeConstraints>() {
+	next_block::<Pallet<Runtime>, Runtime>();
+
+	let asset_1_id: <Runtime as Config>::AssetId = 1_u128.into();
+	let asset_2_id: <Runtime as Config>::AssetId = 131_u128.into();
+
+	let pool_id = Runtime::assert_extrinsic_event_with(
+		Pallet::<Runtime>::create(
+			OriginFor::<Runtime>::root(),
+			PoolInitConfiguration::DualAssetConstantProduct {
+				owner: ALICE.into(),
+				assets_weights: [
+					(asset_1_id, Permill::from_parts(500_000)),
+					(asset_2_id, Permill::from_parts(500_000)),
+				]
+				.into_iter()
+				.try_collect()
+				.unwrap(),
+				fee: Permill::from_parts(10_000),
+			},
+		),
+		|event| match event {
+			Event::PoolCreated { pool_id, .. } => Some(pool_id),
+			_ => None,
+		},
+	);
+
+	mint_assets::<Runtime>(asset_1_id, BOB, PICA::units(1_100_000));
+	mint_assets::<Runtime>(asset_2_id, BOB, PICA::units(1_100_000));
+
+	let assets =
+		[(asset_1_id, PICA::units(1_000_000).into()), (asset_2_id, PICA::units(1_000_000).into())]
+			.into_iter()
+			.collect::<BTreeMap<_, _>>();
+
+	Runtime::assert_extrinsic_event(
+		Pallet::<Runtime>::add_liquidity(
+			OriginFor::<Runtime>::signed(BOB.into()),
+			pool_id,
+			assets.clone(),
+			Zero::zero(),
+			true,
+		),
+		Event::<Runtime>::LiquidityAdded {
+			who: BOB.into(),
+			pool_id,
+			asset_amounts: assets,
+			minted_lp: 1_999_999_994_552_971_605_u128.into(),
+		},
+	);
+}
+
+pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
+	next_block::<Pallet<Runtime>, Runtime>();
+
+	let asset_1_id: <Runtime as Config>::AssetId = KSM::ID.into();
+	let asset_2_id: <Runtime as Config>::AssetId = USDT::ID.into();
+
+	let pool_id = Runtime::assert_extrinsic_event_with(
+		Pallet::<Runtime>::create(
+			OriginFor::<Runtime>::root(),
+			PoolInitConfiguration::DualAssetConstantProduct {
+				owner: ALICE.into(),
+				assets_weights: [
+					(asset_1_id, Permill::from_parts(500_000)),
+					(asset_2_id, Permill::from_parts(500_000)),
+				]
+				.into_iter()
+				.try_collect()
+				.unwrap(),
+				fee: Permill::from_parts(10_000),
+			},
+		),
+		|event| match event {
+			Event::PoolCreated { pool_id, .. } => Some(pool_id),
+			_ => None,
+		},
+	);
+
+	mint_assets::<Runtime>(asset_1_id, BOB, KSM::units(1_000_000));
+	mint_assets::<Runtime>(asset_2_id, BOB, USDT::units(1_000_000));
+
+	let assets = [(asset_1_id, KSM::units(10).into()), (asset_2_id, USDT::units(100).into())]
+		.into_iter()
+		.collect::<BTreeMap<_, _>>();
+
+	Runtime::assert_extrinsic_event(
+		Pallet::<Runtime>::add_liquidity(
+			OriginFor::<Runtime>::signed(BOB.into()),
+			pool_id,
+			assets.clone(),
+			Zero::zero(),
+			true,
+		),
+		Event::<Runtime>::LiquidityAdded {
+			who: BOB.into(),
+			pool_id,
+			asset_amounts: assets,
+			// TODO(benluelo): Figure out where this number comes from
+			minted_lp: 63_245_552_925_824_u128.into(),
+		},
+	);
+}

--- a/code/parachain/frame/pablo/src/testing.rs
+++ b/code/parachain/frame/pablo/src/testing.rs
@@ -5,12 +5,12 @@ use std::collections::BTreeMap;
 use composable_maths::dex::constant_product::compute_first_deposit_lp;
 use composable_support::math::safe::SafeAdd;
 use composable_tests_helpers::{
+	alice, bob,
 	test::{
 		block::next_block,
 		currency::{Currency, PICA, USDT},
 		helper::RuntimeTrait,
 	},
-	ALICE, BOB,
 };
 use composable_traits::currency::BalanceLike;
 use frame_support::{
@@ -19,6 +19,7 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::OriginFor, Config as SystemConfig};
 use sp_arithmetic::Permill;
+use sp_keyring::sr25519::Keyring;
 use sp_runtime::{traits::Zero, AccountId32};
 
 use crate::{Config, Event, Pallet, PoolInitConfiguration};
@@ -93,7 +94,7 @@ pub mod pool_creation {
 		Runtime::assert_extrinsic_event_with(
 			Pallet::<Runtime>::do_create_pool(
 				PoolInitConfiguration::DualAssetConstantProduct {
-					owner: ALICE.into(),
+					owner: alice().into(),
 					assets_weights: bounded_btree_map! {
 						asset_1_id.into() => Permill::from_parts(500_000),
 						asset_2_id.into() => Permill::from_parts(500_000),
@@ -118,7 +119,7 @@ pub mod pool_creation {
 		let _pool_id = Runtime::assert_extrinsic_event_with(
 			Pallet::<Runtime>::do_create_pool(
 				PoolInitConfiguration::DualAssetConstantProduct {
-					owner: ALICE.into(),
+					owner: alice().into(),
 					assets_weights: bounded_btree_map! {
 						asset_1_id.into() => Permill::from_parts(500_000),
 						asset_2_id.into() => Permill::from_parts(500_000),
@@ -146,7 +147,7 @@ pub mod pool_creation {
 			Pallet::<Runtime>::create(
 				OriginFor::<Runtime>::root(),
 				PoolInitConfiguration::DualAssetConstantProduct {
-					owner: ALICE.into(),
+					owner: alice().into(),
 					assets_weights: bounded_btree_map! {
 						asset_1_id.into() => Permill::from_parts(500_000),
 						asset_2_id.into() => Permill::from_parts(500_000),
@@ -167,8 +168,8 @@ pub mod providing_liquidity {
 
 		let pool_id = super::pool_creation::create_new_constant_product_pool_1_1::<Runtime>();
 
-		mint_assets::<Runtime>(PICA::ID, BOB, PICA::units(1_100_000));
-		mint_assets::<Runtime>(USDT::ID, BOB, USDT::units(1_100_000));
+		mint_assets::<Runtime>(PICA::ID, bob(), PICA::units(1_100_000));
+		mint_assets::<Runtime>(USDT::ID, bob(), USDT::units(1_100_000));
 
 		let assets = [
 			(PICA::ID.into(), PICA::units(10_000).into()),
@@ -179,14 +180,14 @@ pub mod providing_liquidity {
 
 		Runtime::assert_extrinsic_event(
 			Pallet::<Runtime>::add_liquidity(
-				OriginFor::<Runtime>::signed(BOB.into()),
+				OriginFor::<Runtime>::signed(bob().into()),
 				pool_id,
 				assets.clone(),
 				Zero::zero(),
 				true,
 			),
 			Event::<Runtime>::LiquidityAdded {
-				who: BOB.into(),
+				who: bob().into(),
 				pool_id,
 				asset_amounts: assets.clone(),
 				// minted_lp: 19_999_999_993_470_955_u128.into(),
@@ -213,7 +214,7 @@ pub fn add_liquidity<Runtime: PabloRuntimeConstraints>() {
 	let pool_id = Runtime::assert_extrinsic_event_with(
 		Pallet::<Runtime>::do_create_pool(
 			PoolInitConfiguration::DualAssetConstantProduct {
-				owner: ALICE.into(),
+				owner: alice().into(),
 				assets_weights: [
 					(asset_1_id, Permill::from_parts(500_000)),
 					(asset_2_id, Permill::from_parts(500_000)),
@@ -231,8 +232,8 @@ pub fn add_liquidity<Runtime: PabloRuntimeConstraints>() {
 		},
 	);
 
-	mint_assets::<Runtime>(asset_1_id, BOB, PICA::units(1_100_000));
-	mint_assets::<Runtime>(asset_2_id, BOB, PICA::units(1_100_000));
+	mint_assets::<Runtime>(asset_1_id, bob(), PICA::units(1_100_000));
+	mint_assets::<Runtime>(asset_2_id, bob(), PICA::units(1_100_000));
 
 	let assets =
 		[(asset_1_id, PICA::units(1_000_000).into()), (asset_2_id, USDT::units(1_000_000).into())]
@@ -241,14 +242,14 @@ pub fn add_liquidity<Runtime: PabloRuntimeConstraints>() {
 
 	Runtime::assert_extrinsic_event(
 		Pallet::<Runtime>::add_liquidity(
-			OriginFor::<Runtime>::signed(BOB.into()),
+			OriginFor::<Runtime>::signed(bob().into()),
 			pool_id,
 			assets.clone(),
 			Zero::zero(),
 			true,
 		),
 		Event::<Runtime>::LiquidityAdded {
-			who: BOB.into(),
+			who: bob().into(),
 			pool_id,
 			asset_amounts: assets.clone(),
 			minted_lp: compute_first_deposit_lp(
@@ -273,7 +274,7 @@ pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
 	let pool_id = Runtime::assert_extrinsic_event_with(
 		Pallet::<Runtime>::do_create_pool(
 			PoolInitConfiguration::DualAssetConstantProduct {
-				owner: ALICE.into(),
+				owner: alice().into(),
 				assets_weights: [
 					(asset_1_id, Permill::from_parts(500_000)),
 					(asset_2_id, Permill::from_parts(500_000)),
@@ -291,8 +292,8 @@ pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
 		},
 	);
 
-	mint_assets::<Runtime>(asset_1_id, BOB, KSM::units(1_000_000));
-	mint_assets::<Runtime>(asset_2_id, BOB, USDT::units(1_000_000));
+	mint_assets::<Runtime>(asset_1_id, bob(), KSM::units(1_000_000));
+	mint_assets::<Runtime>(asset_2_id, bob(), USDT::units(1_000_000));
 
 	let assets = [(asset_1_id, KSM::units(10).into()), (asset_2_id, USDT::units(100).into())]
 		.into_iter()
@@ -300,14 +301,14 @@ pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
 
 	Runtime::assert_extrinsic_event(
 		Pallet::<Runtime>::add_liquidity(
-			OriginFor::<Runtime>::signed(BOB.into()),
+			OriginFor::<Runtime>::signed(bob().into()),
 			pool_id,
 			assets.clone(),
 			Zero::zero(),
 			true,
 		),
 		Event::<Runtime>::LiquidityAdded {
-			who: BOB.into(),
+			who: bob().into(),
 			pool_id,
 			asset_amounts: assets.clone(),
 			// TODO(benluelo): Figure out where this number comes from

--- a/code/parachain/frame/pablo/src/testing.rs
+++ b/code/parachain/frame/pablo/src/testing.rs
@@ -164,28 +164,25 @@ pub mod providing_liquidity {
 		mint_assets::<Runtime>(PICA::ID, BOB, PICA::units(1_100_000));
 		mint_assets::<Runtime>(USDT::ID, BOB, USDT::units(1_100_000));
 
+		let assets = [
+			(PICA::ID.into(), PICA::units(10_000).into()),
+			(USDT::ID.into(), USDT::units(10_000).into()),
+		]
+		.into_iter()
+		.collect::<BTreeMap<_, _>>();
+
 		Runtime::assert_extrinsic_event(
 			Pallet::<Runtime>::add_liquidity(
 				OriginFor::<Runtime>::signed(BOB.into()),
 				pool_id,
-				[
-					(PICA::ID.into(), PICA::units(10_000).into()),
-					(USDT::ID.into(), USDT::units(10_000).into()),
-				]
-				.into_iter()
-				.collect(),
+				assets.clone(),
 				Zero::zero(),
 				true,
 			),
 			Event::<Runtime>::LiquidityAdded {
 				who: BOB.into(),
 				pool_id,
-				asset_amounts: [
-					(PICA::ID.into(), PICA::units(10_000).into()),
-					(USDT::ID.into(), USDT::units(10_000).into()),
-				]
-				.into_iter()
-				.collect(),
+				asset_amounts: assets,
 				minted_lp: 19_999_999_993_470_955_u128.into(),
 			},
 		);

--- a/code/parachain/frame/pablo/src/testing.rs
+++ b/code/parachain/frame/pablo/src/testing.rs
@@ -19,7 +19,6 @@ use frame_support::{
 };
 use frame_system::{pallet_prelude::OriginFor, Config as SystemConfig};
 use sp_arithmetic::Permill;
-use sp_keyring::sr25519::Keyring;
 use sp_runtime::{traits::Zero, AccountId32};
 
 use crate::{Config, Event, Pallet, PoolInitConfiguration};
@@ -40,13 +39,14 @@ pub const PICA_KSM_LPT: u128 = 107;
 // their associated type constraints) are! To work with this, we write some extra boilerplate here
 // to make the call site only require a simple `<Runtime: Trait>` constraint as opposed to repeating
 // the trait bounds on every function.
+// TODO(benluelo): Proc macro to generate the boilerplate around this trait
 
 /// This trait defines the constraints that pablo assumes from the runtime, allowing tests using
 /// this trait to bound the runtime to be run with any runtime thatr fits within these criteria.
 pub trait PabloRuntimeConstraints:
 	RuntimeTrait<Event<Self>>
 	+ SystemConfig<BlockNumber = Self::__SystemBlockNumber, AccountId = Self::__SystemAccountId>
-	+ Config<Balance = Self::__PabloBalance> // , AssetId = Self::__AssetId
+	+ Config<Balance = Self::__PabloBalance>
 	+ pallet_timestamp::Config<Moment = Self::__TimestampMoment>
 {
 	// these associated types aren't intended to be used, they only exist for the reasons
@@ -190,7 +190,6 @@ pub mod providing_liquidity {
 				who: bob().into(),
 				pool_id,
 				asset_amounts: assets.clone(),
-				// minted_lp: 19_999_999_993_470_955_u128.into(),
 				minted_lp: compute_first_deposit_lp(
 					assets.into_iter().map(|(id, deposit)| {
 						(id.into(), deposit.into(), Permill::from_rational::<u32>(1, 2))
@@ -284,7 +283,7 @@ pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
 				.unwrap(),
 				fee: Permill::from_parts(10_000),
 			},
-			Some(PICA_USDT_LPT.into()),
+			Some(KSM_USDT_LPT.into()),
 		),
 		|event| match event {
 			Event::PoolCreated { pool_id, .. } => Some(pool_id),
@@ -311,8 +310,6 @@ pub fn ksm_usdt<Runtime: PabloRuntimeConstraints>() {
 			who: bob().into(),
 			pool_id,
 			asset_amounts: assets.clone(),
-			// TODO(benluelo): Figure out where this number comes from
-			// minted_lp: 63_245_552_925_824_u128.into(),
 			minted_lp: compute_first_deposit_lp(
 				assets.into_iter().map(|(id, deposit)| {
 					(id.into(), deposit.into(), Permill::from_rational::<u32>(1, 2))

--- a/code/parachain/runtime/dali/Cargo.toml
+++ b/code/parachain/runtime/dali/Cargo.toml
@@ -153,6 +153,10 @@ pallet-ibc-ping = { git = "https://github.com/ComposableFi/centauri", rev = "c7d
 
 [dev-dependencies]
 frame-benchmarking = { package = "frame-benchmarking", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }
+pablo = { package = "pallet-pablo", path = "../../frame/pablo", features = [
+  "testing",
+] }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
 
 [features]
 builtin-wasm = []

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -36,6 +36,10 @@ pub mod xcmp;
 
 use alloc::string::String;
 use core::str::FromStr;
+
+#[cfg(test)]
+mod testing;
+
 pub use versions::*;
 
 use lending::MarketId;

--- a/code/parachain/runtime/dali/src/testing.rs
+++ b/code/parachain/runtime/dali/src/testing.rs
@@ -1,0 +1,1 @@
+::pablo::tests! { mod pablo<crate::Runtime> }

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -132,6 +132,12 @@ orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-l
 # simnode support
 simnode-apis = { package = "simnode-runtime-apis", git = "https://github.com/polytope-labs/substrate-simnode", default-features = false, branch = "polkadot-v0.9.27" }
 
+[dev-dependencies]
+pablo = { package = "pallet-pablo", path = "../../frame/pablo", features = [
+  "testing",
+] }
+sp-io = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.27" }
+
 [features]
 builtin-wasm = []
 default = ["std"]

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -28,6 +28,9 @@ mod migrations;
 mod prelude;
 mod weights;
 
+#[cfg(test)]
+mod tests;
+
 pub mod xcmp;
 pub use common::xcmp::{MaxInstructions, UnitWeightCost};
 pub use xcmp::XcmConfig;

--- a/code/parachain/runtime/picasso/src/tests.rs
+++ b/code/parachain/runtime/picasso/src/tests.rs
@@ -1,0 +1,1 @@
+::pablo::tests! { mod pablo<crate::Runtime> }

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -181,10 +181,6 @@ impl CurrencyId {
 
 		pub const ibcDOT: CurrencyId = CurrencyId(6, None);
 
-		pub const KSM_USDT_LPT: CurrencyId = CurrencyId(105, None);
-		pub const PICA_USDT_LPT: CurrencyId = CurrencyId(106, None);
-		pub const PICA_KSM_LPT: CurrencyId = CurrencyId(107, None);
-
 		/// Staked asset xPICA Token
 		pub const xPICA: CurrencyId = CurrencyId(1001, None);
 		/// Staked asset xLAYR Token
@@ -220,6 +216,12 @@ impl CurrencyId {
 		pub const vKSM: CurrencyId = CurrencyId(103, None);
 		/// Moonriver MOVR
 		pub const MOVR: CurrencyId = CurrencyId(104, None);
+
+		pub const KSM_USDT_LPT: CurrencyId = CurrencyId(105, None);
+		pub const PICA_USDT_LPT: CurrencyId = CurrencyId(106, None);
+		pub const PICA_KSM_LPT: CurrencyId = CurrencyId(107, None);
+		// NOTE: Empty CurrencyId slots starting with 108
+
 
 		/// Karura stable coin(Acala Dollar), not native.
 		pub const kUSD: CurrencyId = CurrencyId(
@@ -373,6 +375,7 @@ mod common_sense {
 		assert_eq!(decimals, 6);
 	}
 }
+
 mod ops {
 	use super::CurrencyId;
 	use core::ops::{Add, Mul};


### PR DESCRIPTION
For a description of the build script, see here: https://github.com/benluelo/substrate-pallet-testing-framework/blob/main/test-builder/README.md

Down the line we would be able to just use that package directly, but for now I have just copy-pasted the build script.

If opening in an editor with an LSP configuration that enables all features by default, I recommend setting `SKIP_TESTS_BUILD_SCRIPT=1` as the build script is not yet well optimized.