### PR TITLE
NX-76 - Switch to the official `nixos/nix:2.13.2` image and  upgrade flake deps

### DIFF
--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -49,7 +49,7 @@ runs:
         STATUS_TRANSIENT_FAILURE=200
         # Maximum retries in case of network failures.
         RETRIES=5               
-        CMD="cachix watch-exec --no-http2 --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community ${{ inputs.command }} --no-update-lock-file --show-trace -L 2> >(tee -a $LOG_FILE >&2)" 
+        CMD="cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community ${{ inputs.command }} --no-update-lock-file --show-trace -L 2> >(tee -a $LOG_FILE >&2)" 
         # Marker that a network error occurred.
         BAD="HTTP error 200 ('')"  
         LOG_FILE=/tmp/out.log

--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -49,7 +49,7 @@ runs:
         STATUS_TRANSIENT_FAILURE=200
         # Maximum retries in case of network failures.
         RETRIES=5               
-        CMD="cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community ${{ inputs.command }} --no-update-lock-file --show-trace -L 2> >(tee -a $LOG_FILE >&2)" 
+        CMD="cachix watch-exec --no-http2 --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community ${{ inputs.command }} --no-update-lock-file --show-trace -L 2> >(tee -a $LOG_FILE >&2)" 
         # Marker that a network error occurred.
         BAD="HTTP error 200 ('')"  
         LOG_FILE=/tmp/out.log

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1159,7 +1159,6 @@ jobs:
         # - local-integration-tests
 
         - unit-tests
-        # - check-devnet
         - check-nix-long
         # TODO (vim): Decrease lead time until after release 3
         #- cargo-udeps-check
@@ -1177,69 +1176,6 @@ jobs:
         - lint-test-frontend
       steps:
         - run: echo "Goblins allow your work to see the light"
-
-  # temporarily commented out because nixops is broken
-  #
-  # check-devnet:
-  #     needs:
-  #       - cache-devnet-all-dev-local
-  #     runs-on:
-  #     - self-hosted
-  #     - linux
-  #     - x64
-  #     - sre
-  #     concurrency:
-  #       group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
-  #       cancel-in-progress: true
-  #     container:
-  #       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
-  #     steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         clean: false
-  #         fetch-depth: 0
-  #         ref: ${{ github.event.pull_request.head.sha }}
-  #         persist-credentials: false
-  #     - run: |
-  #         echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
-  #         echo "sandbox = relaxed" >> /etc/nix/nix.conf
-  #         echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
-  #       shell: "bash"
-  #     - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
-  #       with:
-  #         skipPush: true
-  #         installCommand: |
-  #           nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
-  #           nix-channel --update
-  #           nix profile install github:cachix/cachix/3abb69595aa30b774b821efade3cb34da302440e nixpkgs#jq
-  #         authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-  #         name: ${{  env.CACHIX_COMPOSABLE }}
-
-  #     - uses: google-github-actions/setup-gcloud@v0
-  #       with:
-  #         service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-  #         export_default_credentials: true
-
-  #     - name: Build & Push
-  #       run: |
-  #         cd devnet
-  #         jq --null-input --arg client_email "$GCP_DEVNET_SERVICE_ACCOUNT" --arg project_id "$GCP_PROJECT_ID" --arg key "\"$GCP_DEVNET_SERVICE_ACCOUNT_KEY\"" '{ "project_id": $project_id, "private_key": ($key | fromjson), "client_email": $client_email }' > ops.json
-  #         cd ..
-  #         if gsutil -q stat $NIXOPS_STATE_URL/$NIXOPS_STATE;
-  #         then
-  #           gsutil cp $NIXOPS_STATE_URL/$NIXOPS_STATE $NIXOPS_STATE
-  #           nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- deploy --dry-run --check --confirm --deployment devnet-gce --debug --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
-  #         else
-  #           nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- create --dry-run --deployment devnet-gce --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
-  #         fi
-
-  #       env:
-  #         NIXOPS_STATE_URL: "gs://composable-state"
-  #         NIXOPS_STATE: "deployment.nixops"
-  #         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-  #         GCP_DEVNET_SERVICE_ACCOUNT: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT }}
-  #         GCP_DEVNET_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT_KEY }}
-
 
   nix-command-pr-comments:
     permissions:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1190,7 +1190,7 @@ jobs:
         group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
         cancel-in-progress: true
       container:
