### PR TITLE
[CU-3rgvxzn] Lending Controllable State

### DIFF
--- a/code/parachain/frame/composable-traits/src/lending/mod.rs
+++ b/code/parachain/frame/composable-traits/src/lending/mod.rs
@@ -88,7 +88,7 @@ pub struct MarketConfig<VaultId, AssetId, AccountId, LiquidationStrategyId, Bloc
 	pub interest_rate_model: InterestRateModel,
 	pub under_collateralized_warn_percent: Percent,
 	pub liquidators: Vec<LiquidationStrategyId>,
-	pub is_paused_functionalities: Vec<bool>
+	pub is_paused_functionalities: Vec<bool>,
 }
 
 /// Different ways that a market can be repaid.
@@ -253,12 +253,12 @@ pub trait Lending: DeFiEngine {
 	fn update_market_functionality(
 		manager: Self::AccountId,
 		market_id: Self::MarketId,
-		new_states: Vec<(u8, bool)>
+		new_states: Vec<(u8, bool)>,
 	) -> Result<(), DispatchError>;
 
 	fn update_global_market_functionality(
 		manager: Self::AccountId,
-		new_states: Vec<(u8, bool)>
+		new_states: Vec<(u8, bool)>,
 	) -> Result<(), DispatchError>;
 
 	fn get_market_state(

--- a/code/parachain/frame/composable-traits/src/lending/mod.rs
+++ b/code/parachain/frame/composable-traits/src/lending/mod.rs
@@ -191,6 +191,7 @@ impl<T> TotalDebtWithInterest<T> {
 pub trait Lending: DeFiEngine {
 	type VaultId;
 	type MarketId;
+	type MarketConfig;
 	type BlockNumber;
 	/// id of dispatch used to liquidate collateral in case of undercollateralized asset
 	type LiquidationStrategyId;
@@ -247,6 +248,10 @@ pub trait Lending: DeFiEngine {
 		market_id: Self::MarketId,
 		input: UpdateInput<Self::LiquidationStrategyId, Self::BlockNumber>,
 	) -> Result<(), DispatchError>;
+
+	fn get_market_state(
+		market_id: &Self::MarketId,
+	) -> Result<(&Self::MarketId, Self::MarketConfig), DispatchError>;
 
 	/// [`AccountId`][Self::AccountId] of the market instance
 	fn account_id(market_id: &Self::MarketId) -> Self::AccountId;

--- a/code/parachain/frame/composable-traits/src/lending/mod.rs
+++ b/code/parachain/frame/composable-traits/src/lending/mod.rs
@@ -88,6 +88,7 @@ pub struct MarketConfig<VaultId, AssetId, AccountId, LiquidationStrategyId, Bloc
 	pub interest_rate_model: InterestRateModel,
 	pub under_collateralized_warn_percent: Percent,
 	pub liquidators: Vec<LiquidationStrategyId>,
+	pub is_paused_functionalities: Vec<bool>
 }
 
 /// Different ways that a market can be repaid.
@@ -247,6 +248,17 @@ pub trait Lending: DeFiEngine {
 		manager: Self::AccountId,
 		market_id: Self::MarketId,
 		input: UpdateInput<Self::LiquidationStrategyId, Self::BlockNumber>,
+	) -> Result<(), DispatchError>;
+
+	fn update_market_functionality(
+		manager: Self::AccountId,
+		market_id: Self::MarketId,
+		new_states: Vec<(u8, bool)>
+	) -> Result<(), DispatchError>;
+
+	fn update_global_market_functionality(
+		manager: Self::AccountId,
+		new_states: Vec<(u8, bool)>
 	) -> Result<(), DispatchError>;
 
 	fn get_market_state(

--- a/code/parachain/frame/lending/src/helpers/market.rs
+++ b/code/parachain/frame/lending/src/helpers/market.rs
@@ -15,6 +15,7 @@ use sp_runtime::{
 	traits::{One, Saturating, Zero},
 	DispatchError, FixedU128, Perquintill,
 };
+use sp_std::{vec, vec::Vec};
 
 impl<T: Config> Pallet<T> {
 	pub(crate) fn do_create_market(
@@ -135,7 +136,10 @@ impl<T: Config> Pallet<T> {
 				ensure!(manager == market.manager, Error::<T>::Unauthorized);
 				for (index, is_paused) in changed_functionalities {
 					if (index as usize) < market.is_paused_functionalities.len() {
-						market.is_paused_functionalities[index as usize] = is_paused;
+						if let Some(elem) = market.is_paused_functionalities.get_mut(index as usize)
+						{
+							*elem = is_paused
+						};
 					}
 				}
 				Ok(())
@@ -164,11 +168,9 @@ impl<T: Config> Pallet<T> {
 	) -> Result<bool, DispatchError> {
 		let (_, market) = Self::get_market(market_id)?;
 		let index = Self::get_functionality_index(functionality);
-		let functionalities_length = market.is_paused_functionalities.len();
-		if index >= functionalities_length {
-			Err(Error::<T>::FunctionalityNotAddedToMarket.into())
-		} else {
-			Ok(!market.is_paused_functionalities[index])
+		match market.is_paused_functionalities.get(index) {
+			Some(val) => Ok(!val),
+			None => Err(Error::<T>::FunctionalityNotAddedToMarket.into()),
 		}
 	}
 

--- a/code/parachain/frame/lending/src/helpers/market.rs
+++ b/code/parachain/frame/lending/src/helpers/market.rs
@@ -146,22 +146,32 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
+	pub(crate) fn get_functionality_index(
+		functionality: Functionality
+	) -> usize {
+		match functionality {
+			Functionality::DepositVault => 0,
+			Functionality::WithdrawVault => 1,
+			Functionality::DepositCollateral => 2,
+			Functionality::WithdrawCollateral => 3,
+			Functionality::Borrow => 4,
+			Functionality::RepayBorrow => 5,
+			Functionality::Liquidate => 6,
+		}
+	}
+
 	pub(crate) fn functionality_allowed(
 		market_id: &MarketId,
 		functionality: Functionality
 	) -> Result<bool, DispatchError> {
 		let (_, market) = Self::get_market(market_id)?;
-		let index;
-		match functionality {
-			Functionality::DepositVault => index = 0,
-			Functionality::WithdrawVault => index = 1,
-			Functionality::DepositCollateral => index = 2,
-			Functionality::WithdrawCollateral => index = 3,
-			Functionality::Borrow => index = 4,
-			Functionality::RepayBorrow => index = 5,
-			Functionality::Liquidate => index = 6,
+		let index = Self::get_functionality_index(functionality);
+		let functionalities_length = market.is_paused_functionalities.len();
+		if index >= functionalities_length {
+			Err(Error::<T>::FunctionalityNotAddedToMarket.into())
+		} else {
+			Ok(!market.is_paused_functionalities[index])
 		}
-		Ok(!market.is_paused_functionalities[index])
 	}
 
 	/// Returns pair of market's id and market (as 'MarketConfig') via market's id

--- a/code/parachain/frame/lending/src/helpers/market.rs
+++ b/code/parachain/frame/lending/src/helpers/market.rs
@@ -128,7 +128,7 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn do_update_market_functionality(
 		manager: T::AccountId,
 		market_id: MarketId,
-		changed_functionalities: Vec<(u8, bool)>
+		changed_functionalities: Vec<(u8, bool)>,
 	) -> Result<(), DispatchError> {
 		Markets::<T>::mutate(market_id, |market| {
 			if let Some(market) = market {
@@ -146,9 +146,7 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	pub(crate) fn get_functionality_index(
-		functionality: Functionality
-	) -> usize {
+	pub(crate) fn get_functionality_index(functionality: Functionality) -> usize {
 		match functionality {
 			Functionality::DepositVault => 0,
 			Functionality::WithdrawVault => 1,
@@ -162,7 +160,7 @@ impl<T: Config> Pallet<T> {
 
 	pub(crate) fn functionality_allowed(
 		market_id: &MarketId,
-		functionality: Functionality
+		functionality: Functionality,
 	) -> Result<bool, DispatchError> {
 		let (_, market) = Self::get_market(market_id)?;
 		let index = Self::get_functionality_index(functionality);

--- a/code/parachain/frame/lending/src/lib.rs
+++ b/code/parachain/frame/lending/src/lib.rs
@@ -264,7 +264,7 @@ pub mod pallet {
 		WithdrawCollateral,
 		Borrow,
 		RepayBorrow,
-		Liquidate
+		Liquidate,
 	}
 
 	// ----------------------------------------------------------------------------------------------------
@@ -391,15 +391,35 @@ pub mod pallet {
 			changed_functionalities: Vec<(u8, bool)>,
 		},
 		/// Event emitted when asset is deposited by lender.
-		AssetDeposited { sender: T::AccountId, market_id: MarketId, amount: T::Balance },
+		AssetDeposited {
+			sender: T::AccountId,
+			market_id: MarketId,
+			amount: T::Balance,
+		},
 		/// Event emitted when asset is withdrawn by lender.
-		AssetWithdrawn { sender: T::AccountId, market_id: MarketId, amount: T::Balance },
+		AssetWithdrawn {
+			sender: T::AccountId,
+			market_id: MarketId,
+			amount: T::Balance,
+		},
 		/// Event emitted when collateral is deposited.
-		CollateralDeposited { sender: T::AccountId, market_id: MarketId, amount: T::Balance },
+		CollateralDeposited {
+			sender: T::AccountId,
+			market_id: MarketId,
+			amount: T::Balance,
+		},
 		/// Event emitted when collateral is withdrawn.
-		CollateralWithdrawn { sender: T::AccountId, market_id: MarketId, amount: T::Balance },
+		CollateralWithdrawn {
+			sender: T::AccountId,
+			market_id: MarketId,
+			amount: T::Balance,
+		},
 		/// Event emitted when user borrows from given market.
-		Borrowed { sender: T::AccountId, market_id: MarketId, amount: T::Balance },
+		Borrowed {
+			sender: T::AccountId,
+			market_id: MarketId,
+			amount: T::Balance,
+		},
 		/// Event emitted when user repays borrow of beneficiary in given market.
 		BorrowRepaid {
 			sender: T::AccountId,
@@ -408,9 +428,15 @@ pub mod pallet {
 			amount: T::Balance,
 		},
 		/// Event emitted when a liquidation is initiated for a loan.
-		LiquidationInitiated { market_id: MarketId, borrowers: Vec<T::AccountId> },
+		LiquidationInitiated {
+			market_id: MarketId,
+			borrowers: Vec<T::AccountId>,
+		},
 		/// Event emitted to warn that loan may go under collateralize soon.
-		MayGoUnderCollateralizedSoon { market_id: MarketId, account: T::AccountId },
+		MayGoUnderCollateralizedSoon {
+			market_id: MarketId,
+			account: T::AccountId,
+		},
 	}
 
 	// ----------------------------------------------------------------------------------------------------
@@ -477,7 +503,7 @@ pub mod pallet {
 		BorrowPaused,
 		RepayBorrowPaused,
 		LiquidatePaused,
-		FunctionalityNotAddedToMarket
+		FunctionalityNotAddedToMarket,
 	}
 
 	// ----------------------------------------------------------------------------------------------------
@@ -579,25 +605,38 @@ pub mod pallet {
 		fn update_market_functionality(
 			manager: Self::AccountId,
 			market_id: Self::MarketId,
-			changed_functionalities: Vec<(u8, bool)>
+			changed_functionalities: Vec<(u8, bool)>,
 		) -> Result<(), DispatchError> {
-			Self::do_update_market_functionality(manager, market_id, changed_functionalities.clone())?;
-			Self::deposit_event(Event::<T>::FunctionalityChanged { market_id, changed_functionalities });
+			Self::do_update_market_functionality(
+				manager,
+				market_id,
+				changed_functionalities.clone(),
+			)?;
+			Self::deposit_event(Event::<T>::FunctionalityChanged {
+				market_id,
+				changed_functionalities,
+			});
 			Ok(())
 		}
 
 		fn update_global_market_functionality(
 			manager: Self::AccountId,
-			changed_functionalities: Vec<(u8, bool)>
+			changed_functionalities: Vec<(u8, bool)>,
 		) -> Result<(), DispatchError> {
 			for market_id in Markets::<T>::iter_keys() {
-				Self::do_update_market_functionality(manager.clone(), market_id, changed_functionalities.clone())?;
+				Self::do_update_market_functionality(
+					manager.clone(),
+					market_id,
+					changed_functionalities.clone(),
+				)?;
 			}
 			Self::deposit_event(Event::<T>::GlobalFunctionalityChanged { changed_functionalities });
 			Ok(())
 		}
 
-		fn get_market_state(market_id: &Self::MarketId) -> Result<(&Self::MarketId, Self::MarketConfig), DispatchError> {
+		fn get_market_state(
+			market_id: &Self::MarketId,
+		) -> Result<(&Self::MarketId, Self::MarketConfig), DispatchError> {
 			Self::get_market(&market_id)
 		}
 
@@ -610,7 +649,10 @@ pub mod pallet {
 			account: &Self::AccountId,
 			amount: LendAssetAmountOf<Self>,
 		) -> Result<(), DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::DepositVault)?, Error::<T>::DepositVaultPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::DepositVault)?,
+				Error::<T>::DepositVaultPaused
+			);
 			let (_, market) = Self::get_market(market_id)?;
 			T::VaultLender::deposit(&market.borrow_asset_vault, account, amount)?;
 			Self::deposit_event(Event::<T>::AssetDeposited {
@@ -626,7 +668,10 @@ pub mod pallet {
 			account: &Self::AccountId,
 			amount: LendAssetAmountOf<Self>,
 		) -> Result<(), DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::WithdrawVault)?, Error::<T>::WithdrawVaultPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::WithdrawVault)?,
+				Error::<T>::WithdrawVaultPaused
+			);
 			let (_, market) = Self::get_market(market_id)?;
 			T::VaultLender::withdraw(&market.borrow_asset_vault, account, amount)?;
 			Self::deposit_event(Event::<T>::AssetWithdrawn {
@@ -643,7 +688,10 @@ pub mod pallet {
 			amount: CollateralLpAmountOf<Self>,
 			keep_alive: bool,
 		) -> Result<(), DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::DepositCollateral)?, Error::<T>::DepositCollateralPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::DepositCollateral)?,
+				Error::<T>::DepositCollateralPaused
+			);
 			Self::do_deposit_collateral(
 				market_id,
 				account,
@@ -663,7 +711,10 @@ pub mod pallet {
 			account: &Self::AccountId,
 			amount: CollateralLpAmountOf<Self>,
 		) -> Result<(), DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::WithdrawCollateral)?, Error::<T>::WithdrawCollateralPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::WithdrawCollateral)?,
+				Error::<T>::WithdrawCollateralPaused
+			);
 			Self::do_withdraw_collateral(market_id, account, amount.try_into_validated()?)?;
 			Self::deposit_event(Event::<T>::CollateralWithdrawn {
 				sender: account.clone(),
@@ -682,7 +733,10 @@ pub mod pallet {
 			borrowing_account: &Self::AccountId,
 			amount_to_borrow: BorrowAmountOf<Self>,
 		) -> Result<(), DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::Borrow)?, Error::<T>::BorrowPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::Borrow)?,
+				Error::<T>::BorrowPaused
+			);
 			Self::do_borrow(market_id, borrowing_account, amount_to_borrow)?;
 			Self::deposit_event(Event::<T>::Borrowed {
 				sender: borrowing_account.clone(),
@@ -700,7 +754,10 @@ pub mod pallet {
 			total_repay_amount: RepayStrategy<BorrowAmountOf<Self>>,
 			keep_alive: bool,
 		) -> Result<BorrowAmountOf<Self>, DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::RepayBorrow)?, Error::<T>::RepayBorrowPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::RepayBorrow)?,
+				Error::<T>::RepayBorrowPaused
+			);
 			let amount = Self::do_repay_borrow(
 				market_id,
 				from,
@@ -732,7 +789,10 @@ pub mod pallet {
 			now: Timestamp,
 		) -> Result<(), DispatchError> {
 			// if repay borrow is paused, accrue interest should be paused as well
-			ensure!(Self::functionality_allowed(market_id, Functionality::RepayBorrow)?, Error::<T>::RepayBorrowPaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::RepayBorrow)?,
+				Error::<T>::RepayBorrowPaused
+			);
 			Self::do_accrue_interest(market_id, now)
 		}
 
@@ -782,7 +842,10 @@ pub mod pallet {
 			market_id: &<Self as Lending>::MarketId,
 			borrowers: BoundedVec<<Self as DeFiEngine>::AccountId, Self::MaxLiquidationBatchSize>,
 		) -> Result<Vec<<Self as DeFiEngine>::AccountId>, DispatchError> {
-			ensure!(Self::functionality_allowed(market_id, Functionality::Liquidate)?, Error::<T>::LiquidatePaused);
+			ensure!(
+				Self::functionality_allowed(market_id, Functionality::Liquidate)?,
+				Error::<T>::LiquidatePaused
+			);
 			let subjected_borrowers = Self::do_liquidate(liquidator, market_id, borrowers)?;
 			// if at least one borrower was affected then liquidation been initiated
 			if !subjected_borrowers.is_empty() {
@@ -852,7 +915,11 @@ pub mod pallet {
 			changed_functionalities: Vec<(u8, bool)>,
 		) -> DispatchResultWithPostInfo {
 			let who = ensure_signed(origin)?;
-			<Self as Lending>::update_market_functionality(who, market_id, changed_functionalities)?;
+			<Self as Lending>::update_market_functionality(
+				who,
+				market_id,
+				changed_functionalities,
+			)?;
 			Ok(().into())
 		}
 

--- a/code/parachain/frame/lending/src/lib.rs
+++ b/code/parachain/frame/lending/src/lib.rs
@@ -637,7 +637,7 @@ pub mod pallet {
 		fn get_market_state(
 			market_id: &Self::MarketId,
 		) -> Result<(&Self::MarketId, Self::MarketConfig), DispatchError> {
-			Self::get_market(&market_id)
+			Self::get_market(market_id)
 		}
 
 		fn account_id(market_id: &Self::MarketId) -> Self::AccountId {

--- a/code/parachain/frame/lending/src/lib.rs
+++ b/code/parachain/frame/lending/src/lib.rs
@@ -476,7 +476,8 @@ pub mod pallet {
 		WithdrawCollateralPaused,
 		BorrowPaused,
 		RepayBorrowPaused,
-		LiquidatePaused
+		LiquidatePaused,
+		FunctionalityNotAddedToMarket
 	}
 
 	// ----------------------------------------------------------------------------------------------------

--- a/code/parachain/frame/lending/src/lib.rs
+++ b/code/parachain/frame/lending/src/lib.rs
@@ -516,6 +516,7 @@ pub mod pallet {
 	impl<T: Config> Lending for Pallet<T> {
 		type VaultId = T::VaultId;
 		type MarketId = MarketId;
+		type MarketConfig = MarketConfigOf<T>;
 		type BlockNumber = T::BlockNumber;
 		type LiquidationStrategyId = <T as Config>::LiquidationStrategyId;
 		type Oracle = T::Oracle;
@@ -548,6 +549,10 @@ pub mod pallet {
 			Self::do_update_market(manager, market_id, input.clone().try_into_validated()?)?;
 			Self::deposit_event(Event::<T>::MarketUpdated { market_id, input });
 			Ok(())
+		}
+
+		fn get_market_state(market_id: &Self::MarketId) -> Result<(&Self::MarketId, Self::MarketConfig), DispatchError> {
+			Self::get_market(&market_id)
 		}
 
 		fn account_id(market_id: &Self::MarketId) -> Self::AccountId {

--- a/code/parachain/frame/lending/src/tests/mod.rs
+++ b/code/parachain/frame/lending/src/tests/mod.rs
@@ -25,6 +25,7 @@ pub mod interest;
 pub mod liquidation;
 pub mod market;
 pub mod offchain;
+pub mod pausing;
 pub mod prelude;
 pub mod repay;
 pub mod vault;

--- a/code/parachain/frame/lending/src/tests/pausing.rs
+++ b/code/parachain/frame/lending/src/tests/pausing.rs
@@ -1,0 +1,148 @@
+use super::prelude::*;
+use crate::tests::{process_and_progress_blocks};
+use frame_support::traits::{ fungibles::Mutate};
+use composable_traits::{vault::Vault as VaultTrait};
+
+#[test]
+fn test_pausing_vault_deposit() {
+	new_test_ext().execute_with(|| {
+		let (market, _vault_id) = create_simple_market();
+
+		let collateral = 1_000_000_000_000;
+		let borrow = 10;
+		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
+
+        // only manager can pause/unpause
+		assert_noop!(
+			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(0, true)]),
+			crate::Error::<Runtime>::Unauthorized
+		);
+
+        // pausing should go through
+		assert_extrinsic_event::<Runtime>(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(0, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
+				market_id: market,
+				changed_functionalities: vec![(0, true)]
+			}),
+		);
+
+		let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![true, false, false, false, false, false, false]);
+        // vault deposit should fail because it is paused
+        assert_noop!(
+            Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+            crate::Error::<Runtime>::DepositVaultPaused
+        );
+
+		process_and_progress_blocks::<Lending, Runtime>(1);
+		// vault deposit should still fail because it is paused
+		assert_noop!(
+            Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+            crate::Error::<Runtime>::DepositVaultPaused
+        );
+		// try unpausing by not a manager
+        assert_noop!(
+			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(0, false)]),
+			crate::Error::<Runtime>::Unauthorized
+		);
+        // manager unpauses
+        assert_ok!(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(0, false)])
+		);
+        let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+        // vault withdraw should succeed
+		assert_ok!(
+			Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+		);
+	});
+}
+
+
+#[test]
+fn test_pausing_vault_withdraw() {
+	new_test_ext().execute_with(|| {
+		let (market, vault_id) = create_simple_market();
+        let vault_account = Vault::account_id(&vault_id);
+
+		let collateral = 1_000_000_000_000;
+		let borrow = 10;
+		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
+
+		assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market, borrow));
+
+		// only manager can pause/unpause
+		assert_noop!(
+			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(1, true)]),
+			crate::Error::<Runtime>::Unauthorized
+		);
+		// pausing should go through
+		assert_extrinsic_event::<Runtime>(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(1, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
+				market_id: market,
+				changed_functionalities: vec![(1, true)]
+			}),
+		);
+
+		let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false, true, false, false, false, false, false]);
+		// vault withdraw should fail because it is paused
+		assert_noop!(
+			Lending::vault_withdraw(Origin::signed(*ALICE), market, borrow),
+			crate::Error::<Runtime>::WithdrawVaultPaused
+		);
+		process_and_progress_blocks::<Lending, Runtime>(1);
+		// vault withdraw should still fail because it is paused
+		assert_noop!(
+			Lending::vault_withdraw(Origin::signed(*ALICE), market, borrow),
+			crate::Error::<Runtime>::WithdrawVaultPaused
+		);
+		// try unpausing by not a manager
+        assert_noop!(
+			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(1, false)]),
+			crate::Error::<Runtime>::Unauthorized
+		);
+        // manager unpauses
+        assert_ok!(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(1, false)])
+		);
+        let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+        // vault withdraw should succeed
+		assert_ok!(
+			Lending::vault_withdraw(Origin::signed(*ALICE), market, Assets::balance(USDT::ID, &vault_account))
+		);
+	});
+}
+
+#[test]
+fn test_pausing_collateral_deposit() {
+	new_test_ext().execute_with(|| {
+		let (market_id, _vault_id) = create_simple_market();
+		let deposit_usdt = 1_000_000_000;
+		let deposit_btc = 10;
+		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, deposit_usdt));
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, deposit_btc));
+
+
+        
+
+		// assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market_id, deposit_btc));
+		assert_extrinsic_event::<Runtime>(
+			Lending::deposit_collateral(Origin::signed(*ALICE), market_id, deposit_usdt, false),
+			Event::Lending(pallet_lending::Event::<Runtime>::CollateralDeposited {
+				sender: *ALICE,
+				market_id,
+				amount: deposit_usdt,
+			}),
+		);
+	});
+}

