### PR TITLE
merge queue: embarking main (49e6207) and #3079 together

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -10,7 +10,6 @@ on:
 
   # For PRs that need to run in the monorepo context.
   pull_request:
-    types: [ labeled ]
 
 permissions: 
   pull-requests: write
@@ -31,7 +30,7 @@ env:
 jobs:
   check-privilege:
     name: "Privilege Check"
-    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.repository_owner != 'ComposableFi') || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'privileged')) }}
+    if: ${{ github.event_name == 'push' || (github.event_name == 'pull_request_target' && github.repository_owner != 'ComposableFi') || (github.event_name == 'pull_request' && github.repository_owner == 'ComposableFi') }}
     concurrency:
       group: ${{ github.workflow }}-composablejs-${{ github.event.pull_request.title }}
       cancel-in-progress: true
@@ -114,6 +113,8 @@ jobs:
           token: "${{ secrets.CACHIX_AUTH_TOKEN }}"
 
   check-lfs:
+    needs:
+      - check-privilege
     continue-on-error: false
     runs-on:
       - self-hosted


### PR DESCRIPTION
**🙁 This pull request has failed checks. [#3079](/ComposableFi/composable/pull/3079) will be removed from the queue. 🙁**

Branch **main** (49e6207) and [#3079](/ComposableFi/composable/pull/3079) are embarked together for merge.

This pull request has been created by Mergify to speculatively check the mergeability of [#3079](/ComposableFi/composable/pull/3079).
You don't need to do anything. Mergify will close this pull request automatically when it is complete.


**Required conditions of queue** `default` **for merge:**

- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=Cargo clippy check`
  - [ ] `check-skipped=Cargo clippy check`
  - [ ] `check-success=Cargo clippy check`
- [ ] any of [🛡 GitHub branch protection]:
  - [ ] `check-neutral=Cargo deny check`
  - [ ] `check-skipped=Cargo deny check`
  - [ ] `check-success=Cargo deny check`
- `#approved-reviews-by>=2` [🛡 GitHub branch protection]
  - [X] #3079
- `#changes-requested-reviews-by=0` [🛡 GitHub branch protection]
  - [X] #3079
- `#review-threads-unresolved=0` [🛡 GitHub branch protection]
  - [X] #3079
- `-title~="#wip"`
  - [X] #3079
- `branch-protection-review-decision=APPROVED` [🛡 GitHub branch protection]
  - [X] #3079
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-skipped=Effect gate, automatically merged if passed`
  - [ ] `check-neutral=Effect gate, automatically merged if passed`
  - [ ] `check-success=Effect gate, automatically merged if passed`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Common dependencies`
  - [ ] `check-neutral=Common dependencies`
  - [ ] `check-skipped=Common dependencies`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Check nix`
  - [ ] `check-neutral=Check nix`
  - [ ] `check-skipped=Check nix`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Nixfmt check`
  - [ ] `check-neutral=Nixfmt check`
  - [ ] `check-skipped=Nixfmt check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Composable node`
  - [ ] `check-neutral=Package Composable node`
  - [ ] `check-skipped=Package Composable node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Composable bench node`
  - [ ] `check-neutral=Package Composable bench node`
  - [ ] `check-skipped=Package Composable bench node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Polkadot node`
  - [ ] `check-neutral=Package Polkadot node`
  - [ ] `check-skipped=Package Polkadot node`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Unit Tests`
  - [ ] `check-neutral=Unit Tests`
  - [ ] `check-skipped=Unit Tests`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Cargo fmt check`
  - [ ] `check-neutral=Cargo fmt check`
  - [ ] `check-skipped=Cargo fmt check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Spelling check`
  - [ ] `check-neutral=Spelling check`
  - [ ] `check-skipped=Spelling check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (composable)`
  - [ ] `check-neutral=Test running of pallet benchmarks (composable)`
  - [ ] `check-skipped=Test running of pallet benchmarks (composable)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (dali)`
  - [ ] `check-neutral=Test running of pallet benchmarks (dali)`
  - [ ] `check-skipped=Test running of pallet benchmarks (dali)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test running of pallet benchmarks (picasso)`
  - [ ] `check-neutral=Test running of pallet benchmarks (picasso)`
  - [ ] `check-skipped=Test running of pallet benchmarks (picasso)`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-skipped=Docker composable-bridge-devnet`
  - [ ] `check-neutral=Docker composable-bridge-devnet`
  - [ ] `check-success=Docker composable-bridge-devnet`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-skipped=composable-sandbox-container-publish`
  - [ ] `check-neutral=composable-sandbox-container-publish`
  - [ ] `check-success=composable-sandbox-container-publish`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Dockerfiles check`
  - [ ] `check-neutral=Dockerfiles check`
  - [ ] `check-skipped=Dockerfiles check`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Package Subsquid Processor`
  - [ ] `check-neutral=Package Subsquid Processor`
  - [ ] `check-skipped=Package Subsquid Processor`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Test Subquid`
  - [ ] `check-neutral=Test Subquid`
  - [ ] `check-skipped=Test Subquid`
- [X] any of [🛡 GitHub branch protection]:
  - [X] `check-success=Taplo check`
  - [ ] `check-neutral=Taplo check`
  - [ ] `check-skipped=Taplo check`

---

More informations about Mergify merge queue can be found in the [documentation](https://docs.mergify.com/actions/queue.html).

<details>
<summary>Mergify commands</summary>

<br />

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the queue rules

Additionally, on Mergify [dashboard](https://dashboard.mergify.com) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.com
</details>
<!---
DO NOT EDIT
-*- Mergify Payload -*-
{"merge-queue-pr": true}
-*- Mergify Payload End -*-
-->

```yaml
---
pull_requests:
  - number: 3079
...

```