-        image: nixos/nix:2.13.2
+        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
       steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   # NOTE: keep in sync with docs
   NIX_NIXPKGS_CHANNEL: https://nixos.org/channels/nixpkgs-22.05-darwin
-  NIX_CONTAINER_IMAGE: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+  NIX_CONTAINER_IMAGE: nixos/nix:2.13.2
   NIX_INSTALL_SCRIPT: https://releases.nixos.org/nix/nix-2.10.3/install
 
   CACHIX_COMPOSABLE: composable-community
@@ -34,7 +34,7 @@ jobs:
       - x64
       - sre
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -58,7 +58,7 @@ jobs:
       - x64
       - sre
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -81,7 +81,7 @@ jobs:
       - x64
       - sre
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -188,7 +188,7 @@ jobs:
       group: ${{ github.workflow }}-check-nix-long-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -220,7 +220,7 @@ jobs:
       group: ${{ github.workflow }}-taplo-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -242,7 +242,7 @@ jobs:
       group: ${{ github.workflow }}-prettier-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -264,7 +264,7 @@ jobs:
       group: ${{ github.workflow }}-nixfmt-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -286,7 +286,7 @@ jobs:
       group: ${{ github.workflow }}-deadnix-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -308,7 +308,7 @@ jobs:
       group: ${{ github.workflow }}-spell-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -331,7 +331,7 @@ jobs:
       group: ${{ github.workflow }}-docs-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
@@ -406,7 +406,7 @@ jobs:
       group: ${{ github.workflow }}-frontend-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -428,7 +428,7 @@ jobs:
       group: ${{ github.workflow }}-hadolint-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -451,7 +451,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-clippy-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -474,7 +474,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-deny-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -497,7 +497,7 @@ jobs:
       group: ${{ github.workflow }}-benchmarks-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -521,7 +521,7 @@ jobs:
       group: ${{ github.workflow }}-unittests-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -635,7 +635,7 @@ jobs:
       matrix:
         runtime: [dali, picasso, composable]
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -660,7 +660,7 @@ jobs:
   #     matrix:
   #       runtime: [dali, picasso]
   #   container:
-  #     image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+  #     image: nixos/nix:2.13.2
   #   steps:
   #     - uses: actions/checkout@v3
   #     - uses: "./.github/templates/watch-exec"
@@ -680,7 +680,7 @@ jobs:
       group: ${{ github.workflow }}-package-composable-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -702,7 +702,7 @@ jobs:
       group: ${{ github.workflow }}-package-composable-bench-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -724,7 +724,7 @@ jobs:
       group: ${{ github.workflow }}-package-polkadot-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -749,7 +749,7 @@ jobs:
       group: ${{ github.workflow }}-package-${{ matrix.node }}-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -771,7 +771,7 @@ jobs:
       group: ${{ github.workflow }}-package-acala-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -793,7 +793,7 @@ jobs:
       group: ${{ github.workflow }}-package-dali-subxt-client-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -815,7 +815,7 @@ jobs:
       group: ${{ github.workflow }}-package-hyperspace-dali-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -854,7 +854,7 @@ jobs:
       cancel-in-progress: true
     continue-on-error: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -874,7 +874,7 @@ jobs:
       - x64
       - sre
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
@@ -930,7 +930,7 @@ jobs:
       cancel-in-progress: true
     continue-on-error: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1017,7 +1017,7 @@ jobs:
       group: ${{ github.workflow }}-package-zombienet-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1039,7 +1039,7 @@ jobs:
       group: packagepricefeed-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1062,7 +1062,7 @@ jobs:
       group: ${{ github.workflow }}-composable-sandbox-container-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1090,7 +1090,7 @@ jobs:
       group: ${{ github.workflow }}-composable-bridge-devnet-container-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1121,7 +1121,7 @@ jobs:
         group: ${{ github.workflow }}-devnet-integration-tests-${{ github.event.pull_request.title }}
         cancel-in-progress: true
       container:
-        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+        image: nixos/nix:2.13.2
       steps:
       - uses: actions/checkout@v3
         with:
@@ -1195,7 +1195,7 @@ jobs:
         group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
         cancel-in-progress: true
       container:
-        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+        image: nixos/nix:2.13.2
       steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1234,3 +1234,5 @@ jobs:
             Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
           comment_tag: 'Nix commands for this PR'
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+        

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,11 +10,6 @@ permissions:
   pull-requests: write
 
 env:
