### PR TITLE
Switch to pull_request_target

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1243,6 +1243,9 @@ jobs:
 
 
   nix-command-pr-comments:
+    permissions:
+      pull-requests: write
+      issues: write
     runs-on:
       - self-hosted
       - linux

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -35,6 +35,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#devnet-initialize-script-picasso-persistent
@@ -56,6 +59,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#common-deps
@@ -76,6 +82,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#common-test-deps
@@ -93,6 +102,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actionsdesk/lfs-warning@v3.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -118,6 +130,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
           echo "sandbox = relaxed" >> /etc/nix/nix.conf
@@ -150,6 +165,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#cargo-fmt-check
@@ -171,6 +189,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
           echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
@@ -200,6 +221,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#taplo-check
@@ -219,6 +243,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#prettier-check
@@ -238,6 +265,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#nixfmt-check
@@ -257,6 +287,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#deadnix-check
@@ -276,6 +309,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#spell-check
@@ -311,6 +347,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: |
           # Marker status code in case of network failure.
           STATUS_TRANSIENT_FAILURE=200
@@ -369,6 +407,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#frontend-static
@@ -388,6 +429,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#hadolint-check
@@ -408,6 +452,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#cargo-clippy-check
@@ -428,42 +475,13 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#cargo-deny-check
           token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-
-# TODO (vim): Decrease lead time until after release 3
-#  cargo-udeps-check:
-#    name: "Cargo udeps"
-#    needs: common-deps
-#    runs-on:
-      # - self-hosted
-      # - linux
-      # - x64
-      # - sre
-#    concurrency:
-#      group: ${{ github.workflow }}-cargo-udeps-check-${{ github.ref }}
-#      cancel-in-progress: true
-#    container:
-#      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
-#    steps:
-#      - uses: actions/checkout@v3
-#      - run: |
-#          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
-#          echo "sandbox = relaxed" >> /etc/nix/nix.conf
-#          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
-#      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
-#        with:
-#          skipPush: true
-#          installCommand: |
-#            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
-#            nix-channel --update
-#            nix-env -iA nixpkgs.cachix
-#          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-#          name: composable-community
-#      - run: |
-#          cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nix -- build .#cargo-udeps-check --no-update-lock-file --show-trace -L
 
   benchmarks-check:
     name: "Benchmarks check"
@@ -480,6 +498,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#benchmarks-check
@@ -501,6 +522,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#unit-tests
@@ -524,6 +548,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Import project setting
@@ -566,6 +592,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Import project setting
@@ -590,44 +618,6 @@ jobs:
           comment-includes: 'Picasso Preview URL'
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-# TODO (vim): Decrease lead time until after release 3
-#  unit-tests-with-coverage:
-#    name: "Unit Tests with coverage"
-#    needs: common-deps
-#    runs-on:
-#      - self-hosted
-#      - linux
-#      - x64
-#      - sre
-#    concurrency:
-#      group: ${{ github.workflow }}-unittests-with-coverage-${{ github.ref }}
-#      cancel-in-progress: true
-#    container:
-#      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
-#    steps:
-#      - uses: actions/checkout@v3
-#      - run: |
-#          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
-#          echo "sandbox = relaxed" >> /etc/nix/nix.conf
-#          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
-#      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
-#        with:
-#          skipPush: true
-#          installCommand: |
-#            nix-channel --add https://nixos.org/channels/nixpkgs-22.05-darwin nixpkgs
-#            nix-channel --update
-#            nix-env -iA nixpkgs.cachix
-#          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-#          name: composable-community
-#      - run: |
-#          cachix watch-exec -j 16 -c 0 composable-community nix -- build .#unit-tests-with-coverage --no-update-lock-file --show-trace -L
-#      - name: Upload coverage to Codecov
-#        uses: codecov/codecov-action@v2
-#        with:
-#          token: ${{ secrets.CODECOV_TOKEN }}
-#          files: result/lcov/lcov.info
-#          fail_ci_if_error: false
-
   test-running-of-pallet-benchmarks:
     name: "Test running of pallet benchmarks"
     needs: package-composable-bench-node
@@ -646,6 +636,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- run .#benchmarks-once-${{ matrix.runtime }}
@@ -688,6 +681,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#composable-node
@@ -707,6 +703,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#composable-bench-node
@@ -726,6 +725,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#polkadot-node
@@ -748,6 +750,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#${{ matrix.node }}-node
@@ -767,6 +772,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#acala-node
@@ -786,6 +794,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#dali-subxt-client
@@ -805,6 +816,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#hyperspace-dali
@@ -841,6 +855,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#${{ matrix.runtime }}
@@ -871,6 +888,9 @@ jobs:
           name: ${{ env.CACHIX_COMPOSABLE }}
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@v3
         with:
           node-version: 16
@@ -911,6 +931,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#cmc-api
@@ -934,6 +957,9 @@ jobs:
       - sre
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Setup jest
         uses: actions/setup-node@v3
         with:
@@ -959,6 +985,9 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -989,6 +1018,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#zombienet
@@ -1008,6 +1040,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#price-feed
@@ -1028,6 +1063,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/docker-publish"
         with:
           command: nix -- build .#devnet-container
@@ -1053,6 +1091,9 @@ jobs:
       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: "./.github/templates/docker-publish"
         with:
           command: nix -- build .#bridge-devnet-dali-container
@@ -1084,6 +1125,8 @@ jobs:
         with:
           clean: false
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
           echo "sandbox = relaxed" >> /etc/nix/nix.conf
@@ -1156,6 +1199,8 @@ jobs:
         with:
           clean: false
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
           echo "sandbox = relaxed" >> /etc/nix/nix.conf
@@ -1207,8 +1252,10 @@ jobs:
       - check-nix
     name: "Nix command PR comments"
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Comment PR
         uses: "./.github/templates/comment"
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - release-*
       - main
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - develop

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -7,6 +7,8 @@ on:
   pull_request_target:
   pull_request:
 
+permissions: read-all
+
 env:
   # NOTE: keep in sync with docs
   NIX_NIXPKGS_CHANNEL: https://nixos.org/channels/nixpkgs-22.05-darwin

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -5,10 +5,7 @@ on:
       - release-*
       - main
   pull_request_target:
-    branches:
-      - main
-      - develop
-      - releases
+  pull_request:
 
 env:
   # NOTE: keep in sync with docs


### PR DESCRIPTION
Normally, PRs from forks cannot access secrets. This allows them to do so. PRs that alter workflow files won't be able to access secrets still I think.