### PR TITLE
Ben/simulate add remove liquidity

### DIFF
--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -87,7 +87,8 @@ pub trait Amm {
 		who: &Self::AccountId,
 		pool_id: Self::PoolId,
 		lp_amount: Self::Balance,
-	) -> Result<RemoveLiquiditySimulationResult<Self::AssetId, Self::Balance>, DispatchError>
+		min_amounts: BTreeMap<Self::AssetId, Self::Balance>,
+	) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError>
 	where
 		Self::AssetId: sp_std::cmp::Ord;
 
@@ -121,7 +122,7 @@ pub trait Amm {
 		assets: BTreeMap<Self::AssetId, Self::Balance>,
 		min_mint_amount: Self::Balance,
 		keep_alive: bool,
-	) -> Result<(), DispatchError>;
+	) -> Result<Self::Balance, DispatchError>;
 
 	/// Withdraw coins from the pool.
 	/// Withdrawal amount are based on current deposit ratios.
@@ -132,7 +133,7 @@ pub trait Amm {
 		pool_id: Self::PoolId,
 		lp_amount: Self::Balance,
 		min_receive: BTreeMap<Self::AssetId, Self::Balance>,
-	) -> Result<(), DispatchError>;
+	) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError>;
 
 	/// Perform an exchange effectively trading the in_asset against the min_receive one.
 	fn do_swap(
@@ -326,16 +327,6 @@ pub struct PriceAggregate<PoolId, AssetId, Balance> {
 #[derive(RuntimeDebug, Encode, Decode, Default, Clone, PartialEq, Eq, TypeInfo)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub struct RedeemableAssets<AssetId, Balance>
-where
-	AssetId: Ord,
-{
-	pub assets: BTreeMap<AssetId, Balance>,
-}
-
-/// RemoveLiquiditySimulationResult for given amount of lp tokens.
-#[derive(RuntimeDebug, Encode, Decode, Default, Clone, PartialEq, Eq, TypeInfo)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct RemoveLiquiditySimulationResult<AssetId, Balance>
 where
 	AssetId: Ord,
 {

--- a/code/parachain/frame/dex-router/src/lib.rs
+++ b/code/parachain/frame/dex-router/src/lib.rs
@@ -32,10 +32,7 @@ pub mod pallet {
 	use composable_support::math::safe::SafeArithmetic;
 	use composable_traits::{
 		defi::CurrencyPair,
-		dex::{
-			Amm, AssetAmount, DexRoute, DexRouter, RedeemableAssets,
-			RemoveLiquiditySimulationResult, SwapResult,
-		},
+		dex::{Amm, AssetAmount, DexRoute, DexRouter, RedeemableAssets, SwapResult},
 	};
 	use core::fmt::Debug;
 	use frame_support::{pallet_prelude::*, transactional, PalletId};
@@ -442,10 +439,12 @@ pub mod pallet {
 			who: &Self::AccountId,
 			pool_id: Self::PoolId,
 			lp_amount: Self::Balance,
-		) -> Result<RemoveLiquiditySimulationResult<Self::AssetId, Self::Balance>, DispatchError> {
+			min_amounts: BTreeMap<Self::AssetId, Self::Balance>,
+		) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError> {
 			let (route, _reverse) = Self::get_route(pool_id).ok_or(Error::<T>::NoRouteFound)?;
 			match route[..] {
-				[pool_id] => T::Pablo::simulate_remove_liquidity(who, pool_id, lp_amount),
+				[pool_id] =>
+					T::Pablo::simulate_remove_liquidity(who, pool_id, lp_amount, min_amounts),
 				_ => Err(Error::<T>::UnsupportedOperation.into()),
 			}
 		}
@@ -581,7 +580,7 @@ pub mod pallet {
 			assets: BTreeMap<Self::AssetId, Self::Balance>,
 			min_mint_amount: Self::Balance,
 			keep_alive: bool,
-		) -> Result<(), DispatchError> {
+		) -> Result<Self::Balance, DispatchError> {
 			let (route, _reverse) = Self::get_route(pool_id).ok_or(Error::<T>::NoRouteFound)?;
 			match route[..] {
 				[pool_id] =>
@@ -596,7 +595,7 @@ pub mod pallet {
 			pool_id: Self::PoolId,
 			lp_amount: Self::Balance,
 			min_receive: BTreeMap<Self::AssetId, Self::Balance>,
-		) -> Result<(), DispatchError> {
+		) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError> {
 			let (route, _reverse) = Self::get_route(pool_id).ok_or(Error::<T>::NoRouteFound)?;
 			match route[..] {
 				[pool_id] => T::Pablo::remove_liquidity(who, pool_id, lp_amount, min_receive),

--- a/code/parachain/frame/pablo/rpc/src/lib.rs
+++ b/code/parachain/frame/pablo/rpc/src/lib.rs
@@ -1,6 +1,6 @@
 use codec::Codec;
 use composable_support::rpc_helpers::SafeRpcWrapper;
-use composable_traits::dex::{PriceAggregate, RemoveLiquiditySimulationResult};
+use composable_traits::dex::PriceAggregate;
 use core::{fmt::Display, str::FromStr};
 use jsonrpsee::{
 	core::{Error as RpcError, RpcResult},
@@ -50,7 +50,7 @@ where
 		lp_amount: SafeRpcWrapper<Balance>,
 		min_expected_amounts: BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>,
 		at: Option<BlockHash>,
-	) -> RpcResult<RemoveLiquiditySimulationResult<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>>;
+	) -> RpcResult<BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>>;
 }
 
 pub struct Pablo<C, Block> {
@@ -133,8 +133,7 @@ where
 		lp_amount: SafeRpcWrapper<Balance>,
 		min_expected_amounts: BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>,
 		at: Option<<Block as BlockT>::Hash>,
-	) -> RpcResult<RemoveLiquiditySimulationResult<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>>
-	{
+	) -> RpcResult<BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>> {
 		let api = self.client.runtime_api();
 
 		let at = BlockId::hash(at.unwrap_or_else(|| self.client.info().best_hash));

--- a/code/parachain/frame/pablo/runtime-api/src/lib.rs
+++ b/code/parachain/frame/pablo/runtime-api/src/lib.rs
@@ -4,7 +4,7 @@
 
 use codec::Codec;
 use composable_support::rpc_helpers::SafeRpcWrapper;
-use composable_traits::dex::{PriceAggregate, RemoveLiquiditySimulationResult};
+use composable_traits::dex::PriceAggregate;
 use sp_std::collections::btree_map::BTreeMap;
 
 // Pablo Runtime API declaration. Implemented for each runtime at
@@ -37,6 +37,6 @@ sp_api::decl_runtime_apis! {
 			pool_id: SafeRpcWrapper<PoolId>,
 			lp_amount: SafeRpcWrapper<Balance>,
 			min_expected_amounts: BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>,
-		) -> RemoveLiquiditySimulationResult<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>;
+		) -> BTreeMap<SafeRpcWrapper<AssetId>, SafeRpcWrapper<Balance>>;
 	}
 }

--- a/code/parachain/frame/pablo/src/test/pablo_tests.rs
+++ b/code/parachain/frame/pablo/src/test/pablo_tests.rs
@@ -1,7 +1,11 @@
+#![allow(clippy::disallowed_methods, clippy::unwrap_used)]
+
 use crate::{
 	mock::{Pablo, *},
 	test::common_test_functions::*,
 };
+
+use composable_tests_helpers::test::helper::RuntimeTrait;
 use frame_support::assert_ok;
 use sp_runtime::Permill;
 
@@ -25,5 +29,91 @@ mod create {
 
 			assert_ok!(Pablo::do_create_pool(pool_config, Some(LP_TOKEN_ID)));
 		});
+	}
+}
+
+mod simulate {
+	use super::*;
+
+	use composable_traits::dex::Amm;
+	use frame_support::{bounded_btree_map, traits::fungibles::Mutate};
+	use sp_runtime::Permill;
+
+	use crate::{
+		mock::{new_test_ext, Origin, Pablo, System, Test, ALICE},
+		Event, PoolInitConfiguration,
+	};
+
+	#[test]
+	fn simulation_same_as_actual() {
+		new_test_ext().execute_with(|| {
+			System::set_block_number(1);
+			let pool_id = Test::assert_extrinsic_event_with(
+				Pablo::create(
+					Origin::signed(ALICE),
+					PoolInitConfiguration::DualAssetConstantProduct {
+						owner: ALICE,
+						assets_weights: bounded_btree_map! {
+							USDT => Permill::from_percent(50),
+							USDC => Permill::from_percent(50),
+						},
+						fee: Permill::from_percent(1),
+					},
+				),
+				|e| match e {
+					Event::PoolCreated { pool_id, .. } => Some(pool_id),
+					_ => None,
+				},
+			);
+
+			Tokens::mint_into(USDT, &BOB, 1_000_000_000_000_000).unwrap();
+			Tokens::mint_into(USDC, &BOB, 1_000_000_000_000_000).unwrap();
+
+			let add_simulation_result = <Pablo as Amm>::simulate_add_liquidity(
+				&BOB,
+				pool_id,
+				[(USDT, 100_000_000), (USDC, 100_000_000)].into_iter().collect(),
+			)
+			.unwrap();
+
+			let add_result = Test::assert_extrinsic_event_with(
+				Pablo::add_liquidity(
+					Origin::signed(BOB),
+					pool_id,
+					[(USDT, 100_000_000), (USDC, 100_000_000)].into_iter().collect(),
+					0,
+					false,
+				),
+				|e| match e {
+					Event::LiquidityAdded { minted_lp, .. } => Some(minted_lp),
+					_ => None,
+				},
+			);
+
+			assert_eq!(add_simulation_result, add_result);
+
+			let remove_simulation_result = <Pablo as Amm>::simulate_remove_liquidity(
+				&BOB,
+				pool_id,
+				add_result,
+				[(USDT, 0), (USDC, 0)].into_iter().collect(),
+			)
+			.unwrap();
+
+			let remove_result = Test::assert_extrinsic_event_with(
+				Pablo::remove_liquidity(
+					Origin::signed(BOB),
+					pool_id,
+					add_result,
+					[(USDT, 0), (USDC, 0)].into_iter().collect(),
+				),
+				|e| match e {
+					Event::LiquidityRemoved { asset_amounts, .. } => Some(asset_amounts),
+					_ => None,
+				},
+			);
+
+			assert_eq!(remove_simulation_result, remove_result);
+		})
 	}
 }

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 //! Test runtime.
 //! Consider to set minimal values (duration, times, and limits) to be easy to test within day of
 //! work. Example, use several hours, instead of several days.
@@ -58,7 +60,7 @@ use composable_support::rpc_helpers::SafeRpcWrapper;
 use composable_traits::{
 	assets::Asset,
 	defi::Rate,
-	dex::{Amm, PriceAggregate, RemoveLiquiditySimulationResult},
+	dex::{Amm, PriceAggregate},
 	xcm::assets::RemoteAssetRegistryInspect,
 };
 use cosmwasm::instrument::CostRules;
@@ -1529,12 +1531,11 @@ impl_runtime_apis! {
 			pool_id: SafeRpcWrapper<PoolId>,
 			amounts: BTreeMap<SafeRpcWrapper<CurrencyId>, SafeRpcWrapper<Balance>>,
 		) -> SafeRpcWrapper<Balance> {
-			let amounts: BTreeMap<CurrencyId, Balance> = amounts.iter().map(|(k, v)| (k.0,v.0)).collect();
 			SafeRpcWrapper(
 				<Pablo as Amm>::simulate_add_liquidity(
 					&who.0,
 					pool_id.0,
-					amounts,
+					amounts.iter().map(|(k, v)| (k.0, v.0)).collect(),
 				)
 				.unwrap_or_else(|_| Zero::zero())
 			)
@@ -1545,23 +1546,23 @@ impl_runtime_apis! {
 			pool_id: SafeRpcWrapper<PoolId>,
 			lp_amount: SafeRpcWrapper<Balance>,
 			min_expected_amounts: BTreeMap<SafeRpcWrapper<CurrencyId>, SafeRpcWrapper<Balance>>,
-		) -> RemoveLiquiditySimulationResult<SafeRpcWrapper<CurrencyId>, SafeRpcWrapper<Balance>> {
-			let min_expected_amounts: BTreeMap<_, _> = min_expected_amounts.iter().map(|(k, v)| (k.0, v.0)).collect();
-			let default_removed_assets = min_expected_amounts.keys().map(|k| (*k, 0_u128)).collect::<BTreeMap<_,_>>();
-			let simulate_remove_liquidity_result = <Pablo as Amm>::simulate_remove_liquidity(&who.0, pool_id.0, lp_amount.0)
-				.unwrap_or(
-					RemoveLiquiditySimulationResult{
-						assets: default_removed_assets
-					}
-				);
-			let mut new_map = BTreeMap::new();
-			for (k,v) in simulate_remove_liquidity_result.assets.iter() {
-				new_map.insert(SafeRpcWrapper(*k), SafeRpcWrapper(*v));
-			}
-			RemoveLiquiditySimulationResult{
-				assets: new_map
-			}
-
+		) -> BTreeMap<SafeRpcWrapper<CurrencyId>, SafeRpcWrapper<Balance>> {
+			<Pablo as Amm>::simulate_remove_liquidity(
+				&who.0,
+				pool_id.0,
+				lp_amount.0,
+				min_expected_amounts
+					.iter()
+					.map(|(k, v)| (k.0, v.0))
+					.collect()
+				)
+				.map(|simulation_result| {
+					simulation_result
+						.into_iter()
+						.map(|(k, v)| (SafeRpcWrapper(k), SafeRpcWrapper(v)))
+						.collect()
+				})
+				.unwrap_or_default()
 		}
 	}
 

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -81,9 +81,9 @@ composable-traits = { path = "../../frame/composable-traits", default-features =
 crowdloan-rewards = { package = "pallet-crowdloan-rewards", path = '../../frame/crowdloan-rewards', default-features = false }
 currency-factory = { package = "pallet-currency-factory", path = "../../frame/currency-factory", default-features = false }
 governance-registry = { package = "pallet-governance-registry", path = "../../frame/governance-registry", default-features = false }
+pablo = { package = "pallet-pablo", path = "../../frame/pablo", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 vesting = { package = "pallet-vesting", path = "../../frame/vesting", default-features = false }
-pablo = { package = "pallet-pablo", path = "../../frame/pablo", default-features = false }
 
 # Used for the node template's RPCs
 system-rpc-runtime-api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.27" }


### PR DESCRIPTION
Updates the simulate add/remove liquidity functionality to be inline with the latest dex refactor updates. Also changes the input to `remove_liquidity` to require `min_amounts` length to be between 1 and 2 with a `BiBoundedVec`.