-  # NOTE: keep in sync with docs
-  NIX_NIXPKGS_CHANNEL: https://nixos.org/channels/nixpkgs-22.05-darwin
-  NIX_CONTAINER_IMAGE: nixos/nix:2.13.2
-  NIX_INSTALL_SCRIPT: https://releases.nixos.org/nix/nix-2.10.3/install
-
   CACHIX_COMPOSABLE: composable-community
   CACHIX_COMPRESSION_LEVEL: 3
 

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1190,7 +1190,7 @@ jobs:
         group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
         cancel-in-progress: true
       container:
-        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+        image: nixos/nix:2.13.2
       steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -1159,7 +1159,7 @@ jobs:
         # - local-integration-tests
 
         - unit-tests
-        - check-devnet
+        # - check-devnet
         - check-nix-long
         # TODO (vim): Decrease lead time until after release 3
         #- cargo-udeps-check
@@ -1178,65 +1178,67 @@ jobs:
       steps:
         - run: echo "Goblins allow your work to see the light"
 
-  check-devnet:
-      needs:
-        - cache-devnet-all-dev-local
-      runs-on:
-      - self-hosted
-      - linux
-      - x64
-      - sre
-      concurrency:
-        group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
-        cancel-in-progress: true
-      container:
-        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
-      steps:
-      - uses: actions/checkout@v3
-        with:
-          clean: false
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
-      - run: |
-          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
-          echo "sandbox = relaxed" >> /etc/nix/nix.conf
-          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
-        shell: "bash"
-      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
-        with:
-          skipPush: true
-          installCommand: |
-            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
-            nix-channel --update
-            nix profile install github:cachix/cachix/3abb69595aa30b774b821efade3cb34da302440e nixpkgs#jq
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          name: ${{  env.CACHIX_COMPOSABLE }}
+  # temporarily commented out because nixops is broken
+  #
+  # check-devnet:
+  #     needs:
+  #       - cache-devnet-all-dev-local
+  #     runs-on:
+  #     - self-hosted
+  #     - linux
+  #     - x64
+  #     - sre
+  #     concurrency:
+  #       group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
+  #       cancel-in-progress: true
+  #     container:
+  #       image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+  #     steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         clean: false
+  #         fetch-depth: 0
+  #         ref: ${{ github.event.pull_request.head.sha }}
+  #         persist-credentials: false
+  #     - run: |
+  #         echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
+  #         echo "sandbox = relaxed" >> /etc/nix/nix.conf
+  #         echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
+  #       shell: "bash"
+  #     - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
+  #       with:
+  #         skipPush: true
+  #         installCommand: |
+  #           nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
+  #           nix-channel --update
+  #           nix profile install github:cachix/cachix/3abb69595aa30b774b821efade3cb34da302440e nixpkgs#jq
+  #         authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+  #         name: ${{  env.CACHIX_COMPOSABLE }}
 
-      - uses: google-github-actions/setup-gcloud@v0
-        with:
-          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
-          export_default_credentials: true
+  #     - uses: google-github-actions/setup-gcloud@v0
+  #       with:
+  #         service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+  #         export_default_credentials: true
 
-      - name: Build & Push
-        run: |
-          cd devnet
-          jq --null-input --arg client_email "$GCP_DEVNET_SERVICE_ACCOUNT" --arg project_id "$GCP_PROJECT_ID" --arg key "\"$GCP_DEVNET_SERVICE_ACCOUNT_KEY\"" '{ "project_id": $project_id, "private_key": ($key | fromjson), "client_email": $client_email }' > ops.json
-          cd ..
-          if gsutil -q stat $NIXOPS_STATE_URL/$NIXOPS_STATE;
-          then
-            gsutil cp $NIXOPS_STATE_URL/$NIXOPS_STATE $NIXOPS_STATE
-            nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- deploy --dry-run --check --confirm --deployment devnet-gce --debug --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
-          else
-            nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- create --dry-run --deployment devnet-gce --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
-          fi
+  #     - name: Build & Push
+  #       run: |
+  #         cd devnet
+  #         jq --null-input --arg client_email "$GCP_DEVNET_SERVICE_ACCOUNT" --arg project_id "$GCP_PROJECT_ID" --arg key "\"$GCP_DEVNET_SERVICE_ACCOUNT_KEY\"" '{ "project_id": $project_id, "private_key": ($key | fromjson), "client_email": $client_email }' > ops.json
+  #         cd ..
+  #         if gsutil -q stat $NIXOPS_STATE_URL/$NIXOPS_STATE;
+  #         then
+  #           gsutil cp $NIXOPS_STATE_URL/$NIXOPS_STATE $NIXOPS_STATE
+  #           nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- deploy --dry-run --check --confirm --deployment devnet-gce --debug --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
+  #         else
+  #           nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- create --dry-run --deployment devnet-gce --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
+  #         fi
 