--- a/code/parachain/frame/lending/src/tests/pausing.rs
+++ b/code/parachain/frame/lending/src/tests/pausing.rs
@@ -358,7 +358,7 @@ fn test_pausing_repay_borrow() {
 		let alice_total_debt_with_interest_before_repay_pause =
 			Lending::total_debt_with_interest(&market_id, &ALICE).unwrap().unwrap_amount();
 
-		// interest accured
+		// interest accrued
 		assert!(
 			alice_total_debt_with_interest_initial <
 				alice_total_debt_with_interest_before_repay_pause
@@ -397,7 +397,7 @@ fn test_pausing_repay_borrow() {
 			crate::Error::<Runtime>::RepayBorrowPaused
 		);
 
-		// no new interest should accure due to repay pause
+		// no new interest should accrued due to repay pause
 		process_and_progress_blocks::<Lending, Runtime>(1_000);
 
 		// new debt plus interest
@@ -564,11 +564,11 @@ fn test_pausing_liquidation() {
 fn get_bool_vec(num: i32, desired_len: usize) -> (Vec<(u8, bool)>, Vec<bool>) {
 	let mut single_position = 1;
 	let mut index = 0;
-	let mut changed_functionalitie = Vec::new();
+	let mut changed_functionalities = Vec::new();
 	let mut result_functionalities = Vec::new();
 	while single_position <= num {
 		if single_position & num != 0 {
-			changed_functionalitie.push((index, true));
+			changed_functionalities.push((index, true));
 			result_functionalities.push(true);
 		} else {
 			result_functionalities.push(false);
@@ -579,7 +579,7 @@ fn get_bool_vec(num: i32, desired_len: usize) -> (Vec<(u8, bool)>, Vec<bool>) {
 	while desired_len > result_functionalities.len() {
 		result_functionalities.push(false);
 	}
-	(changed_functionalitie, result_functionalities)
+	(changed_functionalities, result_functionalities)
 }
 
 #[test]

--- a/code/parachain/frame/lending/src/tests/pausing.rs
+++ b/code/parachain/frame/lending/src/tests/pausing.rs
@@ -1,63 +1,64 @@
 use super::prelude::*;
-use crate::tests::{process_and_progress_blocks};
+use crate::{tests::{process_and_progress_blocks}, Functionality};
 use frame_support::traits::{ fungibles::Mutate};
 use composable_traits::{vault::Vault as VaultTrait};
+use num_traits::Pow;
 
 #[test]
 fn test_pausing_vault_deposit() {
 	new_test_ext().execute_with(|| {
-		let (market, _vault_id) = create_simple_market();
+		let (market_id, _vault_id) = create_simple_market();
 
 		let collateral = 1_000_000_000_000;
 		let borrow = 10;
 		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
 		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
-
+		let vault_deposit_index = Lending::get_functionality_index(Functionality::DepositVault).try_into().unwrap();
         // only manager can pause/unpause
 		assert_noop!(
-			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(0, true)]),
+			Lending::update_market_functionality(Origin::signed(*BOB), market_id, vec![(vault_deposit_index, true)]),
 			crate::Error::<Runtime>::Unauthorized
 		);
 
         // pausing should go through
 		assert_extrinsic_event::<Runtime>(
-			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(0, true)]),
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(vault_deposit_index, true)]),
 			Event::Lending(crate::Event::FunctionalityChanged {
-				market_id: market,
+				market_id,
 				changed_functionalities: vec![(0, true)]
 			}),
 		);
 
-		let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
 		// market state should have changed
 		assert_eq!(market_state.is_paused_functionalities, vec![true, false, false, false, false, false, false]);
         // vault deposit should fail because it is paused
         assert_noop!(
-            Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+            Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow),
             crate::Error::<Runtime>::DepositVaultPaused
         );
 
 		process_and_progress_blocks::<Lending, Runtime>(1);
 		// vault deposit should still fail because it is paused
 		assert_noop!(
-            Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+            Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow),
             crate::Error::<Runtime>::DepositVaultPaused
         );
 		// try unpausing by not a manager
         assert_noop!(
-			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(0, false)]),
+			Lending::update_market_functionality(Origin::signed(*BOB), market_id, vec![(vault_deposit_index, false)]),
 			crate::Error::<Runtime>::Unauthorized
 		);
         // manager unpauses
         assert_ok!(
-			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(0, false)])
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(vault_deposit_index, false)])
 		);
