### PR TITLE
chore(docs): add cosmwasm-orchestrate docs

### DIFF
--- a/docs/docs/products/cosmwasm-orchestrate.md
+++ b/docs/docs/products/cosmwasm-orchestrate.md
@@ -1,0 +1,95 @@
+# Introduction
+
+CosmWasm Orchestrate is a tool for simulating and testing CosmWasm contracts on a virtual machine. Although this is the first version of the tool, it already provides a very close simulation experience to running your contracts on an actual chain.
+
+## Why use this?
+
+- **Complete simulation on a VM**: Your contracts do not run in a mock environment but actually in a complete VM, therefor your `CosmosMsg`'s, queries, and sub-messages run properly.
+
+- **IBC capable**: You don't need to spin up a few chains to simulate IBC. You can just start a few VM instances on our framework and run IBC contracts in memory. This means that you will be able to test your IBC contracts really fast and correctly.
+    
+- **Easy to use**: Talking about VMs might sound frustrating but there is almost no setup necessary to run a test. Just provide the wasm contract that you want to test and call the entry point that you wanna test.
+
+- **Flexible**: The framework is also very flexible and lets you define your own mechanism to handle custom messages, handle different address formats and even implement your own host functions and VM.
+
+
+## A Quick Example
+
+Enough talking and let's check out a very basic usage of our framework. Here you can see we execute a `cw20-base` contract. The exact steps are:
+
+1. Fetch the wasm binary of the contract with the address `juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf`.
+2. Instantiate the `cw20-base` contract.
+3. Execute a transfer.
+4. Query the contract to see if the transfer is done correctly.
+
+All in just a few lines.
+
+```rust
+// Fetch the wasm binary of the given contract from a remote chain.
+let code = CosmosFetcher::from_contract_addr(
+    "https://juno-api.polkachu.com",
+    "juno19rqljkh95gh40s7qdx40ksx3zq5tm4qsmsrdz9smw668x9zdr3lqtg33mf",
+)
+.await
+.unwrap();
+
+// Generate a Juno compatible address
+let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+
+// Create a VM state by providing the codes that will be executed.
+let mut state = StateBuilder::new().add_code(&code).build();
+
+let info = info(&sender);
+
+// Instantiate the cw20 contract
+let (contract, _) = <JunoApi>::instantiate(
+    &mut state,
+    1,
+    None,
+    block(),
+    None,
+    info.clone(),
+    100_000_000,
+    InstantiateMsg {
+        name: "Picasso".into(),
+        symbol: "PICA".into(),
+        decimals: 12,
+        initial_balances: vec![Cw20Coin {
+            amount: 10000000_u128.into(),
+            address: sender.into(),
+        }],
+        mint: None,
+        marketing: None,
+    },
+)
+.unwrap();
+
+// Transfer 10_000 PICA to the "receiver"
+let _ = <JunoApi>::execute(
+    &mut state,
+    env(&contract),
+    info,
+    100_000_000,
+    ExecuteMsg::Transfer {
+        recipient: Account::generate_from_seed::<JunoAddressHandler>("receiver")
+            .unwrap()
+            .into(),
+        amount: 10_000_u128.into(),
+    },
+)
+.unwrap();
+
+// Read the balance by using query. Note that the raw storage can be read here as well.
+let balance_response: BalanceResponse = JunoApi::<Direct>::query(
+    &mut state,
+    env(&contract),
+    QueryMsg::Balance {
+        address: Account::generate_from_seed::<JunoAddressHandler>("receiver")
+            .unwrap()
+            .into(),
+    },
+)
+.unwrap();
+
+assert_eq!(Into::<u128>::into(balance_response.balance), 10_000_u128);
+```