-        env:
-          NIXOPS_STATE_URL: "gs://composable-state"
-          NIXOPS_STATE: "deployment.nixops"
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
-          GCP_DEVNET_SERVICE_ACCOUNT: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT }}
-          GCP_DEVNET_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT_KEY }}
+  #       env:
+  #         NIXOPS_STATE_URL: "gs://composable-state"
+  #         NIXOPS_STATE: "deployment.nixops"
+  #         GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  #         GCP_DEVNET_SERVICE_ACCOUNT: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT }}
+  #         GCP_DEVNET_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT_KEY }}
 
 
   nix-command-pr-comments:

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -129,7 +129,7 @@ jobs:
       group: ${{ github.workflow }}-check-nix-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:
@@ -164,7 +164,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-fmt-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      image: nixos/nix:2.13.2
     steps:
       - uses: actions/checkout@v3
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -462,6 +462,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-working-nixops": {
+      "locked": {
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1629252929,
@@ -495,11 +511,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1674459583,
-        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
+        "lastModified": 1674641431,
+        "narHash": "sha256-qfo19qVZBP4qn5M5gXc/h1MDgAtPA5VxJm9s8RUAkVk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
+        "rev": "9b97ad7b4330aacda9b2343396eb3df8a853b4fc",
         "type": "github"
       },
       "original": {
@@ -550,6 +566,7 @@
         "flake-utils": "flake-utils_3",
         "helix": "helix",
         "nixpkgs": "nixpkgs_4",
+        "nixpkgs-working-nixops": "nixpkgs-working-nixops",
         "npm-buildpackage": "npm-buildpackage",
         "rust-overlay": "rust-overlay_3"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -9,11 +9,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1671155090,
-        "narHash": "sha256-kRbTLQN4oQGu3YTxRgB75rCV18QLc4ENKfT3xhjrVT4=",
+        "lastModified": 1673633885,
+        "narHash": "sha256-XxFZvY20EqOYlOP1dF/YcPYpgSJtlRIqIeWXHJqCnws=",
         "owner": "hercules-ci",
         "repo": "arion",
-        "rev": "cabcbcacca1ba6e71f91dbccec24880850bdf516",
+        "rev": "09ef2d13771ec1309536bbf97720767f90a5afa7",
         "type": "github"
       },
       "original": {
@@ -31,11 +31,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1656042461,
-        "narHash": "sha256-8me0sv6kMgEJLxwep06adAMeRC9XdDXY9gusTqI8PBc=",
+        "lastModified": 1672257746,
+        "narHash": "sha256-uVVAUIxGPnNKv0pIhmjxlHZ78dFAlQh4gMNoT2iDJko=",
         "owner": "NixOS",
         "repo": "bundlers",
-        "rev": "b11f6a6b4d96ad424dc927fa211d1a1ac50179ef",
+        "rev": "3476034902f2d1dbf3021acd6d883fb39b217697",
         "type": "github"
       },
       "original": {
@@ -50,14 +50,15 @@
         "flake-utils": "flake-utils_2",
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1660447363,
-        "narHash": "sha256-Y1OtGWEb0bgFlp9YULaiYcgfEoHVIz1NuXwzlFZ/0HE=",
+        "lastModified": 1674348649,
+        "narHash": "sha256-hBRlaUlsrmW1wAPevwQnkrT0XiLrmlAHWabWYmLeQlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "5548a68f5d4d60a2315ab1232e6fba5528e71dc8",
+        "rev": "ccea7b33178daf6010aae3ea2b3fb5b0241b9146",
         "type": "github"
       },
       "original": {
@@ -69,11 +70,11 @@
     "crane_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1661875961,
-        "narHash": "sha256-f1h/2c6Teeu1ofAHWzrS8TwBPcnN+EEu+z1sRVmMQTk=",
+        "lastModified": 1670900067,
+        "narHash": "sha256-VXVa+KBfukhmWizaiGiHRVX/fuk66P8dgSFfkVN4/MY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "d9f394e4e20e97c2a60c3ad82c2b6ef99be19e24",
+        "rev": "59b31b41a589c0a65e4a1f86b0e5eac68081468b",
         "type": "github"
       },
       "original": {
@@ -114,6 +115,7 @@
           "nci",
           "devshell"
         ],