-        let (_, market_state) = Lending::get_market_state(&market).unwrap();
+        let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
 		// market state should have changed
 		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
         // vault withdraw should succeed
 		assert_ok!(
-			Lending::vault_deposit(Origin::signed(*ALICE), market, borrow),
+			Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow),
 		);
 	});
 }
@@ -66,7 +67,7 @@ fn test_pausing_vault_deposit() {
 #[test]
 fn test_pausing_vault_withdraw() {
 	new_test_ext().execute_with(|| {
-		let (market, vault_id) = create_simple_market();
+		let (market_id, vault_id) = create_simple_market();
         let vault_account = Vault::account_id(&vault_id);
 
 		let collateral = 1_000_000_000_000;
@@ -74,75 +75,567 @@ fn test_pausing_vault_withdraw() {
 		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
 		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
 
-		assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market, borrow));
-
+		assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow));
+		let vault_withdraw_index = Lending::get_functionality_index(Functionality::WithdrawVault).try_into().unwrap();
 		// only manager can pause/unpause
 		assert_noop!(
-			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(1, true)]),
+			Lending::update_market_functionality(Origin::signed(*BOB), market_id, vec![(vault_withdraw_index, true)]),
 			crate::Error::<Runtime>::Unauthorized
 		);
 		// pausing should go through
 		assert_extrinsic_event::<Runtime>(
-			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(1, true)]),
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(vault_withdraw_index, true)]),
 			Event::Lending(crate::Event::FunctionalityChanged {
-				market_id: market,
+				market_id,
 				changed_functionalities: vec![(1, true)]
 			}),
 		);
 