--- a/docs/docs/products/cosmwasm-orchestrate/concepts/address-handlers.md
+++ b/docs/docs/products/cosmwasm-orchestrate/concepts/address-handlers.md
@@ -1,0 +1,80 @@
+# Address Handlers
+
+Throughout this documentation, you see that we always use `JunoApi`. But there are a 
+few other APIs as well like `WasmApi`, `SubstrateApi`, etc. The only difference between
+these APIs is how they handle address generation, validation, and canonicalization.
+
+For example, Cosmos APIs like `JunoApi` or `WasmApi` use `Bech32` encoding and `JunoApi` uses
+`juno` as the prefix and `WasmApi` uses `wasm` as the prefix.
+
+## Creating your own Cosmos address handler
+
+Cosmos address handlers are implementing the `CosmosAddressHandler` trait which
+handles the `Bech32` stuff under the hood. The only thing that you want to specify
+is the `PREFIX` constant which is the prefix value in `Bech32` encoding.
+
+Let's create an Address Handler for `CoolChain` where the prefix is `cool`:
+
+```rust
+pub struct CoolAddressHandler;
+
+impl CosmosAddressHandler for CoolAddressHandler {
+    const PREFIX: &'static str = "cool";
+}
+```
+
+For ease of use, you can also define this API:
+
+```rust
+pub type CoolApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    CoolAddressHandler,
+    State<(), CoolAddressHandler>,
+    Context<'a, (), CoolAddressHandler>,
+>;
+```
+
+From now on, you can generate account addresses by using `CoolAddressHandler`:
+
+```rust
+Account::generate_from_seed::<CoolAddressHandler>("sender").unwrap();
+```
+
+And you will use the `CoolApi` for API calls:
+
+```rust
+<CoolApi>::instantiate(..);
+```
+
+## Implementing an address handler from scratch
+
+You can also implement an address handler from scratch by implementing `AddressHandler` trait.
+
+Let's implement a dummy address handler that works with `String` addresses without any restrictions.
+
+```rust
+struct DummyAddressHandler;
+
+impl AddressHandler for DummyAddressHandler {
+    fn addr_canonicalize(input: &str) -> Result<Vec<u8>, VmError> {
+        // We just convert the address into binary
+        Ok(input.as_bytes().into())
+    }
+
+    fn addr_humanize(addr: &[u8]) -> Result<String, VmError> {
+        String::from_utf8(addr.into()).map_err(|_| VmError::InvalidAddress)
+    }
+
+    fn addr_generate<'a, I: IntoIterator<Item = &'a [u8]>>(iter: I) -> Result<String, VmError> {
+        // Just hash the inputs
+        let mut hash = Sha256::new();
+        for data in iter {
+            hash = hash.chain_update(data);
+        }
+        Self::addr_humanize(hash.finalize().as_ref())
+    }
+}
+```
+
+Then follow the above steps to use it in your tests and that's all.

--- a/docs/docs/products/cosmwasm-orchestrate/concepts/concepts.md
+++ b/docs/docs/products/cosmwasm-orchestrate/concepts/concepts.md
@@ -1,0 +1,9 @@
+# Concepts
+
+There are a few concepts that are good for a user to know, these are:
+
+* [`Direct` and `Dispatch` execution types](./direct-dispatch.md): Explains the behaviors of `Direct`
+and `Dispatch` execution types and their use cases.
+* [Address handlers](./address-handlers.md): Explains why we have different APIs and how you can
+implement your address handler based on your needs.
+* [Custom message/query handler](./custom-handler.md): Explains how a user can enable handling of `CosmosMsg::Custom` and `QueryRequest::Custom`.

