### PR TITLE
#cu-86698p7yq removing tests cache to avoid missed tests runs

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1105,27 +1105,20 @@ jobs:
           name: ${{  env.CACHIX_COMPOSABLE }}
 
       - run: |
-          DEVNET_MAIN=$(nix show-derivation github:ComposableFi/composable/#devnet-dali)
-          DEVNET_PR=$(nix show-derivation .#devnet-dali)
-          TESTS_MAIN=$(nix show-derivation github:ComposableFi/composable/#runtime-tests)
-          TESTS_PR=$(nix show-derivation .#runtime-tests)
+          ( nix run .#devnet-dali 2>&1 & ) | tee devnet-dali.log &
+          until test -f devnet-dali.log; do sleep 1 && echo "waiting network start"; done;
 
-          if [ "$DEVNET_MAIN" != "$DEVNET_PR" ] || [ "$TESTS_MAIN" != "$TESTS_PR" ]; then
-            ( nix run .#devnet-dali 2>&1 & ) | tee devnet-dali.log &
-            until test -f devnet-dali.log; do sleep 1 && echo "waiting network start"; done;
-
-            ( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 "Network launched 🚀🚀"
-            echo "PATH=$(pwd):$PATH" >> $GITHUB_ENV
-            cd code/integration-tests/runtime-tests || exit
-            npm install -q
-            export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
-            until test -f runtime-tests.log; do sleep 1 && echo "waiting tests start"; done;
-            tail --follow runtime-tests.log &
-            ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )
-            ( while : ; do if test $( wc --lines stop.log | cut --delimiter " " --fields 1 ) -gt 4; then kill -9 $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) &
-            wait $RUNTIME_TESTS_PID
-            exit $?
-          fi
+          ( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 "Network launched 🚀🚀"
+          echo "PATH=$(pwd):$PATH" >> $GITHUB_ENV
+          cd code/integration-tests/runtime-tests || exit
+          npm install -q
+          export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
+          until test -f runtime-tests.log; do sleep 1 && echo "waiting tests start"; done;
+          tail --follow runtime-tests.log &
+          ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )
+          ( while : ; do if test $( wc --lines stop.log | cut --delimiter " " --fields 1 ) -gt 4; then kill -9 $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) &
+          wait $RUNTIME_TESTS_PID
+          exit $?
   
   effects-gate:
       name: "Effect gate, automatically merged if passed"

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1069,10 +1069,10 @@ jobs:
 
   devnet-integration-tests:
       name: "Devnet integration tests"
-      needs:
-        - package-polkadot-node
-        - package-composable-node
-        - check-nix
+      # needs:
+      #   - package-polkadot-node
+      #   - package-composable-node
+      #   - check-nix
       runs-on:
       - self-hosted
       - linux
@@ -1106,10 +1106,21 @@ jobs:
 
       - run: |
           ( nix run .#devnet-dali 2>&1 & ) | tee devnet-dali.log &
-          until test -f devnet-dali.log; do sleep 1 && echo "waiting network start"; done;
-
-          ( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 "Network launched 🚀🚀"
-          echo "PATH=$(pwd):$PATH" >> $GITHUB_ENV
+          until test -f devnet-dali.log; do
+            sleep 1 && echo "waiting network start";
+          done;
+          TIMEOUT=240
+          COMMAND="( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 \"Network launched 🚀🚀\""
+          set +o errexit
+          timeout $TIMEOUT bash -c "$COMMAND"
+          START_RESULT="$?"
+          set -o errexit
+          if [[ $START_RESULT -ne 0 ]] ; then 
+            printf "failed to start devnet within %s with exit code %s" "$TIMEOUT" "$START_RESULT"
+            exit $START_RESULT
+          fi
+          
+          echo "PATH=$(pwd):$PATH" >> "$GITHUB_ENV"
           cd code/integration-tests/runtime-tests || exit
           npm install -q
           export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!


### PR DESCRIPTION
- avoid issue when tests fail because of host updates
- will add back as pure nix build after nix upgrade (nix 22.11 can run cgroups (containers) in build)
- fail fast on timeout
- depends on https://github.com/ComposableFi/composable/pull/2882/checks

Signed-off-by: dzmitry-lahoda <dzmitry@lahoda.pro>