-		let (_, market_state) = Lending::get_market_state(&market).unwrap();
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
 		// market state should have changed
 		assert_eq!(market_state.is_paused_functionalities, vec![false, true, false, false, false, false, false]);
 		// vault withdraw should fail because it is paused
 		assert_noop!(
-			Lending::vault_withdraw(Origin::signed(*ALICE), market, borrow),
+			Lending::vault_withdraw(Origin::signed(*ALICE), market_id, borrow),
 			crate::Error::<Runtime>::WithdrawVaultPaused
 		);
 		process_and_progress_blocks::<Lending, Runtime>(1);
 		// vault withdraw should still fail because it is paused
 		assert_noop!(
-			Lending::vault_withdraw(Origin::signed(*ALICE), market, borrow),
+			Lending::vault_withdraw(Origin::signed(*ALICE), market_id, borrow),
 			crate::Error::<Runtime>::WithdrawVaultPaused
 		);
 		// try unpausing by not a manager
         assert_noop!(
-			Lending::update_market_functionality(Origin::signed(*BOB), market, vec![(1, false)]),
+			Lending::update_market_functionality(Origin::signed(*BOB), market_id, vec![(vault_withdraw_index, false)]),
 			crate::Error::<Runtime>::Unauthorized
 		);
         // manager unpauses
         assert_ok!(
-			Lending::update_market_functionality(Origin::signed(*ALICE), market, vec![(1, false)])
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(vault_withdraw_index, false)])
 		);