--- a/docs/docs/products/cosmwasm-orchestrate/concepts/custom-handler.md
+++ b/docs/docs/products/cosmwasm-orchestrate/concepts/custom-handler.md
@@ -1,0 +1,71 @@
+# Custom Message Handler
+
+`CustomMsg` calls result in `NotSupported` error in the default implementation. But our 
+framework is flexible enough to let you define your own custom message logic.
+
+
+## Implementing a custom message handler
+
+If your chain supports `CosmosMsg::Custom`, you can simply implement the `CustomHandler`
+trait in our framework and handle custom messages and queries. Note that your `CustomHandler`
+type needs to implement `Clone` because it will get reverted if the transaction fails.
+
+```rust
+/// Type that implements the CustomHandler
+#[derive(Default, Clone)]
+pub struct MyCustomHandler {}
+
+/// Custom message type
+#[derive(Debug, Deserialize)]
+pub struct MyCustomMessage;
+
+/// Custom query type
+#[derive(Debug, Deserialize)]
+pub struct MyCustomQuery;
+
+impl CustomHandler for MyCustomHandler {
+    type QueryCustom = MyCustomQuery;
+    type MessageCustom = MyCustomMessage;
+
+    fn handle_message<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        message: MyCustomMessage,
+        _event_handler: &mut dyn FnMut(Event),
+    ) -> Result<Option<Binary>, VmError> {
+        vm.state
+            .db
+            .custom_handler
+            .do_something_with_message(message);
+        Ok(None)
+    }
+
+    fn handle_query<AH: AddressHandler>(
+        vm: &mut Context<Self, AH>,
+        query: MyCustomQuery,
+    ) -> Result<SystemResult<CosmwasmQueryResult>, VmError> {
+        vm.state.db.custom_handler.do_something_with_query(query);
+        Ok(SystemResult::Ok(CosmwasmQueryResult::Ok(vec![].into())))
+    }
+}
+```
+
+Then you again need to create an `Api` type which uses `MyCustomHandler`.
+
+```rust
+pub type CustomJunoApi<'a, E = Dispatch> = Api<
+    'a,
+    E,
+    JunoAddressHandler,
+    State<MyCustomHandler, JunoAddressHandler>,
+    Context<'a, MyCustomHandler, JunoAddressHandler>,
+>;
+```
+
+One more thing is, you need to provide `MyCustomHandler` to the `StateBuilder`.
+
+```rust
+let mut state = StateBuilder::<JunoAddressHandler, MyCustomHandler>::new()
+    .add_code(&code)
+    .set_custom_handler(MyCustomHandler {})
+    .build();
+```

--- a/docs/docs/products/cosmwasm-orchestrate/concepts/direct-dispatch.md
+++ b/docs/docs/products/cosmwasm-orchestrate/concepts/direct-dispatch.md
@@ -1,0 +1,42 @@
+# `Direct` and `Dispatch` APIs 
+
+Sometimes, it might be not required to do a complete simulation of an entry point.
+For example, you might wanna execute `instantiate` entry point but you might just want to
+get the `instantiate` functions result and not proceed to sub-message execution.
+Therefore, there are two execution types that handle exactly this: `Direct` and `Dispatch`.
+
+
+## Dispatch
+
+When you want to simulate a complete execution like how a transaction is handled in a real environment, `Dispatch` is used.
+`Dispatch` executes the entry point you call and also handles the sub-messages. It commits the transaction
+changes when the execution succeeds and aborts it when the execution fails.
+
+Note that the same error-handling mechanism is valid here as well. In the case of an error in the top-level contract,
+the transaction will be reverted, otherwise, the behavior will be up to the user (catching errors with `Reply`).
+
+`Dispatch` is the default execution type of `API`s. So you don't need to specify `Dispatch`
+like `JunoApi::<Dispatch>::..`. But note that, because of the limitations of rust's type
+inference, you can't do `JunoApi::instantiate`, but need to use it like `<JunoApi>::instantiate` for
+Rust to infer the generic types for you.
+
+
+## Direct
+
+Some entry points like `query` are not meant to be `Dispatch` and also sometimes you might just 
+run an entry point and get the `Response` without running sub-messages or creating a transaction. 
+`Direct` is used in this case. Running a dispatchable entry point(eg. `instantiate`) with `Direct` is like a unit test.
+
+But the notable thing is some entry points like `instantiate` might modify the storage. And since they are not
+handled like `Dispatch`, the changes won't get reverted if the execution fails. It is not a big deal since
+you will probably want to abort the test in case of failure anyways. But if for some reason you want to call
+a dispatchable entry point and make sure that the storage modifications are not persisted, you can just create
+a separate state for each run.
+
+You can set the execution type to `Direct` by specifying it during the call:
+
+```rust
+JunoApi::<Direct>::instantiate();
+// or
+<JunoApi<Direct>>::instantiate();
+```

