### PR TITLE
Remove the need for privilege label

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -113,6 +113,8 @@ jobs:
           token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
   check-lfs:
+    needs:
+      - check-privilege
     continue-on-error: false
     runs-on:
       - self-hosted

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,6 @@ on:
 
   # For PRs that need to run in the monorepo context.
   pull_request:
-    types: [ labeled ]
 
 permissions: 
   pull-requests: write
@@ -31,7 +30,7 @@ env:
 jobs:
   check-privilege:
     name: "Privilege Check"
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.repository_owner != 'ComposableFi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'privileged')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.repository_owner != 'ComposableFi') || (github.event_name == 'pull_request' && github.repository_owner == 'ComposableFi') }}
     concurrency:
       group: ${{ github.workflow }}-composablejs-${{ github.event.pull_request.title }}
       cancel-in-progress: true


### PR DESCRIPTION
Having to add `privileged` label to PRs is annoying and messes up the merge queue. We actually don't need it since we consider write access to the repo privileged access anyway.