-        let (_, market_state) = Lending::get_market_state(&market).unwrap();
+        let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
 		// market state should have changed
 		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
         // vault withdraw should succeed
 		assert_ok!(
-			Lending::vault_withdraw(Origin::signed(*ALICE), market, Assets::balance(USDT::ID, &vault_account))
+			Lending::vault_withdraw(Origin::signed(*ALICE), market_id, Assets::balance(USDT::ID, &vault_account))
 		);
 	});
 }
 
 #[test]
+// took from test_vault_market_can_withdraw
 fn test_pausing_collateral_deposit() {
 	new_test_ext().execute_with(|| {
 		let (market_id, _vault_id) = create_simple_market();
-		let deposit_usdt = 1_000_000_000;
-		let deposit_btc = 10;
-		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, deposit_usdt));
-		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, deposit_btc));
-
-
-        
-
-		// assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market_id, deposit_btc));
+		let collateral = 1_000_000_000_000;
+		let borrow = 10;
+		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
+		
+		assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow));
+		let collateral_deposit_index = Lending::get_functionality_index(Functionality::DepositCollateral).try_into().unwrap();
+		// pausing should go through
 		assert_extrinsic_event::<Runtime>(
-			Lending::deposit_collateral(Origin::signed(*ALICE), market_id, deposit_usdt, false),
-			Event::Lending(pallet_lending::Event::<Runtime>::CollateralDeposited {
-				sender: *ALICE,
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(collateral_deposit_index, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
 				market_id,
-				amount: deposit_usdt,
+				changed_functionalities: vec![(2, true)]
+			}),
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false, false, true, false, false, false, false]);
+
+		assert_noop!(
+			Lending::deposit_collateral(Origin::signed(*ALICE), market_id, collateral, false),
+			crate::Error::<Runtime>::DepositCollateralPaused
+		);
+		process_and_progress_blocks::<Lending, Runtime>(1);
+		// collateral deposit should still fail because it is paused
+		assert_noop!(
+			Lending::deposit_collateral(Origin::signed(*ALICE), market_id, collateral, false),
+			crate::Error::<Runtime>::DepositCollateralPaused
+		);
+		// manager unpauses
+        assert_ok!(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(collateral_deposit_index, false)])
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+		assert_extrinsic_event::<Runtime>(
+			Lending::deposit_collateral(
+				Origin::signed(*ALICE),
+				market_id,
+				collateral,
+				false,
+			),
+			Event::Lending(crate::Event::CollateralDeposited {
+				sender: *ALICE,
+				amount: collateral,
+				market_id,
+			}),
+		);
+		process_and_progress_blocks::<Lending, Runtime>(1);
+		// We waited 1 block, the market should have withdraw the funds
+		assert_extrinsic_event::<Runtime>(
+			Lending::borrow(Origin::signed(*ALICE), market_id, borrow - 1),
+			Event::Lending(crate::Event::Borrowed {
+				sender: *ALICE,
+				amount: borrow - 1, // DEFAULT_MARKET_VAULT_RESERVE
+				market_id,
 			}),
 		);
 	});
 }