+        "flake-parts": "flake-parts_3",
         "flake-utils-pre-commit": [
           "helix",
           "nci"
@@ -127,6 +129,10 @@
           "nci"
         ],
         "mach-nix": [
+          "helix",
+          "nci"
+        ],
+        "nix-pypi-fetcher": [
           "helix",
           "nci"
         ],
@@ -145,11 +151,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1668851003,
-        "narHash": "sha256-X7RCQQynbxStZR2m7HW38r/msMQwVl3afD6UXOCtvx4=",
+        "lastModified": 1671323629,
+        "narHash": "sha256-9KHTPjIDjfnzZ4NjpE3gGIVHVHopy6weRDYO/7Y3hF8=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "c77e8379d8fe01213ba072e40946cbfb7b58e628",
+        "rev": "2d7d68505c8619410df2c6b6463985f97cbcba6e",
         "type": "github"
       },
       "original": {
@@ -161,11 +167,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1650374568,
-        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
         "type": "github"
       },
       "original": {
@@ -182,16 +188,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1669931201,
-        "narHash": "sha256-UnYFeaLPLj7e4eEt4GJooeJZhaZXyloQZYinwO/CeUw=",
+        "lastModified": 1672877861,
+        "narHash": "sha256-ROnSmsk5grROL6gnHBnSdqlPPBrBJMApCeB7xzY567M=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "995d6bc162c0539998ef6375c2c6b612972dc016",
+        "rev": "7930f5b1c356270cec420d4f4cb43f4907206640",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
-        "ref": "easyOverlay",
         "repo": "flake-parts",
         "type": "github"
       }
