### PR TITLE
Added PICA/KSM pool to Dali runtime migrations

### DIFF
--- a/code/parachain/runtime/common/src/fees.rs
+++ b/code/parachain/runtime/common/src/fees.rs
@@ -75,6 +75,7 @@ impl WellKnownForeignToNativePriceConverter {
 			CurrencyId::PBLO => Some(rational!(1 / 1)),
 			CurrencyId::KSM_USDT_LPT => Some(rational!(1 / 1_000_000_000)),
 			CurrencyId::PICA_USDT_LPT => Some(rational!(1 / 1_000_000_000)),
+			CurrencyId::PICA_KSM_LPT => Some(rational!(1 / 1_000_000_000)),
 			_ => None,
 		}
 	}

--- a/code/parachain/runtime/dali/src/migrations.rs
+++ b/code/parachain/runtime/dali/src/migrations.rs
@@ -110,6 +110,13 @@ pub mod pablo_picasso_init_pools {
 					CurrencyId::PICA_USDT_LPT,
 					Permill::from_rational::<u32>(3, 1000),
 				),
+				PoolCreationInput::new_two_token_pool(
+					CurrencyId::PICA,
+					Permill::from_percent(50),
+					CurrencyId::KSM,
+					CurrencyId::PICA_KSM_LPT,
+					Permill::from_rational::<u32>(3, 1000),
+				),
 			];
 
 			add_initial_pools_to_storage(pools)

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -196,6 +196,7 @@ impl CurrencyId {
 
 		pub const KSM_USDT_LPT: CurrencyId = CurrencyId(105, None);
 		pub const PICA_USDT_LPT: CurrencyId = CurrencyId(106, None);
+		pub const PICA_KSM_LPT: CurrencyId = CurrencyId(107, None);
 		// NOTE: Empty CurrencyId slots starting with 107
 
 


### PR DESCRIPTION
Will add to Picasso runtime migrations after validation here.

Added new LPT for PICA/KSM