+
+#[test]
+fn test_pausing_borrow() {
+	new_test_ext().execute_with(|| {
+		let (market_id, _vault_id) = create_simple_market();
+		let collateral = 1_000_000_000_000;
+		let borrow = 10;
+		assert_ok!(Tokens::mint_into(USDT::ID, &ALICE, collateral));
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, borrow));
+		
+		assert_ok!(Lending::vault_deposit(Origin::signed(*ALICE), market_id, borrow));
+		let borrow_index = Lending::get_functionality_index(Functionality::Borrow).try_into().unwrap();
+		// pausing should go through
+		assert_extrinsic_event::<Runtime>(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(borrow_index, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
+				market_id,
+				changed_functionalities: vec![(4, true)]
+			}),
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false, false, false, false, true, false, false]);
+
+		assert_extrinsic_event::<Runtime>(
+			Lending::deposit_collateral(
+				Origin::signed(*ALICE),
+				market_id,
+				collateral,
+				false,
+			),
+			Event::Lending(crate::Event::CollateralDeposited {
+				sender: *ALICE,
+				amount: collateral,
+				market_id: market_id,
+			}),
+		);
+		process_and_progress_blocks::<Lending, Runtime>(1);
+		
+		// We waited 1 block, the market should have withdraw the funds
+		// now we should fail to borrow
+		assert_noop!(
+			Lending::borrow(Origin::signed(*ALICE), market_id, borrow - 1),
+			crate::Error::<Runtime>::BorrowPaused
+		);
+		
+		// manager unpauses
+        assert_ok!(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(borrow_index, false)])
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+		// now can borrow
+		assert_extrinsic_event::<Runtime>(
+			Lending::borrow(Origin::signed(*ALICE), market_id, borrow - 1),
+			Event::Lending(crate::Event::Borrowed {
+				sender: *ALICE,
+				amount: borrow - 1, // DEFAULT_MARKET_VAULT_RESERVE
+				market_id,
+			}),
+		);
+	});
+}
+
+#[test]
+fn test_pausing_repay_borrow() {
+	new_test_ext().execute_with(|| {
+		// accounts have 1 unit of collateral
+		let alice_balance = BTC::ONE;
+
+		let (market_id, _vault_id) = create_simple_market();
+
+		mint_and_deposit_collateral::<Runtime>(*ALICE, alice_balance, market_id, BTC::ID);
+
+		let borrow_asset_deposit = USDT::units(1_000_000);
+		assert_ok!(Tokens::mint_into(USDT::ID, &CHARLIE, borrow_asset_deposit));
+		assert_extrinsic_event::<Runtime>(
+			Lending::vault_deposit(Origin::signed(*CHARLIE), market_id, borrow_asset_deposit),
+			Event::Lending(crate::Event::AssetDeposited {
+				sender: *CHARLIE,
+				market_id,
+				amount: borrow_asset_deposit,
+			}),
+		);
+
+		process_and_progress_blocks::<Lending, Runtime>(1_000);
+
+		let get_collateral_borrow_limit_for_account = |account| {
+			// `limit_normalized` is the limit in USDT
+			// `limit` is the limit in BTC
+			// BTC is worth 50_000 times more than USDT (see `create_simple_market()`)
+
+			// borrow_limit * COLLATERAL::ONE / price_of(COLLATERAL::ONE)
+			// REVIEW: I'm still not sure if this makes sense
+			let limit_normalized = Lending::get_borrow_limit(&market_id, &account).unwrap();
+			let limit = limit_normalized
+				.mul(BTC::ONE)
+				.div(get_price(BTC::ID, BTC::ONE));
+			limit
+		};
+
+		let alice_limit = get_collateral_borrow_limit_for_account(*ALICE);
+		assert_extrinsic_event::<Runtime>(
+			// partial borrow
+			Lending::borrow(Origin::signed(*ALICE), market_id, alice_limit / 2),
+			Event::Lending(crate::Event::<Runtime>::Borrowed {
+				sender: *ALICE,
+				market_id,
+				amount: alice_limit / 2,
+			}),
+		);
+
+		let alice_total_debt_with_interest_initial =
+			Lending::total_debt_with_interest(&market_id, &ALICE)
+				.unwrap()
+				.unwrap_amount();
+
+		process_and_progress_blocks::<Lending, Runtime>(1_000);
+
+		let alice_total_debt_with_interest_before_repay_pause =
+		Lending::total_debt_with_interest(&market_id, &ALICE)
+			.unwrap()
+			.unwrap_amount();
+
+		// interest accured
+		assert!(alice_total_debt_with_interest_initial < alice_total_debt_with_interest_before_repay_pause);
+
+		let repay_borrow_index = Lending::get_functionality_index(Functionality::RepayBorrow).try_into().unwrap();
+		// pausing should go through
+		assert_extrinsic_event::<Runtime>(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(repay_borrow_index, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
+				market_id,
+				changed_functionalities: vec![(5, true)]
+			}),
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false, false, false, false, false, true, false]);
+
+		// cant repay borrow
+		assert_noop!(
+			Lending::repay_borrow(
+				Origin::signed(*ALICE),
+				market_id,
+				*ALICE,
+				RepayStrategy::PartialAmount(USDT::units(1) / 10_000),
+				false,
+			),
+			crate::Error::<Runtime>::RepayBorrowPaused
+		);
+		
+		// no new interest should accure due to repay pause
+		process_and_progress_blocks::<Lending, Runtime>(1_000);
+
+		// new debt plus interest
+		let alice_total_debt_with_interest_after_repay_pause =
+		Lending::total_debt_with_interest(&market_id, &ALICE)
+			.unwrap()
+			.unwrap_amount();
+		// should be equal
+		assert_eq!(alice_total_debt_with_interest_after_repay_pause, alice_total_debt_with_interest_before_repay_pause);
+
+		// manager unpauses
+        assert_ok!(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(repay_borrow_index, false)])
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+
+		// pay off a small amount
+		assert_extrinsic_event::<Runtime>(
+			Lending::repay_borrow(
+				Origin::signed(*ALICE),
+				market_id,
+				*ALICE,
+				RepayStrategy::PartialAmount(USDT::units(1) / 10_000),
+				false,
+			),
+			Event::Lending(crate::Event::<Runtime>::BorrowRepaid {
+				sender: *ALICE,
+				market_id: market_id,
+				beneficiary: *ALICE,
+				amount: USDT::units(1) / 10_000,
+			}),
+		);
+
+		let alice_total_debt_with_interest_after_repay_unpause =
+		Lending::total_debt_with_interest(&market_id, &ALICE)
+			.unwrap()
+			.unwrap_amount();
+		assert!(alice_total_debt_with_interest_after_repay_pause > alice_total_debt_with_interest_after_repay_unpause);
+		process_and_progress_blocks::<Lending, Runtime>(1_000);
+		// interest should grow
+		let alice_total_debt_with_interest_after_repay_unpause_next =
+		Lending::total_debt_with_interest(&market_id, &ALICE)
+			.unwrap()
+			.unwrap_amount();
+		assert!(alice_total_debt_with_interest_after_repay_unpause_next > alice_total_debt_with_interest_after_repay_unpause);
+	});
+}
+
+#[test]
+fn test_pausing_liquidation() {
+	new_test_ext().execute_with(|| {
+		let (market_id, vault_id) = create_simple_market();
+		let collateral = BTC::units(100);
+		assert_ok!(Tokens::mint_into(BTC::ID, &ALICE, collateral));
+
+		assert_extrinsic_event::<Runtime>(
+			Lending::deposit_collateral(Origin::signed(*ALICE), market_id, collateral, false),
+			Event::Lending(crate::Event::CollateralDeposited {
+				sender: *ALICE,
+				amount: collateral,
+				market_id,
+			}),
+		);
+
+		let usdt_amt = 2 * DEFAULT_COLLATERAL_FACTOR * USDT::ONE * get_price(BTC::ID, collateral) /
+			get_price(NORMALIZED::ID, NORMALIZED::ONE);
+		assert_ok!(Tokens::mint_into(USDT::ID, &CHARLIE, usdt_amt));
+		assert_ok!(Vault::deposit(Origin::signed(*CHARLIE), vault_id, usdt_amt));
+
+		// Allow the market to initialize it's account by withdrawing
+		// from the vault
+		process_and_progress_blocks::<Lending, Runtime>(1);
+
+		let borrow_limit = Lending::get_borrow_limit(&market_id, &ALICE).expect("impossible");
+		assert!(borrow_limit > 0);
+
+		assert_extrinsic_event::<Runtime>(
+			Lending::borrow(Origin::signed(*ALICE), market_id, borrow_limit),
+			Event::Lending(crate::Event::Borrowed {
+				sender: *ALICE,
+				amount: borrow_limit,
+				market_id,
+			}),
+		);
+
+		let liquidate_index = Lending::get_functionality_index(Functionality::Liquidate).try_into().unwrap();
+		// pausing should go through
+		assert_extrinsic_event::<Runtime>(
+			Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(liquidate_index, true)]),
+			Event::Lending(crate::Event::FunctionalityChanged {
+				market_id: market_id,
+				changed_functionalities: vec![(6, true)]
+			}),
+		);
+		let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+		// market state should have changed
+		assert_eq!(market_state.is_paused_functionalities, vec![false, false, false, false, false, false, true]);
+
+		process_and_progress_blocks::<Lending, Runtime>(10_000);
+
+				assert_noop!(
+					Lending::liquidate(
+						Origin::signed(*ALICE),
+						market_id.clone(),
+						TestBoundedVec::try_from(vec![*ALICE]).unwrap(),
+					),
+					crate::Error::<Runtime>::LiquidatePaused
+				);
+
+				process_and_progress_blocks::<Lending, Runtime>(10_000);
+
+
+				assert_noop!(
+					Lending::liquidate(
+						Origin::signed(*ALICE),
+						market_id.clone(),
+						TestBoundedVec::try_from(vec![*ALICE]).unwrap(),
+					),
+					crate::Error::<Runtime>::LiquidatePaused
+				);
+
+				// manager unpauses
+				assert_ok!(
+					Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(liquidate_index, false)])
+				);
+				let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+				// market state should have changed
+				assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+
+		assert_extrinsic_event::<Runtime>(
+			Lending::liquidate(
+				Origin::signed(*ALICE),
+				market_id.clone(),
+				TestBoundedVec::try_from(vec![*ALICE]).unwrap(),
+			),
+			Event::Lending(crate::Event::LiquidationInitiated {
+				market_id,
+				borrowers: vec![*ALICE],
+			}),
+		);
+		// Check if cleanup was done correctly
+		assert!(!crate::DebtIndex::<Runtime>::contains_key(market_id, *ALICE));
+		assert!(!crate::BorrowTimestamp::<Runtime>::contains_key(market_id, *ALICE));
+	});
+}
+
+// return all combinations of vec with length desired_len where items are booleans
+fn get_bool_vec(num: i32, desired_len: usize) -> (Vec<(u8, bool)>, Vec<bool>){
+	let mut single_position = 1;
+	let mut index = 0;
+	let mut changed_functionalitie = Vec::new();
+	let mut result_functionalities = Vec::new();
+	while single_position <= num {
+		
+		if single_position & num != 0 {
+			changed_functionalitie.push((index, true));
+			result_functionalities.push(true);
+		} else {
+			result_functionalities.push(false);
+		}
+		single_position = single_position << 1;
+		index += 1;
+	}
+	while desired_len > result_functionalities.len() {
+		result_functionalities.push(false);
+	}
+	(changed_functionalitie, result_functionalities)
+}
+
+#[test]
+fn test_get_bool_vec() {
+	new_test_ext().execute_with(|| {
+		assert_eq!(get_bool_vec(0, 4), (vec![], vec![false; 4]));
+		assert_eq!(get_bool_vec(7, 4), (vec![(0, true), (1, true), (2, true)], vec![true, true, true, false]));
+		assert_eq!(get_bool_vec(9, 4), (vec![(0, true), (3, true)], vec![true, false, false, true]));
+	});
+}
+
+#[test]
+fn test_pausing_global() {
+	new_test_ext().execute_with(|| {
+		let (market_id_1, _vault_id_1) = create_simple_market();
+		let (market_id_2, _vault_id_2) = create_simple_market();
+		assert!(market_id_1 != market_id_2);
+		let (_, market_state_1) = Lending::get_market_state(&market_id_1).unwrap();
+		let (_, market_state_2) = Lending::get_market_state(&market_id_2).unwrap();
+		let functionality_len_1 = market_state_1.is_paused_functionalities.len();
+		let functionality_len_2 = market_state_2.is_paused_functionalities.len();
+		assert_eq!(functionality_len_1, functionality_len_2);
+
+		for i in 0..2.pow(functionality_len_1) {
+			let (changed_functionalities, result_functionalities) = get_bool_vec(i, functionality_len_1);
+			assert_noop!(
+				Lending::update_global_market_functionality(Origin::signed(*BOB), changed_functionalities.clone()),
+				crate::Error::<Runtime>::Unauthorized
+			);
+			// pausing should go through
+			assert_extrinsic_event::<Runtime>(
+				Lending::update_global_market_functionality(Origin::signed(*ALICE), changed_functionalities.clone()),
+				Event::Lending(crate::Event::GlobalFunctionalityChanged {
+					changed_functionalities: changed_functionalities.clone()
+				}),
+			);
+			let (_, market_state_1) = Lending::get_market_state(&market_id_1).unwrap();
+			let (_, market_state_2) = Lending::get_market_state(&market_id_2).unwrap();
+			assert_eq!(market_state_1.is_paused_functionalities, result_functionalities.clone());
+			assert_eq!(market_state_2.is_paused_functionalities, result_functionalities.clone());
+			let undo_changes: Vec<(u8, bool)> = changed_functionalities.iter().map(|(i, change)| -> (u8, bool) {
+				(*i, !*change)
+			}).collect();
+			assert_extrinsic_event::<Runtime>(
+				Lending::update_global_market_functionality(Origin::signed(*ALICE), undo_changes.clone()),
+				Event::Lending(crate::Event::GlobalFunctionalityChanged {
+					changed_functionalities: undo_changes.clone()
+				}),
+			);
+			let (_, market_state_1) = Lending::get_market_state(&market_id_1).unwrap();
+			let (_, market_state_2) = Lending::get_market_state(&market_id_2).unwrap();
+			assert_eq!(market_state_1.is_paused_functionalities, vec![false; functionality_len_1]);
+			assert_eq!(market_state_2.is_paused_functionalities, vec![false; functionality_len_2]);
+		}
+		
+	});
+}
+
+prop_compose! {
+	fn valid_amount_without_overflow()
+		(x in MINIMUM_BALANCE..u64::MAX as Balance) -> Balance {
+		x
+	}
+}
+
+proptest! {
+	#![proptest_config(ProptestConfig::with_cases(10_000))]
+
+	#[test]
+	// used market_collateral_deposit_withdraw_identity test
+	fn test_pausing_collateral_withdraw(amount in valid_amount_without_overflow()) {
+		new_test_ext().execute_with(|| {
+			let (market_id, _) = create_simple_market();
+			let before = Tokens::balance( BTC::ID, &ALICE);
+			prop_assert_ok!(Tokens::mint_into( BTC::ID, &ALICE, amount));
+
+			assert_extrinsic_event::<Runtime>(
+				Lending::deposit_collateral(Origin::signed(*ALICE), market_id, amount, false),
+				Event::Lending(crate::Event::CollateralDeposited {
+					sender: *ALICE,
+					amount,
+					market_id,
+				}),
+			);
+
+			let collateral_withdraw_index = Lending::get_functionality_index(Functionality::WithdrawCollateral).try_into().unwrap();
+			// pausing should go through
+			assert_extrinsic_event::<Runtime>(
+				Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(collateral_withdraw_index, true)]),
+				Event::Lending(crate::Event::FunctionalityChanged {
+					market_id,
+					changed_functionalities: vec![(3, true)]
+				}),
+			);
+			let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+			// market state should have changed
+			assert_eq!(market_state.is_paused_functionalities, vec![false, false, false, true, false, false, false]);
+
+			assert_noop!(
+				Lending::withdraw_collateral(Origin::signed(*ALICE), market_id, amount),
+				crate::Error::<Runtime>::WithdrawCollateralPaused
+			);
+
+			// manager unpauses
+			assert_ok!(
+				Lending::update_market_functionality(Origin::signed(*ALICE), market_id, vec![(collateral_withdraw_index, false)])
+			);
+			let (_, market_state) = Lending::get_market_state(&market_id).unwrap();
+			// market state should have changed
+			assert_eq!(market_state.is_paused_functionalities, vec![false; 7]);
+
+			assert_extrinsic_event::<Runtime>(
+				Lending::withdraw_collateral(Origin::signed(*ALICE), market_id, amount),
+				Event::Lending(crate::Event::CollateralWithdrawn {
+					sender: *ALICE,
+					amount,
+					market_id,
+				}),
+			);
+			prop_assert_eq!(Tokens::balance( BTC::ID, &ALICE) - before, amount);
+
+			Ok(())
+		})?;
+	}
+}
+

