### PR TITLE
fix(ci): revert NX-76 because it was not tested.

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,6 +10,11 @@ permissions:
   pull-requests: write
 
 env:
+  # NOTE: keep in sync with docs
+  NIX_NIXPKGS_CHANNEL: https://nixos.org/channels/nixpkgs-22.05-darwin
+  NIX_CONTAINER_IMAGE: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+  NIX_INSTALL_SCRIPT: https://releases.nixos.org/nix/nix-2.10.3/install
+
   CACHIX_COMPOSABLE: composable-community
   CACHIX_COMPRESSION_LEVEL: 3
 
@@ -29,7 +34,7 @@ jobs:
       - x64
       - sre
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -53,7 +58,7 @@ jobs:
       - x64
       - sre
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -76,7 +81,7 @@ jobs:
       - x64
       - sre
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -124,7 +129,7 @@ jobs:
       group: ${{ github.workflow }}-check-nix-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -159,7 +164,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-fmt-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -183,7 +188,7 @@ jobs:
       group: ${{ github.workflow }}-check-nix-long-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -215,7 +220,7 @@ jobs:
       group: ${{ github.workflow }}-taplo-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -237,7 +242,7 @@ jobs:
       group: ${{ github.workflow }}-prettier-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -259,7 +264,7 @@ jobs:
       group: ${{ github.workflow }}-nixfmt-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -281,7 +286,7 @@ jobs:
       group: ${{ github.workflow }}-deadnix-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -303,7 +308,7 @@ jobs:
       group: ${{ github.workflow }}-spell-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -326,7 +331,7 @@ jobs:
       group: ${{ github.workflow }}-docs-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
@@ -401,7 +406,7 @@ jobs:
       group: ${{ github.workflow }}-frontend-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -423,7 +428,7 @@ jobs:
       group: ${{ github.workflow }}-hadolint-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -446,7 +451,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-clippy-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -469,7 +474,7 @@ jobs:
       group: ${{ github.workflow }}-cargo-deny-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -492,7 +497,7 @@ jobs:
       group: ${{ github.workflow }}-benchmarks-check-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -516,7 +521,7 @@ jobs:
       group: ${{ github.workflow }}-unittests-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -630,7 +635,7 @@ jobs:
       matrix:
         runtime: [dali, picasso, composable]
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -655,7 +660,7 @@ jobs:
   #     matrix:
   #       runtime: [dali, picasso]
   #   container:
-  #     image: nixos/nix:2.13.2
+  #     image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
   #   steps:
   #     - uses: actions/checkout@v3
   #     - uses: "./.github/templates/watch-exec"
@@ -675,7 +680,7 @@ jobs:
       group: ${{ github.workflow }}-package-composable-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -697,7 +702,7 @@ jobs:
       group: ${{ github.workflow }}-package-composable-bench-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -719,7 +724,7 @@ jobs:
       group: ${{ github.workflow }}-package-polkadot-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -744,7 +749,7 @@ jobs:
       group: ${{ github.workflow }}-package-${{ matrix.node }}-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -766,7 +771,7 @@ jobs:
       group: ${{ github.workflow }}-package-acala-node-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -788,7 +793,7 @@ jobs:
       group: ${{ github.workflow }}-package-dali-subxt-client-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -810,7 +815,7 @@ jobs:
       group: ${{ github.workflow }}-package-hyperspace-dali-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -849,7 +854,7 @@ jobs:
       cancel-in-progress: true
     continue-on-error: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -869,7 +874,7 @@ jobs:
       - x64
       - sre
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - run: |
           echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
@@ -925,7 +930,7 @@ jobs:
       cancel-in-progress: true
     continue-on-error: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1012,7 +1017,7 @@ jobs:
       group: ${{ github.workflow }}-package-zombienet-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1034,7 +1039,7 @@ jobs:
       group: packagepricefeed-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1057,7 +1062,7 @@ jobs:
       group: ${{ github.workflow }}-composable-sandbox-container-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1085,7 +1090,7 @@ jobs:
       group: ${{ github.workflow }}-composable-bridge-devnet-container-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     container:
-      image: nixos/nix:2.13.2
+      image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1116,7 +1121,7 @@ jobs:
         group: ${{ github.workflow }}-devnet-integration-tests-${{ github.event.pull_request.title }}
         cancel-in-progress: true
       container:
-        image: nixos/nix:2.13.2
+        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
       steps:
       - uses: actions/checkout@v3
         with:
@@ -1159,6 +1164,7 @@ jobs:
         # - local-integration-tests
 
         - unit-tests
+        - check-devnet
         - check-nix-long
         # TODO (vim): Decrease lead time until after release 3
         #- cargo-udeps-check
@@ -1176,6 +1182,67 @@ jobs:
         - lint-test-frontend
       steps:
         - run: echo "Goblins allow your work to see the light"
+
+  check-devnet:
+      needs:
+        - cache-devnet-all-dev-local
+      runs-on:
+      - self-hosted
+      - linux
+      - x64
+      - sre
+      concurrency:
+        group: $${github.workflow }}-check-devnet-${{ github.event.pull_request.title }}
+        cancel-in-progress: true
+      container:
+        image: niteo/nixpkgs-nixos-22.05:316b762afdb9e142a803f29c49a88b4a47db80ee
+      steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: false
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - run: |
+          echo "experimental-features = nix-command flakes" > /etc/nix/nix.conf
+          echo "sandbox = relaxed" >> /etc/nix/nix.conf
+          echo "narinfo-cache-negative-ttl = 0" >> /etc/nix/nix.conf
+        shell: "bash"
+      - uses: cachix/cachix-action@f5f67badd061acb62b5c6e25e763572ca8317004
+        with:
+          skipPush: true
+          installCommand: |
+            nix-channel --add ${{ env.NIX_NIXPKGS_CHANNEL }} nixpkgs
+            nix-channel --update
+            nix profile install github:cachix/cachix/3abb69595aa30b774b821efade3cb34da302440e nixpkgs#jq
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          name: ${{  env.CACHIX_COMPOSABLE }}
+
+      - uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.GCP_CREDENTIALS }}
+          export_default_credentials: true
+
+      - name: Build & Push
+        run: |
+          cd devnet
+          jq --null-input --arg client_email "$GCP_DEVNET_SERVICE_ACCOUNT" --arg project_id "$GCP_PROJECT_ID" --arg key "\"$GCP_DEVNET_SERVICE_ACCOUNT_KEY\"" '{ "project_id": $project_id, "private_key": ($key | fromjson), "client_email": $client_email }' > ops.json
+          cd ..
+          if gsutil -q stat $NIXOPS_STATE_URL/$NIXOPS_STATE;
+          then
+            gsutil cp $NIXOPS_STATE_URL/$NIXOPS_STATE $NIXOPS_STATE
+            nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- deploy --dry-run --check --confirm --deployment devnet-gce --debug --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
+          else
+            nix develop .#ci --show-trace -L --command cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community nixops -- create --dry-run --deployment devnet-gce --show-trace --option narinfo-cache-negative-ttl 0 --include composable-devnet-dali-dev composable-devnet-picasso-dev
+          fi
+
+        env:
+          NIXOPS_STATE_URL: "gs://composable-state"
+          NIXOPS_STATE: "deployment.nixops"
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_DEVNET_SERVICE_ACCOUNT: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT }}
+          GCP_DEVNET_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_DEVNET_SERVICE_ACCOUNT_KEY }}
+
 
   nix-command-pr-comments:
     permissions:
@@ -1233,6 +1300,4 @@ jobs:
             _For more info on how to use Nix, check out our [Nix docs](https://docs.composable.finance/nix.html)_
             Note that the initial build may take about one hour if it has not been cached by our CI yet. Once it is cached, builds should take about one minute. We currently do not provide build caches for ARM machines such as M1 Macs, but building on ARM is supported.
           comment_tag: 'Nix commands for this PR'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-        
+          github_token: ${{ secrets.GITHUB_TOKEN }}       


### PR DESCRIPTION
The PR for issue NX-76 was merged with green checks, but apparently all of those checks were not actually being ran against the updated workflow. Presumably because the PR was made from a fork. This commit
reverts it, and the changes will get re-introduced later.