### PR TITLE
merge queue: embarking main (25d70b7) and #3034 together

### DIFF
--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 #![feature(sync_unsafe_cell)]
+#![feature(trait_alias)]
 #![cfg_attr(
 	not(test),
 	deny(
@@ -43,12 +44,14 @@ pub mod dispatchable_call;
 pub mod ibc;
 pub mod instrument;
 pub mod pallet_hook;
+mod prelude;
 pub mod runtimes;
 pub mod types;
 pub mod utils;
 pub mod weights;
 pub use crate::ibc::NoRelayer;
 pub mod entrypoint;
+mod mapping;
 
 #[cfg(any(feature = "runtime-benchmarks", test))]
 mod benchmarking;
@@ -149,7 +152,6 @@ pub mod pallet {
 		Emitted { contract: AccountIdOf<T>, ty: Vec<u8>, attributes: Vec<(Vec<u8>, Vec<u8>)> },
 		Migrated { contract: AccountIdOf<T>, to: CosmwasmCodeId },
 		AdminUpdated { contract: AccountIdOf<T>, new_admin: Option<AccountIdOf<T>> },
-		IbcChannelOpen { contract: AccountIdOf<T> },
 	}
 
 	#[pallet::error]

--- a/code/parachain/frame/cosmwasm/src/mapping.rs
+++ b/code/parachain/frame/cosmwasm/src/mapping.rs
@@ -1,0 +1,93 @@
+//! this simply maps `ibc-rs` and `cosmwasm-std` types back and forth
+
+use cosmwasm_vm::cosmwasm_std::{IbcChannel, IbcChannelOpenMsg, IbcEndpoint, IbcOrder as CwOrder};
+use ibc::core::{
+	ics04_channel::{
+		channel::{Counterparty, Order as IbcOrder},
+		error::Error as IbcError,
+		Version as IbcVersion,
+	},
+	ics24_host::identifier::{ChannelId, ConnectionId, PortId},
+};
+
+use crate::{prelude::*, Config};
+
+pub fn ibc_to_cw_channel_open<T: Config + Send + Sync>(
+	channel_id: &ChannelId,
+	port_id: &PortId,
+	counterparty: &Counterparty,
+	order: IbcOrder,
+	version: &IbcVersion,
+	connection_hops: &[ConnectionId],
+) -> Result<IbcChannelOpenMsg, IbcError> {
+	Ok(IbcChannelOpenMsg::OpenInit {
+		channel: IbcChannel::new(
+			IbcEndpoint { channel_id: channel_id.to_string(), port_id: port_id.to_string() },
+			IbcEndpoint {
+				port_id: counterparty.port_id.to_string(),
+				channel_id: counterparty.channel_id.expect("channel").to_string(),
+			},
+			map_order(order),
+			version.to_string(),
+			connection_hops
+				.get(0)
+				.expect("by spec there is at least one connection; qed")
+				.to_string(),
+		),
+	})
+}
+
+pub fn map_order(order: IbcOrder) -> CwOrder {
+	match order {
+		IbcOrder::Unordered => CwOrder::Unordered,
+		IbcOrder::Ordered => CwOrder::Ordered,
+	}
+}
+
+pub fn to_cosmwasm_timeout_block(
+	ibc::core::ics02_client::height::Height { revision_number, revision_height }: ibc::core::ics02_client::height::Height,
+) -> cosmwasm_vm::cosmwasm_std::IbcTimeoutBlock {
+	cosmwasm_vm::cosmwasm_std::IbcTimeoutBlock {
+		revision: revision_number,
+		height: revision_height,
+	}
+}
+
+pub fn to_cosmwasm_timestamp(
+	timestamp: ibc::timestamp::Timestamp,
+) -> cosmwasm_vm::cosmwasm_std::Timestamp {
+	cosmwasm_vm::cosmwasm_std::Timestamp::from_nanos(timestamp.nanoseconds())
+}
+
+pub fn ibc_open_try_to_cw_open<T: Config + Send + Sync>(
+	channel_id: &ChannelId,
+	port_id: &PortId,
+	counterparty: &Counterparty,
+	order: IbcOrder,
+	version: &IbcVersion,
+	connection_hops: &[ConnectionId],
+) -> Result<IbcChannelOpenMsg, IbcError> {
+	let message = {
+		IbcChannelOpenMsg::OpenInit {
+			channel: IbcChannel::new(
+				IbcEndpoint { channel_id: channel_id.to_string(), port_id: port_id.to_string() },
+				IbcEndpoint {
+					port_id: counterparty.port_id.to_string(),
+					channel_id: counterparty
+						.channel_id
+						.expect(
+							"one may not have OpenTry without remote channel id by protocol; qed",
+						)
+						.to_string(),
+				},
+				map_order(order),
+				version.to_string(),
+				connection_hops
+					.get(0)
+					.expect("by spec there is at least one connection; qed")
+					.to_string(),
+			),
+		}
+	};
+	Ok(message)
+}

--- a/code/parachain/frame/cosmwasm/src/prelude.rs
+++ b/code/parachain/frame/cosmwasm/src/prelude.rs
@@ -1,0 +1,5 @@
+pub use alloc::{
+	format,
+	string::{String, ToString},
+	vec::Vec,
+};

--- a/code/parachain/frame/cosmwasm/src/tests.rs
+++ b/code/parachain/frame/cosmwasm/src/tests.rs
@@ -222,9 +222,23 @@ fn ed25519_batch_verify_fails_if_input_lengths_are_incorrect() {
 }
 
 mod pallet_contracts {
+	use core::str::FromStr;
+
+	use crate::{ibc::Router, Pallet};
+
 	use super::*;
 	use cosmwasm_vm::system::CUSTOM_CONTRACT_EVENT_PREFIX;
 	use frame_support::{assert_ok, BoundedVec};
+	use ibc::core::{
+		ics03_connection::context::ConnectionReader,
+		ics04_channel::{
+			channel::{Counterparty, Order},
+			context::ChannelReader,
+		},
+		ics24_host::identifier::{ConnectionId, PortId},
+		ics26_routing::context::{ModuleCallbackContext, ModuleId, ModuleOutputBuilder},
+	};
+	use pallet_ibc::{routing::ModuleRouter, Signer};
 
 	fn make_event_type(custom_event_name: &str) -> Vec<u8> {
 		format!("{CUSTOM_CONTRACT_EVENT_PREFIX}{custom_event_name}").into()
@@ -283,5 +297,197 @@ mod pallet_contracts {
 				1 + depth as usize
 			);
 		})
+	}
+
+	impl ConnectionReader for Test {
+		fn minimum_delay_period(&self) -> core::time::Duration {
+			unimplemented!()
+		}
+
+		fn connection_end(
+			&self,
+			_conn_id: &ibc::core::ics24_host::identifier::ConnectionId,
+		) -> Result<
+			ibc::core::ics03_connection::connection::ConnectionEnd,
+			ibc::core::ics03_connection::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn host_oldest_height(&self) -> ibc::Height {
+			unimplemented!()
+		}
+
+		fn commitment_prefix(&self) -> ibc::core::ics23_commitment::commitment::CommitmentPrefix {
+			unimplemented!()
+		}
+
+		fn connection_counter(&self) -> Result<u64, ibc::core::ics03_connection::error::Error> {
+			unimplemented!()
+		}
+	}
+
+	impl ChannelReader for Test {
+		fn channel_end(
+			&self,
+			_port_channel_id: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::channel::ChannelEnd,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn connection_channels(
+			&self,
+			_cid: &ibc::core::ics24_host::identifier::ConnectionId,
+		) -> Result<
+			Vec<(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+			)>,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn get_next_sequence_send(
+			&self,
+			_port_channel_id: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::packet::Sequence,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn get_next_sequence_recv(
+			&self,
+			_port_channel_id: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::packet::Sequence,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn get_next_sequence_ack(
+			&self,
+			_port_channel_id: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::packet::Sequence,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn get_packet_commitment(
+			&self,
+			_key: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+				ibc::core::ics04_channel::packet::Sequence,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::commitment::PacketCommitment,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn get_packet_receipt(
+			&self,
+			_key: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+				ibc::core::ics04_channel::packet::Sequence,
+			),
+		) -> Result<ibc::core::ics04_channel::packet::Receipt, ibc::core::ics04_channel::error::Error>
+		{
+			unimplemented!()
+		}
+
+		fn get_packet_acknowledgement(
+			&self,
+			_key: &(
+				ibc::core::ics24_host::identifier::PortId,
+				ibc::core::ics24_host::identifier::ChannelId,
+				ibc::core::ics04_channel::packet::Sequence,
+			),
+		) -> Result<
+			ibc::core::ics04_channel::commitment::AcknowledgementCommitment,
+			ibc::core::ics04_channel::error::Error,
+		> {
+			unimplemented!()
+		}
+
+		fn hash(&self, _value: Vec<u8>) -> Vec<u8> {
+			unimplemented!()
+		}
+
+		fn client_update_time(
+			&self,
+			_client_id: &ibc::core::ics24_host::identifier::ClientId,
+			_height: ibc::Height,
+		) -> Result<ibc::timestamp::Timestamp, ibc::core::ics04_channel::error::Error> {
+			unimplemented!()
+		}
+
+		fn client_update_height(
+			&self,
+			_client_id: &ibc::core::ics24_host::identifier::ClientId,
+			_height: ibc::Height,
+		) -> Result<ibc::Height, ibc::core::ics04_channel::error::Error> {
+			unimplemented!()
+		}
+
+		fn channel_counter(&self) -> Result<u64, ibc::core::ics04_channel::error::Error> {
+			unimplemented!()
+		}
+
+		fn max_expected_time_per_block(&self) -> core::time::Duration {
+			unimplemented!()
+		}
+	}
+	impl ModuleCallbackContext for Test {}
+
+	#[test]
+	fn open_channel_ceremony() {
+		type T = Test;
+		new_test_ext().execute_with(|| {
+			let mut ibc = Router::<T>::default();
+			let module_id = ModuleId::from_str("cosmwasm").unwrap();
+			let ibc = ibc.get_route_mut(&module_id).unwrap();
+			assert_ok!(ibc.on_chan_open_init(
+				&Test::default(),
+				&mut ModuleOutputBuilder::new(),
+				Order::Ordered,
+				&[ConnectionId::new(42)],
+				&PortId::from_str(
+					format!(
+						"wasm.{}",
+						Pallet::<Test>::account_to_cosmwasm_addr(MOCK_PALLET_IBC_CONTRACT_ADDRESS)
+					)
+					.as_str(),
+				)
+				.unwrap(),
+				&<_>::default(),
+				&Counterparty { port_id: <_>::default(), channel_id: Some(<_>::default()) },
+				&<_>::default(),
+				&Signer::from_str("42").unwrap(),
+			));
+		});
 	}
 }

--- a/code/parachain/frame/cosmwasm/src/types.rs
+++ b/code/parachain/frame/cosmwasm/src/types.rs
@@ -34,7 +34,11 @@ pub enum EntryPoint {
 	Execute,
 	Migrate,
 	Reply,
-	// TODO(hussein-aitlahcen): do we want to support cosmwasm sudo?
+	IbcChannelOpen,
+	IbcChannelConnect,
+	IbcChannelClose,
+	IbcPacketTimeout,
+	IbcPacketAck,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Encode, Decode, TypeInfo, Debug)]


### PR DESCRIPTION
**✨ Unexpected queue change: an external action moved the target branch head to 130059524dcc3d9da438679467baa2ae02017ebe. The pull request [#3034](/ComposableFi/composable/pull/3034) has been re-embarked. ✨**

Branch **main** (25d70b7) and [#3034](/ComposableFi/composable/pull/3034) are embarked together for merge.

This pull request has been created by Mergify to speculatively check the mergeability of [#3034](/ComposableFi/composable/pull/3034).
You don't need to do anything. Mergify will close this pull request automatically when it is complete.


**Required conditions of queue** `default` **for merge:**

- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=Effect gate, automatically merged if passed`
  - [ ] `check-skipped=Effect gate, automatically merged if passed`
  - [ ] `check-success=Effect gate, automatically merged if passed`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=Docker composable-bridge-devnet`
  - [ ] `check-skipped=Docker composable-bridge-devnet`
  - [ ] `check-success=Docker composable-bridge-devnet`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=composable-sandbox-container-publish`
  - [ ] `check-skipped=composable-sandbox-container-publish`
  - [ ] `check-success=composable-sandbox-container-publish`
- `#approved-reviews-by>=2` [🛡 GitHub branch protection]
  - [X] #3034
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #3034
- `#review-threads-unresolved=0` [🛡 GitHub branch protection]
  - [X] #3034
- `-title~="#wip"`
  - [X] #3034
- `branch-protection-review-decision=APPROVED` [🛡 GitHub branch protection]
  - [X] #3034
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Common dependencies`
  - [ ] `check-neutral=Common dependencies`
  - [ ] `check-skipped=Common dependencies`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Check nix`
  - [ ] `check-neutral=Check nix`
  - [ ] `check-skipped=Check nix`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Nixfmt check`
  - [ ] `check-neutral=Nixfmt check`
  - [ ] `check-skipped=Nixfmt check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Composable node`
  - [ ] `check-neutral=Package Composable node`
  - [ ] `check-skipped=Package Composable node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Composable bench node`
  - [ ] `check-neutral=Package Composable bench node`
  - [ ] `check-skipped=Package Composable bench node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Polkadot node`
  - [ ] `check-neutral=Package Polkadot node`
  - [ ] `check-skipped=Package Polkadot node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Unit Tests`
  - [ ] `check-neutral=Unit Tests`
  - [ ] `check-skipped=Unit Tests`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Cargo fmt check`
  - [ ] `check-neutral=Cargo fmt check`
  - [ ] `check-skipped=Cargo fmt check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Prettier check`
  - [ ] `check-neutral=Prettier check`
  - [ ] `check-skipped=Prettier check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Cargo clippy check`
  - [ ] `check-neutral=Cargo clippy check`
  - [ ] `check-skipped=Cargo clippy check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Cargo deny check`
  - [ ] `check-neutral=Cargo deny check`
  - [ ] `check-skipped=Cargo deny check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Spelling check`
  - [ ] `check-neutral=Spelling check`
  - [ ] `check-skipped=Spelling check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (composable)`
  - [ ] `check-neutral=Test running of pallet benchmarks (composable)`
  - [ ] `check-skipped=Test running of pallet benchmarks (composable)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (dali)`
  - [ ] `check-neutral=Test running of pallet benchmarks (dali)`
  - [ ] `check-skipped=Test running of pallet benchmarks (dali)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (picasso)`
  - [ ] `check-neutral=Test running of pallet benchmarks (picasso)`
  - [ ] `check-skipped=Test running of pallet benchmarks (picasso)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Devnet integration tests`
  - [ ] `check-neutral=Devnet integration tests`
  - [ ] `check-skipped=Devnet integration tests`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Dockerfiles check`
  - [ ] `check-neutral=Dockerfiles check`
  - [ ] `check-skipped=Dockerfiles check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Subsquid Processor`
  - [ ] `check-neutral=Package Subsquid Processor`
  - [ ] `check-skipped=Package Subsquid Processor`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test Subquid`
  - [ ] `check-neutral=Test Subquid`
  - [ ] `check-skipped=Test Subquid`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Taplo check`
  - [ ] `check-neutral=Taplo check`
  - [ ] `check-skipped=Taplo check`

---

More informations about Mergify merge queue can be found in the [documentation](https://docs.mergify.com/actions/queue.html).

<details>
<summary>Mergify commands</summary>

<br />

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the queue rules

Additionally, on Mergify [dashboard](https://dashboard.mergify.com) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.com
</details>
<!---
DO NOT EDIT
-*- Mergify Payload -*-
{"merge-queue-pr": true}
-*- Mergify Payload End -*-
-->

```yaml
---
pull_requests:
  - number: 3034
...

```