--- a/code/parachain/frame/lending/src/weights.rs
+++ b/code/parachain/frame/lending/src/weights.rs
@@ -35,21 +35,21 @@ impl WeightInfo for () {
 			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(11 as Weight))
 	}
-	// TODO
+	// TODO yet to get generated weights
 	fn update_market_functionality() -> Weight {
 		(96_881_000 as Weight)
 	}
-	// TODO
+	// TODO yet to get generated weights
 	fn update_global_market_functionality() -> Weight {
 		(96_881_000 as Weight)
 	}
-	// same as vaults deposit plus 1 more read
+	// TODO yet to get generated weights
 	fn vault_deposit() -> Weight {
 		(140_947_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(10 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(5 as Weight))
 	}
-	// same as vaults withdraw plus 1 more read
+	// TODO yet to get generated weights
 	fn vault_withdraw() -> Weight {
 		(112_296_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(9 as Weight))

--- a/code/parachain/frame/lending/src/weights.rs
+++ b/code/parachain/frame/lending/src/weights.rs
@@ -11,6 +11,8 @@ use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {
 	fn create_market() -> Weight;
+	fn update_market_functionality() -> Weight;
+	fn update_global_market_functionality() -> Weight;
 	fn vault_deposit() -> Weight;
 	fn vault_withdraw() -> Weight;
 	fn deposit_collateral() -> Weight;
@@ -32,6 +34,14 @@ impl WeightInfo for () {
 		(96_881_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(5 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(11 as Weight))
+	}
+	// TODO
+	fn update_market_functionality() -> Weight {
+		(96_881_000 as Weight)
+	}
+	// TODO
+	fn update_global_market_functionality() -> Weight {
+		(96_881_000 as Weight)
 	}
 	// same as vaults deposit plus 1 more read
 	fn vault_deposit() -> Weight {

--- a/code/parachain/runtime/dali/src/weights/lending.rs
+++ b/code/parachain/runtime/dali/src/weights/lending.rs
@@ -62,6 +62,14 @@ impl<T: frame_system::Config> lending::WeightInfo for WeightInfo<T> {
 			.saturating_add(T::DbWeight::get().reads(9 as Weight))
 			.saturating_add(T::DbWeight::get().writes(4 as Weight))
 	}
+	// TODO
+	fn update_market_functionality() -> Weight {
+		(96_881_000 as Weight)
+	}
+	// TODO
+	fn update_global_market_functionality() -> Weight {
+		(96_881_000 as Weight)
+	}
 	// Storage: Lending Markets (r:1 w:0)
 	// Storage: Lending AccountCollateral (r:1 w:1)
 	// Storage: Tokens Accounts (r:2 w:2)


### PR DESCRIPTION
1. Moved function to query market state to the Lending trait [CU-34qhn91](https://app.clickup.com/t/34qhn91)
2. Added is_paused_functionalities array to MarketConfig to control execution of Lending functions: vault_deposit, vault_withdraw, deposit_collateral, withdraw_collateral, borrow, repay_borrow, liquidate. Functionalities enum represents each of the previous market actions functionality_allowed function allows to convert enum's value into index of is_paused_functionalities. [CU-34qhn8e](https://app.clickup.com/t/34qhn8e)
3. update_market_functionality takes in market_id + vector of (index: u8, new_value: bool), where index is index of functionality in market_config.is_paused_functionalities vector, new_value is 1) true in case the functionality should be paused, 2) false is it isnt pausd [CU-34qhng8](https://app.clickup.com/t/34qhng8)
4. update_global_market_functionality similar update_market_functionality but applies all changes to functionalities to all the markets. [CU-34qhng8](https://app.clickup.com/t/34qhng8)
5. added tests for pausing every functionality, plus accure_interest for which interest shouldnt be accured if repay_borrowed is paused. [CU-34qhngw](https://app.clickup.com/t/34qhngw ) [CU-34qhnhu](https://app.clickup.com/t/34qhnhu ) 
6. added benchmarks for new extrinsics + benchmarks for vault_deposit and vault_withdraw

this pr implements call filtering as explained by @benluelo. https://paritytech.github.io/substrate/master/frame_support/traits/trait.InstanceFilter.html

this functionality is meant to be permisioned(by devs at the beginning) and governed later