@@ -201,11 +206,29 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1671322946,
-        "narHash": "sha256-J8Qj+ITV+eti+irTK9Zn2LZVYoIW2g7irPUckU8yZvU=",
+        "lastModified": 1673362319,
+        "narHash": "sha256-Pjp45Vnj7S/b3BRpZEVfdu8sqqA6nvVjvYu59okhOyI=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3f7172646953bf86dad5953bc45f0edae62ac445",
+        "rev": "82c16f1682cf50c01cb0280b38a1eed202b3fe9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1668450977,
+        "narHash": "sha256-cfLhMhnvXn6x1vPm+Jow3RiFAUSCw/l1utktCw5rVA4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "d591857e9d7dd9ddbfba0ea02b43b927c3c0f1fa",
         "type": "github"
       },
       "original": {
@@ -246,11 +269,11 @@
     },
     "flake-utils_3": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -308,14 +331,14 @@
       "inputs": {
         "nci": "nci",
         "nixpkgs": "nixpkgs_3",
-        "rust-overlay": "rust-overlay"
+        "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1670336313,
-        "narHash": "sha256-aGJH6PQjMzDDzuBBHpTNIwp1NHYCWUpA00YcFbdoDow=",
+        "lastModified": 1674686664,
+        "narHash": "sha256-frFKDrh3QNWQPlaAwn0B9azUxw3uu3oVFjCwZTCka7I=",
         "owner": "helix-editor",
         "repo": "helix",
-        "rev": "af532147c97987d6170dc06a52aa3434ebf1b9d4",
+        "rev": "22b3d3d6367f2e559a7193172bd1dba03b864bd3",
         "type": "github"
       },
       "original": {
@@ -338,11 +361,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1669011203,
-        "narHash": "sha256-Lymj4HktNEFmVXtwI0Os7srDXHZbZW0Nzw3/+5Hf8ko=",
+        "lastModified": 1671430291,
+        "narHash": "sha256-UIc7H8F3N8rK72J/Vj5YJdV72tvDvYjH+UPsOFvlcsE=",
         "owner": "yusdacra",
         "repo": "nix-cargo-integration",
-        "rev": "c5133b91fc1d549087c91228bd213f2518728a4b",
+        "rev": "b1b0d38b8c3b0d0e6a38638d5bbe10b0bc67522c",
         "type": "github"
       },
       "original": {
@@ -406,6 +429,24 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
+        "lastModified": 1672350804,
+        "narHash": "sha256-jo6zkiCabUBn3ObuKXHGqqORUMH27gYDIFFfLq5P4wg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "677ed08a50931e38382dbef01cba08a8f7eac8f6",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "dir": "lib",
         "lastModified": 1665349835,
         "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
@@ -438,11 +479,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1670242877,
-        "narHash": "sha256-jBLh7dRHnbfvPPA9znOC6oQfKrCPJ0El8Zoe0BqnCjQ=",
+        "lastModified": 1671359686,
+        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "6e51c97f1c849efdfd4f3b78a4870e6aa2da4198",
+        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
         "type": "github"
       },
       "original": {
@@ -454,11 +495,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1667231093,
-        "narHash": "sha256-RERXruzBEBuf0c7OfZeX1hxEKB+PTCUNxWeB6C1jd8Y=",
+        "lastModified": 1674459583,
+        "narHash": "sha256-L0UZl/u2H3HGsrhN+by42c5kNYeKtdmJiPzIRvEVeiM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d40fea9aeb8840fea0d377baa4b38e39b9582458",
+        "rev": "1b1f50645af2a70dc93eae18bfd88d330bfbcf7f",
         "type": "github"
       },
       "original": {
@@ -470,11 +511,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1667292599,
-        "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
+        "lastModified": 1653917367,
+        "narHash": "sha256-04MsJC0g9kE01nBuXThMppZK+yvCZECQnUaZKSU+HJo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef2f213d9659a274985778bff4ca322f3ef3ac68",
+        "rev": "437c8e6554911095f0557d524e9d2ffe1c26e33a",
         "type": "github"
       },
       "original": {
@@ -487,11 +528,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1654787802,
-        "narHash": "sha256-53wPtqRsiaR8e3njRHZbO4lPX1W9hHdTarHEx6gE/s0=",
+        "lastModified": 1670813451,
+        "narHash": "sha256-v0IvQ35CMKtPreGlxWb1FvFUraJNZd144+MbiDwGoAA=",
         "owner": "serokell",
         "repo": "nix-npm-buildpackage",
-        "rev": "ec9a825ad4a6f1fb2d6bb8371be827c9c8bf5b80",
+        "rev": "ec0365cd14a3359a23b80a9e2531a09afc3488fc",
         "type": "github"
       },
       "original": {
@@ -510,23 +551,26 @@
         "helix": "helix",
         "nixpkgs": "nixpkgs_4",
         "npm-buildpackage": "npm-buildpackage",
-        "rust-overlay": "rust-overlay_2"
+        "rust-overlay": "rust-overlay_3"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_4",
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
         "nixpkgs": [
-          "helix",
+          "crane",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1668998422,
-        "narHash": "sha256-G/BklIplCHZEeDIabaaxqgITdIXtMolRGlwxn9jG2/Q=",
+        "lastModified": 1672712534,
+        "narHash": "sha256-8S0DdMPcbITnlOu0uA81mTo3hgX84wK8S9wS34HEFY4=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "68ab029c93f8f8eed4cf3ce9a89a9fd4504b2d6e",
+        "rev": "69fb7bf0a8c40e6c4c197fa1816773774c8ac59f",
         "type": "github"
       },
       "original": {
@@ -537,17 +581,39 @@
     },
     "rust-overlay_2": {
       "inputs": {
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "helix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671416426,
+        "narHash": "sha256-kpSH1Jrxfk2qd0pRPJn1eQdIOseGv5JuE+YaOrqU9s4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "fbaaff24f375ac25ec64268b0a0d63f91e474b7d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_3": {
+      "inputs": {
         "flake-utils": "flake-utils_5",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1668739305,
-        "narHash": "sha256-BJNiTOWWBMdDXMUrl1ysDr+62nqIayf8SprK/blaFM0=",
+        "lastModified": 1674699969,
+        "narHash": "sha256-gkhhGV7zBVoEIl1sFSz67r0d8fTeY57coY/+zDzxrbk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f0ddbb639e2f23529ced79602cee6eb3903fc888",
+        "rev": "480f9cc37db841d1fd3ac0b0c059d48e5eb6946c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # remove me when the `nixops_unstable` works again on the latest unstable
+    nixpkgs-working-nixops.url = "github:NixOS/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1/";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-utils.url = "github:numtide/flake-utils";
     npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,8 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     # remove me when the `nixops_unstable` works again on the latest unstable
-    nixpkgs-working-nixops.url = "github:NixOS/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1/";
+    nixpkgs-working-nixops.url =
+      "github:NixOS/nixpkgs/34c5293a71ffdb2fe054eb5288adc1882c1eb0b1/";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-utils.url = "github:numtide/flake-utils";
     npm-buildpackage.url = "github:serokell/nix-npm-buildpackage";

--- a/flake/dev-shells.nix
+++ b/flake/dev-shells.nix
@@ -66,7 +66,7 @@
 
         ci = pkgs.mkShell {
           buildInputs = [ pkgs-working-nixops.nixops_unstable ];
-          NIX_PATH = "nixpkgs=${pkgs.path}";
+          NIX_PATH = "nixpkgs=${pkgs-working-nixops.path}";
         };
       };
     };

--- a/flake/dev-shells.nix
+++ b/flake/dev-shells.nix
@@ -1,68 +1,73 @@
 { self, ... }: {
-  perSystem = { config, self', inputs', pkgs, pkgs-working-nixops, system, systemCommonRust, ... }: {
-    devShells = rec {
-      minimal = pkgs.mkShell {
-        buildInputs = with pkgs;
-          [ clang nodejs python3 yarn ]
-          ++ (with self'.packages; [ rust-nightly ]);
-        LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath
-          (with pkgs; [ stdenv.cc.cc.lib llvmPackages.libclang.lib pkgs.zlib ]);
-        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-        PROTOC = "${pkgs.protobuf}/bin/protoc";
-        ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
-        NIX_PATH = "nixpkgs=${pkgs.path}";
-      };
+  perSystem = { config, self', inputs', pkgs, pkgs-working-nixops, system
+    , systemCommonRust, ... }: {
+      devShells = rec {
+        minimal = pkgs.mkShell {
+          buildInputs = with pkgs;
+            [ clang nodejs python3 yarn ]
+            ++ (with self'.packages; [ rust-nightly ]);
+          LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath (with pkgs; [
+            stdenv.cc.cc.lib
+            llvmPackages.libclang.lib
+            pkgs.zlib
+          ]);
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+          PROTOC = "${pkgs.protobuf}/bin/protoc";
+          ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+          NIX_PATH = "nixpkgs=${pkgs.path}";
+        };
 
-      default = minimal.overrideAttrs (base: {
-        buildInputs = base.buildInputs ++ (with pkgs; [
-          bacon
-          google-cloud-sdk
-          jq
-          lldb
-          llvmPackages_latest.bintools
-          llvmPackages_latest.lld
-          llvmPackages_latest.llvm
-          nix-tree
-          nixfmt
-          openssl
-          openssl.dev
-          pkg-config
-          qemu
-          rnix-lsp
-          taplo
-          xorriso
-          zlib.out
-          nix-tree
-          nixfmt
-          rnix-lsp
-          nodePackages.typescript
-          nodePackages.typescript-language-server
-          git
-          git-lfs
-        ]);
-      });
+        default = minimal.overrideAttrs (base: {
+          buildInputs = base.buildInputs ++ (with pkgs; [
+            bacon
+            google-cloud-sdk
+            jq
+            lldb
+            llvmPackages_latest.bintools
+            llvmPackages_latest.lld
+            llvmPackages_latest.llvm
+            nix-tree
+            nixfmt
+            openssl
+            openssl.dev
+            pkg-config
+            qemu
+            rnix-lsp
+            taplo
+            xorriso
+            zlib.out
+            nix-tree
+            nixfmt
+            rnix-lsp
+            nodePackages.typescript
+            nodePackages.typescript-language-server
+            git
+            git-lfs
+          ]);
+        });
 
-      with-helix = default.overrideAttrs (base: {
-        buildInputs = base.buildInputs ++ [ inputs'.helix.packages.default ];
-      });
+        with-helix = default.overrideAttrs (base: {
+          buildInputs = base.buildInputs ++ [ inputs'.helix.packages.default ];
+        });
 
-      wasm = default.overrideAttrs (base: {
-        buildInputs = base.buildInputs ++ [ pkgs.grub2 ]
-          ++ (with self'.packages; [ subwasm wasm-optimizer ]);
-      });
+        wasm = default.overrideAttrs (base: {
+          buildInputs = base.buildInputs ++ [ pkgs.grub2 ]
+            ++ (with self'.packages; [ subwasm wasm-optimizer ]);
+        });
 
-      xcvm = wasm.overrideAttrs (base: {
-        buildInputs = base.buildInputs ++ (with self'.packages; [ junod gex ]);
-        shellHook = ''
-          echo "junod alice key:"
-          echo "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose" | junod keys add alice --recover --keyring-backend test || true
-        '';
-      });
+        xcvm = wasm.overrideAttrs (base: {
+          buildInputs = base.buildInputs
+            ++ (with self'.packages; [ junod gex ]);
+          shellHook = ''
+            echo "junod alice key:"
+            echo "clip hire initial neck maid actor venue client foam budget lock catalog sweet steak waste crater broccoli pipe steak sister coyote moment obvious choose" | junod keys add alice --recover --keyring-backend test || true
+          '';
+        });
 
-      ci = pkgs.mkShell {
-        buildInputs = [ pkgs-working-nixops.nixops_unstable ];
-        NIX_PATH = "nixpkgs=${pkgs.path}";
+        ci = pkgs.mkShell {
+          buildInputs = [ pkgs-working-nixops.nixops_unstable ];
+          NIX_PATH = "nixpkgs=${pkgs.path}";
+        };
       };
     };
-  };
 }

--- a/flake/dev-shells.nix
+++ b/flake/dev-shells.nix
@@ -1,5 +1,5 @@
 { self, ... }: {
-  perSystem = { config, self', inputs', pkgs, system, systemCommonRust, ... }: {
+  perSystem = { config, self', inputs', pkgs, pkgs-working-nixops, system, systemCommonRust, ... }: {
     devShells = rec {
       minimal = pkgs.mkShell {
         buildInputs = with pkgs;
@@ -60,7 +60,7 @@
       });
 
       ci = pkgs.mkShell {
-        buildInputs = [ pkgs.nixopsUnstable ];
+        buildInputs = [ pkgs-working-nixops.nixops_unstable ];
         NIX_PATH = "nixpkgs=${pkgs.path}";
       };
     };

--- a/tools/pkgs.nix
+++ b/tools/pkgs.nix
@@ -9,8 +9,7 @@
       ];
     };
     # remove me when the `nixops_unstable` works again on the latest unstable
-    _module.args.pkgs-working-nixops = import self.inputs.nixpkgs-working-nixops {
-      inherit system;
-    };
+    _module.args.pkgs-working-nixops =
+      import self.inputs.nixpkgs-working-nixops { inherit system; };
   };
 }

--- a/tools/pkgs.nix
+++ b/tools/pkgs.nix
@@ -8,5 +8,9 @@
         rust-overlay.overlays.default
       ];
     };
+    # remove me when the `nixops_unstable` works again on the latest unstable
+    _module.args.pkgs-working-nixops = import self.inputs.nixpkgs-working-nixops {
+      inherit system;
+    };
   };
 }

--- a/tools/rust.nix
+++ b/tools/rust.nix
@@ -46,11 +46,10 @@
             cargoExtraArgs = "--all --check --verbose";
           });
 
-        cargo-clippy-check = crane.nightly.cargoBuild
+        cargo-clippy-check = crane.nightly.cargoClippy
           (systemCommonRust.common-attrs // {
             cargoArtifacts = self'.packages.common-deps-nightly;
-            cargoBuildCommand = "cargo clippy";
-            cargoExtraArgs = "--all-targets --tests -- -D warnings";
+            cargoClippyExtraArgs = "--all-targets --tests -- -D warnings";
           });
 
         cargo-deny-check = crane.nightly.cargoBuild

--- a/tools/rust.nix
+++ b/tools/rust.nix
@@ -52,14 +52,13 @@
             cargoClippyExtraArgs = "--all-targets --tests -- -D warnings";
           });
 
-        cargo-deny-check = crane.nightly.cargoBuild
-          (systemCommonRust.common-attrs // {
-            buildInputs = with pkgs; [ cargo-deny ];
-            cargoArtifacts = self'.packages.common-deps;
-            cargoBuildCommand = "cargo deny";
-            cargoExtraArgs =
-              "--manifest-path ./parachain/frame/composable-support/Cargo.toml check ban";
-          });
+        cargo-deny-check = crane.nightly.mkCargoDerivation {
+          buildInputs = with pkgs; [ cargo-deny ];
+          src = ../code;
+          cargoArtifacts = self'.packages.common-deps;
+          buildPhaseCargoCommand =
+            "cargo-deny --manifest-path ./parachain/frame/composable-support/Cargo.toml check bans";
+        };
 
         cargo-udeps-check = crane.nightly.cargoBuild
           (systemCommonRust.common-attrs // {


### PR DESCRIPTION
sadly enough `nixops_unstable` is broken on the latest version, so I've also added an additional input which pins nixpkgs to a specific rev where it still works.