--- a/docs/docs/products/cosmwasm-orchestrate/tutorial-dex.md
+++ b/docs/docs/products/cosmwasm-orchestrate/tutorial-dex.md
@@ -1,0 +1,421 @@
+# Tutorial: Testing a DEX 
+
+Let's see a real-world example by testing `wasmswap`. We are going to swap the native token `cosm`
+with the Cw20 token `pica`.
+
+## Setting up
+
+We are using a slightly modified version of `wasmswap`. The only difference is our VM doesn't alter
+the `data` field because it is supposed to be up to user to use any data in any format. So we chose
+to follow the spec there. Let's clone the template for our tutorial:
+
+```sh
+git clone https://github.com/ComposableFi/cw-toolkit
+cd cw-toolkit
+git checkout tags/wasmswap-template
+cd orchestrate-tutorial
+```
+
+Add the latest `cosmwasm-orchestrate` as a `dev-dependency`:
+
+```toml
+# In Cargo.toml
+
+[dev-dependencies]
+cosmwasm-orchestrate = { git = "https://github.com/ComposableFi/cosmwasm-vm" }
+```
+
+And let's create a file for the integration tests:
+
+```bash
+mkdir tests
+touch tests/integration.rs
+```
+
+## Setting up the state for the test
+
+### Code
+
+```rust
+// In `integration.rs`
+
+use cosmwasm_orchestrate::{
+    block,
+    cosmwasm_std::{Coin, MessageInfo},
+    env, info,
+    vm::*,
+    Direct, JunoApi, StateBuilder, WasmLoader,
+};
+use cosmwasm_std::{Addr, Decimal, Uint128};
+use cw20::{BalanceResponse, Cw20Coin, Cw20ExecuteMsg, Cw20QueryMsg, Denom};
+use cw20_base::msg::InstantiateMsg as Cw20InstantiateMsg;
+use wasmswap::msg::{ExecuteMsg, InstantiateMsg, TokenSelect};
+
+#[test]
+fn swap_works() {
+    // Compile and load the wasmswap contract
+    let wasmswap_code = WasmLoader::new(env!("CARGO_PKG_NAME")).load().unwrap();
+    let cw20_code = include_bytes!("../scripts/cw20_base.wasm");
+    // Create a VM state by providing the codes that will be executed.
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_code(cw20_code)
+        .build();
+}
+```
+
+If you were to build your test right now, it will fail but we'll shortly make it work, no worries.
+
+### Analyze
+
+```rust
+let cw20_code = include_bytes!("../scripts/cw20_base.wasm");
+```
+For loading `cw20_base` contract, we just used `include_bytes` because we have the binary locally.
+But if you need to get this binary from a (reliable) remote source, you could also use:
+* `CosmosFetcher`: To fetch the code from a Cosmos chain.
+* `FileFetcher`: To fetch the code from a server. (Like using `wget`)
+
+---
+
+```rust
+let wasmswap_code = WasmLoader::new(env!("CARGO_PKG_NAME")).load().unwrap();
+```
+For the wasmswap contract, we used a special type of loader which is `WasmLoader`. The thing is
+our VM works with wasm binaries just like any other chain. So we need to make sure that we are
+feeding the VM with the latest compiled wasm binary every time we run the tests. We could manually
+compile the binary and just do `include_bytes` but believe me, you will forget to do it very often
+and get confused. 
+
+`WasmLoader` gets the package name and compiles and loads the contract for you. Note that the default
+configuration assumes the rust package name is the same as the contract name. So `wasmswap` as the package
+name means that the contract's name is also `wasmswap` and the full name will be `wasmswap.wasm`.
+The second assumption of the default loader is the target directory is `target/wasm32-unknown-unknown/release`.
+The good thing is you can configure any of those, even the command that will be used to build your 
+contract.
+
+---
+
+```rust
+let mut state = StateBuilder::new()
+    .add_code(&wasmswap_code) // code_id = 1
+    .add_code(cw20_code)      // code_id = 2
+    .build();
+```
+Finally, we need to create a `State` for the VM which will contain the wasm binaries. Note that 
+code id's that we are gonna use later on will be in the same order as how it is given to the `StateBuilder`.
+So in this case, `code_id` for `wasmswap_code` will be `1` and `2` for `cw20_code`.
+
+## Instantiating the token
+
+Let's instantiate the `cw20` contract for `PICA`.
+
+### Code
+```rust
+    let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+
+    // Instantiate the cw20 contract
+    let (cw20_address, _) = <JunoApi>::instantiate(
+        &mut state,
+        2,  // Code ID of cw20_base is 2
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000_000,
+        Cw20InstantiateMsg {
+            name: "Picasso".into(),
+            symbol: "PICA".into(),
+            decimals: 10,
+            initial_balances: vec![Cw20Coin {
+                address: sender.clone().into(),
+                amount: Uint128::new(100_000_000_000_000),
+            }],
+            mint: None,
+            marketing: None,
+        },
+    )
+    .unwrap();
+```
+
+To run, use:
+```rust
+cargo test --test integration
+```
+
+### Analyze
+
+```rust
+let sender = Account::generate_from_seed::<JunoAddressHandler>("sender").unwrap();
+```
+
+We need to create a valid address which we are gonna use to call the contracts. Which is the
+`sender` field in `MessageInfo`. For that, we are using `Account` type with `JunoAddressHandler`.
+This will create a `bech32` encoded address with `juno` prefix.
+
+---
+
+```rust
+let (cw20_address, _) = <JunoApi>::instantiate(
+    &mut state,
+    2,  // Code ID of cw20_base is 2
+    None,
+    block(),
+    None,
+    info(&sender),
+    100_000_000_000, // We don't care about the gas
+    Cw20InstantiateMsg {
+        name: "Picasso".into(),
+        symbol: "PICA".into(),
+        decimals: 10,
+        initial_balances: vec![Cw20Coin {
+            address: sender.clone().into(),
+            amount: Uint128::new(100_000_000_000_000),
+        }],
+        mint: None,
+        marketing: None,
+    },
+)
+.unwrap();
+```
+
+And then we are instantiating the `cw20` contract. The first notable thing is we are using `JunoApi` because
+we have used the `JunoAddressHandler`. `JunoApi` will use `JunoAddressHandler` as the address handler.
+
+Note that we are giving the instantiate message as is without doing any JSON encoding. This is because
+`instantiate` function gets any JSON-serializable type and serializes it under the hood. But if you
+have no access to message type and you don't want to define them yourself, you can use `instantiate_raw`
+function and provide the JSON-encoded message.
+
+Finally, note that we do `info(&sender)` which creates a `MessageInfo` and sets the `sender` field to
+the given account's address.
+
+## Instantiating the swap
+
+Next thing is to instantiate the swap with the token we just created.
+
+```rust
+    let (contract_addr, _) = <JunoApi>::instantiate(
+        &mut state,
+        1, // Code ID for wasmswap is 1
+        None,
+        block(),
+        None,
+        info(&sender),
+        100_000_000_000,
+        InstantiateMsg {
+            token1_denom: Denom::Native("cosm".into()),
+            token2_denom: Denom::Cw20(Addr::unchecked(cw20_address.clone())),
+            lp_token_code_id: 2,
+            owner: None,
+            protocol_fee_recipient: sender.clone().into(),
+            protocol_fee_percent: Decimal::zero(),
+            lp_fee_percent: Decimal::zero(),
+        },
+    )
+    .unwrap();
+```
+
+Just as we instantiated the `cw20` token, we instantiated the swap. Note that `cw20_address` that
+we got from the previous token instantiation is given to the swap contract as the `cw20` token.
+
+And also, `lp_token_code_id` is set to `2` which is the code id for `cw20_base`.
+
+## Increasing allowance
+
+Before executing the swap, we need to make sure that the swap contract has the allowance to transfer tokens
+from the account that does the swap. So let's create a second account and increase the allowance for the
+swap contract.
+
+```rust
+    // Create the second account which will do the swap
+    let swapper = Account::generate_from_seed::<JunoAddressHandler>("swapper").unwrap();
+
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&cw20_address),
+        info(&sender),
+        100_000_000_000,
+        Cw20ExecuteMsg::IncreaseAllowance {
+            spender: contract_addr.clone().into(),
+            amount: Uint128::new(100_000_000_000),
+            expires: Some(cw0::Expiration::Never {}),
+        },
+    )
+    .unwrap();
+```
+
+Note that we have given `cw20_address` to the `env` function. This will create an `Env` and set 
+`contract.address` field to the given address and this contract will be executed.
+
+## Adding liquidity to the swap
+
+We also need to have enough liquidity to be able to do the swap. So let's add some juice.
+
+```rust
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&contract_addr),
+        MessageInfo {
+            sender: sender.clone().into(),
+            funds: vec![Coin::new(400_000_000, "cosm")],
+        },
+        100_000_000_000,
+        ExecuteMsg::AddLiquidity {
+            token1_amount: 400_000_000u128.into(),
+            min_liquidity: 50_000u128.into(),
+            max_token2: 300_000_000u128.into(),
+            expiration: None,
+        },
+    )
+    .unwrap();
+```
+
+And when we execute it:
+```sh
+thread 'works' panicked at 'called `Result::unwrap()` on an `Err` value: BankError(InsufficientBalance)', tests/orchestrate.rs:109:6
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+```
+
+WHAT THE HELL?
+
+No worries, it is intended to show you how to easily understand what went wrong. Our VM logs too many
+great things about the execution flow which includes the error messages. So let's enable logs to see
+all that yummy logs.
+
+```toml
+# In Cargo.toml
+env_logger = "0.10"
+```
+
+```rust
+// In integration.rs
+
+fn initialize() {
+    use std::sync::Once;
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        env_logger::init();
+    });
+}
+
+#[test]
+fn swap_works() {
+    initialize();
+}
+
+```
+
+And then let's execute the test once more with enabling the logs.
+
+```rust
+RUST_LOG=debug cargo test --test integration
+```
+
+Before going into the reason for failure, take your time to read the logs and see how much useful information
+there is. You can see the host functions that are running, responses from the executions, and
+sub-messages that are dispatched.
+
+Now let's see what went wrong:
+```
+[2022-12-11T20:10:53Z DEBUG cosmwasm_orchestrate::vm] Transfer: 
+    Account(Addr("juno1pgm8hyk0pvphmlvfjc8wsvk4daluz5tgrw6pu5mfpemk74uxnx9qwm56ug")) 
+    -> Account(Addr("juno1ptl22cw3jth6ue4ruhgef2s5gfz23tt57vlrmydqu7vxk5xhn4gse7s6fe"))
+    [Coin { denom: "cosm", amount: Uint128(400000000) }]
+
+[2022-12-11T20:10:53Z DEBUG cosmwasm_orchestrate::vm] < Transaction abort: 0
+```
+
+The VM is trying to transfer `400_000_000cosm` and then it aborts the transaction with `BankError(InsufficientBalance)`.
+
+The problem is obvious. See that we needed to transfer some funds to the contract to be able to add the
+liquidity by properly setting `funds` field in the `MessageInfo`. But the `sender` account does not have
+any `cosm` balance at all. So, the VM tried to transfer the given funds to the contract before execution
+and failed.
+
+Let's add some balance to the `sender` account in the `StateBuilder`.
+
+```rust
+    // Change the `StateBuilder` to:
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_balance(sender.clone(), Coin::new(100_000_000_000_000, "cosm"))
+        .add_code(cw20_code)
+        .build();
+
+```
+
+Now that we have enough balance, let's re-run again and see the lovely green `ok` message.
+
+## `cosmwasm_std` vs. `cosmwasm_orchestrate::cosmwasm_std`
+
+You might have already noticed it but we are using `Coin` and `MessageInfo` from `cosmwasm_orchestrate::cosmwasm_std`
+instead of using them directly from `cosmwasm_std`. This is a temporary thing that we hope to resolve
+soon. The problem is our VM is `no_std` but `cosmwasm_std` is originally only `std`. We created a PR
+for this and until it gets merged, `cosmwasm-orchestrate` will be using our fork, hence `Cargo` thinks
+that `cosmwasm_std::Coin` is not the same thing as `cosmwasm_orchestrate::cosmwasm_std::Coin`. Until the
+merge, for any type/function that is given to `cosmwasm-orchestrate`, use `cosmwasm_orchestrate::cosmwasm_std`.
+You will get a type mismatch error if you do it wrong, so beware of that.
+
+## Executing the swap
+```rust
+    // Change the `StateBuilder` to:
+    let mut state = StateBuilder::new()
+        .add_code(&wasmswap_code)
+        .add_balance(sender.clone(), Coin::new(100_000_000_000_000, "cosm"))
+        .add_balance(swapper.clone(), Coin::new(120_000_000, "cosm"))
+        .add_code(cw20_code)
+        .build();
+
+    let _ = <JunoApi>::execute(
+        &mut state,
+        env(&contract_addr),
+        MessageInfo {
+            sender: swapper.clone().into(),
+            funds: vec![Coin::new(120_000_000, "cosm")],
+        },
+        100_000_000_000,
+        ExecuteMsg::Swap {
+            input_token: TokenSelect::Token1,
+            input_amount: Uint128::new(120_000_000),
+            min_output: Uint128::zero(),
+            expiration: None,
+        },
+    )
+    .unwrap();
+```
+
+Note that we add balance to `swapper` account as well to be able to send funds to the swap contract.
+And finally, we can swap `120_000_000cosm`. The final thing to do is verify the swap worked.
+
+## Verifying the swap
+
+We will check `swapper`'s `pica` balance to verify the swap. To do that, we need to query the `cw20` token.
+
+```rust
+    let query_res: BalanceResponse = <JunoApi<Direct>>::query(
+        &mut state,
+        env(&cw20_address),
+        Cw20QueryMsg::Balance {
+            address: swapper.clone().into(),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        query_res.balance,
+        Uint128::new((120_000_000 * 300_000_000) / (400_000_000 + 120_000_000))
+    );
+```
+
+Note that we used `<JunoApi<Direct>>` this time instead of `<JunoApi>`. This is because the execution
+type for `query` can only be `Direct`. See previous sections to learn more about this.
+
+And here we verified the whole execution.
+
+One final note is if you were to verify the native balances also, you could directly use the bank module
+to see the balances:
+
+```rust
+state.db.bank.balance(&swapper, "cosm");
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -191,6 +191,34 @@ const sidebars = {
         },
         {
           type: 'category',
+          label: 'CosmWasm Orchestrate',
+          link: {
+            type: 'doc',
+            id: 'products/cosmwasm-orchestrate'
+          },
+          collapsible: true,
+          collapsed: true,
+          items: [
+            {
+              type: 'category',
+              label: 'Concepts',
+              link: {
+                type: 'doc',
+                id: 'products/cosmwasm-orchestrate/concepts/concepts'
+              },
+              collapsible: true,
+              collapsed: true,
+              items: [
+                'products/cosmwasm-orchestrate/concepts/direct-dispatch',
+                'products/cosmwasm-orchestrate/concepts/address-handlers',
+                'products/cosmwasm-orchestrate/concepts/custom-handler',
+              ]
+            },
+            'products/cosmwasm-orchestrate/tutorial-dex'
+          ]
+        },
+        {
+          type: 'category',
           label: 'Mosaic (Discontinued)',
           link: {
             type: 'doc',


### PR DESCRIPTION
Just moved `cosmwasm-orchestrate` docs to here from `cosmwasm-vm` to take advantage of CI and beautiful docusaurus.