### PR TITLE
Fix HTTP error 200 from nix #cu-20465559 #XCVM-288 

### DIFF
--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -83,10 +83,11 @@ runs:
             if [[ $STATUS_CODE -eq 0 ]] ; then
               break
             fi
-            
-            if [[ $STATUS_CODE -ne 0 ]] || [[ $STATUS_CODE -ne $STATUS_TRANSIENT_FAILURE ]] ; then
+
+            if [[ $STATUS_CODE -ne 0 ]] && [[ $STATUS_CODE -ne $STATUS_TRANSIENT_FAILURE ]] ; then
                 break
             fi
+            
             ((try=try+1))
         done
 

--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -52,6 +52,7 @@ runs:
         INPUTS_COMMAND="${{ inputs.command }}"        
         CACHIX="cachix watch-exec --jobs 16 --compression-level ${CACHIX_COMPRESSION_LEVEL?} composable-community"
         HAPPY_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --show-trace -L 2> >(tee --append $LOG_FILE >&2)" 
+        SLOW_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --show-trace --fallback -L 2> >(tee --append $LOG_FILE >&2)" 
         
         printf "will try execute '${HAPPY_CMD?}'"
 
@@ -73,9 +74,16 @@ runs:
         try=0
         while [[ "${try?}" -le "${RETRIES?}" ]]; do
             if [[ "${try?}" -eq "${RETRIES?}" ]] ; then
-                exit 1
-            fi
+                eval "${SLOW_CMD?}"
+                STATUS_CODE=$?
+                break
+            fi     
+                   
             run
+            if [[ $STATUS_CODE -eq 0 ]] ; then
+              break
+            fi
+            
             if [[ $STATUS_CODE -ne 0 ]] || [[ $STATUS_CODE -ne $STATUS_TRANSIENT_FAILURE ]] ; then
                 break
             fi

--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -74,6 +74,7 @@ runs:
         try=0
         while [[ "${try?}" -le "${RETRIES?}" ]]; do
             if [[ "${try?}" -eq "${RETRIES?}" ]] ; then
+                printf "will try execute '${SLOW_CMD?}'"
                 eval "${SLOW_CMD?}"
                 STATUS_CODE=$?
                 break

--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -49,13 +49,18 @@ runs:
         STATUS_TRANSIENT_FAILURE=200
         # Maximum retries in case of network failures.
         RETRIES=5               
-        CMD="cachix watch-exec --jobs 16 --compression-level $CACHIX_COMPRESSION_LEVEL composable-community ${{ inputs.command }} --no-update-lock-file --show-trace -L 2> >(tee -a $LOG_FILE >&2)" 
+        INPUTS_COMMAND="${{ inputs.command }}"        
+        CACHIX="cachix watch-exec --jobs 16 --compression-level ${CACHIX_COMPRESSION_LEVEL?} composable-community"
+        HAPPY_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --show-trace -L 2> >(tee --append $LOG_FILE >&2)" 
+        
+        printf "will try execute '${HAPPY_CMD?}'"
+
         # Marker that a network error occurred.
         BAD="HTTP error 200 ('')"  
         LOG_FILE=/tmp/out.log
 
         function run() {
-            eval "${CMD?}"
+            eval "${HAPPY_CMD?}"
             STATUS_CODE=$?
             if [[ $STATUS_CODE -ne 0 ]] ; then
                 C=$(grep -c "HTTP error 200" $LOG_FILE)

--- a/code/parachain/frame/composable-traits/src/lib.rs
+++ b/code/parachain/frame/composable-traits/src/lib.rs
@@ -13,9 +13,9 @@
 // TODO: make `deny`
 #![warn(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![warn(bad_style, trivial_numeric_casts)]
 // TODO: make `deny`
 #![warn(
-	bad_style,
 	bare_trait_objects,
 	improper_ctypes,
 	non_shorthand_field_patterns,
@@ -30,7 +30,6 @@
 	unused_parens,
 	while_true,
 	trivial_casts,
-	trivial_numeric_casts,
 	unused_extern_crates
 )]
 #![allow(incomplete_features)]


### PR DESCRIPTION
for https://app.clickup.com/t/20465559/XCVM-288

- retry never worked (if I read code right - tried to bash - seems never worked - was afraid || in bash works like && )
- if cache failed, build without (longer, but robust)
- changes in rust code just to trigger some invalidation (and sure - make our linter stricter:)
- same but from upstream to check more gates https://github.com/ComposableFi/composable/pull/3067

# notes

```
if [[ $STATUS_CODE -ne 0 ]] || [[ $STATUS_CODE -ne $STATUS_TRANSIENT_FAILURE ]] ; then
                break
            fi
```

so if status code not 0 or not transient, then break while loop. 

1 != 1 || 1 != 42 = true