### PR TITLE
#cu-86698p7yq always run integration tests to avoid regression

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1103,40 +1103,9 @@ jobs:
             nix-env -iA nixpkgs.cachix nixpkgs.nodejs
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           name: ${{  env.CACHIX_COMPOSABLE }}
-
       - run: |
-          DEVNET_MAIN=$(nix show-derivation github:ComposableFi/composable/#devnet-dali)
-          DEVNET_PR=$(nix show-derivation .#devnet-dali)
-          TESTS_MAIN=$(nix show-derivation github:ComposableFi/composable/#runtime-tests)
-          TESTS_PR=$(nix show-derivation .#runtime-tests)
-
-          if [ "$DEVNET_MAIN" != "$DEVNET_PR" ] || [ "$TESTS_MAIN" != "$TESTS_PR" ]; then
-            ( nix run .#devnet-dali 2>&1 & ) | tee devnet-dali.log &
-            until test -f devnet-dali.log; do
-              sleep 1 && echo "waiting network start";
-            done;
-            TIMEOUT=240
-            COMMAND="( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 \"Network launched 🚀🚀\""
-            set +o errexit
-            timeout $TIMEOUT bash -c "$COMMAND"
-            START_RESULT="$?"
-            set -o errexit
-            if [[ $START_RESULT -ne 0 ]] ; then 
-              printf "failed to start devnet within %s with exit code %s" "$TIMEOUT" "$START_RESULT"
-              exit $START_RESULT
-            fi
-            echo "PATH=$(pwd):$PATH" >> $GITHUB_ENV
-            cd code/integration-tests/runtime-tests || exit
-            npm install -q
-            export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
-            until test -f runtime-tests.log; do sleep 1 && echo "waiting tests start"; done;
-            tail --follow runtime-tests.log &
-            ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )
-            ( while : ; do if test $( wc --lines stop.log | cut --delimiter " " --fields 1 ) -gt 4; then kill -9 $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) &
-            wait $RUNTIME_TESTS_PID
-            exit $?
-          fi
-  
+          nix run .#devnet-integration-tests
+          
   effects-gate:
       name: "Effect gate, automatically merged if passed"
       runs-on:

--- a/code/integration-tests/runtime-tests/runtime-tests.nix
+++ b/code/integration-tests/runtime-tests/runtime-tests.nix
@@ -54,7 +54,8 @@
 
           cd code/integration-tests/runtime-tests || exit
           npm install -q
-          export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
+          export ENDPOINT=127.0.0.1:9988 ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log &
+          RUNTIME_TESTS_PID=$!
           wait_for_log "runtime-tests.log" "waiting tests start"
           tail --follow runtime-tests.log &
           ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )

--- a/code/integration-tests/runtime-tests/runtime-tests.nix
+++ b/code/integration-tests/runtime-tests/runtime-tests.nix
@@ -33,9 +33,14 @@
           ( ${
             pkgs.lib.meta.getExe self'.packages.devnet-dali
           } 2>&1 & ) | tee devnet-dali.log &
-          until test -f devnet-dali.log; do
-            sleep 1 && echo "waiting network start";
-          done;
+          wait_for_log () {
+           until test -f "$1"; do
+              sleep 1 
+              echo "$2"
+            done
+          }
+          
+          wait_for_log "devnet-dali.log" "waiting network start"
           TIMEOUT=240
           COMMAND="( tail --follow --lines=0  devnet-dali.log & ) | grep --max-count=1 \"Network launched 🚀🚀\""
           set +o errexit

--- a/code/integration-tests/runtime-tests/runtime-tests.nix
+++ b/code/integration-tests/runtime-tests/runtime-tests.nix
@@ -55,7 +55,7 @@
           cd code/integration-tests/runtime-tests || exit
           npm install -q
           export ENDPOINT=127.0.0.1:9988 && export ENDPOINT_RELAYCHAIN=127.0.0.1:9944 && npm run test_short 2>&1>runtime-tests.log & RUNTIME_TESTS_PID=$!
-          until test -f runtime-tests.log; do sleep 1 && echo "waiting tests start"; done;
+          wait_for_log "runtime-tests.log" "waiting tests start"
           tail --follow runtime-tests.log &
           ( tail --follow --lines=0 runtime-tests.log & ) | ( grep --max-count=5 "API-WS: disconnected from" >stop.log & )
           ( while : ; do if test $( wc --lines stop.log | cut --delimiter " " --fields 1 ) -gt 4; then kill -s SIGKILL $RUNTIME_TESTS_PID && echo "Failed" && exit 42; fi; sleep 1; done ) &


### PR DESCRIPTION
- run via nix
- if tests are flaky would disable it via https://github.com/ComposableFi/composable/blob/main/rfcs/0014-flaky-and-brittle-effects-gates.md