### PR TITLE
Updated Pablo Pool Migration in Picasso - Added PICA/KSM pool [CU-861m40629]

### DIFF
--- a/code/parachain/runtime/picasso/src/migrations.rs
+++ b/code/parachain/runtime/picasso/src/migrations.rs
@@ -145,6 +145,13 @@ pub mod pablo_picasso_init_pools {
 					CurrencyId::PICA_USDT_LPT,
 					Permill::from_rational::<u32>(3, 1000),
 				),
+				PoolCreationInput::new_two_token_pool(
+					CurrencyId::PICA,
+					Permill::from_percent(50),
+					CurrencyId::KSM,
+					CurrencyId::PICA_KSM_LPT,
+					Permill::from_rational::<u32>(3, 1000),
+				),
 			];
 
 			add_initial_pools_to_storage(pools)


### PR DESCRIPTION
[[CU-861m40629]](https://app.clickup.com/t/861m40629)
Updated the initial pool configuration for Pablo via the Picasso runtime migration to add a PICA/KSM pool