### PR TITLE
Support SS58 addresses

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -3087,7 +3087,6 @@ dependencies = [
  "frame-system",
  "frame-system-benchmarking",
  "frame-system-rpc-runtime-api",
- "hex",
  "hex-literal",
  "ibc",
  "ibc-primitives",

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -282,7 +282,8 @@ pub mod pallet {
 
 		/// A way to convert from our native account to cosmwasm `Addr`.
 		type AccountToAddr: Convert<AccountIdOf<Self>, String>
-			+ Convert<String, Result<AccountIdOf<Self>, ()>>;
+			+ Convert<String, Result<AccountIdOf<Self>, ()>>
+			+ Convert<Vec<u8>, Result<AccountIdOf<Self>, ()>>;
 
 		/// Type of an account balance.
 		type Balance: Balance + Into<u128>;

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -197,29 +197,36 @@ impl pallet_timestamp::Config for Test {
 
 /// Native <-> Cosmwasm account mapping
 pub struct AccountToAddr;
+
 impl Convert<alloc::string::String, Result<AccountId, ()>> for AccountToAddr {
 	fn convert(a: alloc::string::String) -> Result<AccountId, ()> {
-		match a.strip_prefix("0x") {
-			Some(account_id) => Ok(<[u8; 32]>::try_from(hex::decode(account_id).map_err(|_| ())?)
-				.map_err(|_| ())?
-				.into()),
-			_ => Err(()),
-		}
+		let account =
+			ibc_primitives::runtime_interface::ss58_to_account_id_32(&a).map_err(|_| ())?;
+		Ok(account.into())
 	}
 }
+
 impl Convert<AccountId, alloc::string::String> for AccountToAddr {
 	fn convert(a: AccountId) -> alloc::string::String {
-		alloc::format!("0x{}", hex::encode(a))
+		let account = ibc_primitives::runtime_interface::account_id_to_ss58(a.into(), 49);
+		String::from_utf8_lossy(account.as_slice()).to_string()
+	}
+}
+impl Convert<Vec<u8>, Result<AccountId, ()>> for AccountToAddr {
+	fn convert(a: Vec<u8>) -> Result<AccountId, ()> {
+		Ok(<[u8; 32]>::try_from(a).map_err(|_| ())?.into())
 	}
 }
 
 /// Native <-> Cosmwasm asset mapping
 pub struct AssetToDenom;
+
 impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
 	fn convert(currency_id: alloc::string::String) -> Result<CurrencyId, ()> {
 		core::str::FromStr::from_str(&currency_id).map_err(|_| ())
 	}
 }
+
 impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
 	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
 		alloc::format!("{}", currency_id)

--- a/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
@@ -24,9 +24,9 @@ impl<T: Config> From<CosmwasmAccount<T>> for CanonicalCosmwasmAccount<T> {
 impl<T: Config + VMPallet> TryFrom<Vec<u8>> for CanonicalCosmwasmAccount<T> {
 	type Error = T::VmError;
 	fn try_from(source: Vec<u8>) -> Result<Self, Self::Error> {
-		Ok(CanonicalCosmwasmAccount(CosmwasmAccount::try_from(
-			String::from_utf8_lossy(&source).into_owned(),
-		)?))
+		Ok(CanonicalCosmwasmAccount(CosmwasmAccount::new(Pallet::<T>::canonical_addr_to_account(
+			source,
+		)?)))
 	}
 }
 

--- a/code/parachain/frame/cosmwasm/src/tests.rs
+++ b/code/parachain/frame/cosmwasm/src/tests.rs
@@ -221,6 +221,49 @@ fn ed25519_batch_verify_fails_if_input_lengths_are_incorrect() {
 	})
 }
 
+#[test]
+fn ss58_address_format_is_supported_correctly() {
+	new_test_ext().execute_with(|| {
+		let valid_ss58_addresses = [
+			(
+				"5yNZjX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL",
+				"d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+			),
+			(
+				"5txRkPpGeTRJyZ96t5aSxLKaQDa32ZY21rq8MDHaN7dLGCBe",
+				"10dbdfc9a706a4cf96b9e9dfb25384a2cf25faeaddabd4c98079f8360bc4ad46",
+			),
+			(
+				"5uawZPfyfP9hdowPJbeiR2GMSZatLq3b9wpWc6yWjSLeakgh",
+				"2cb50f2480175397eb320e637fc56be1939e18fb2b326eab5fdeaad9d43ffc74",
+			),
+			(
+				"5umjqLRoE5wrXUGyedwbATZjj1SukRC9eh8qGJPpVx47bUam",
+				"34f149d3a32ff2afe4daee3f4c917b90a73b88ee84a2666b477cdd67d6c5d17b",
+			),
+		];
+		for (ss58_addr, hex_addr) in valid_ss58_addresses {
+			// ss58 string to AccountId works
+			let lhs = Cosmwasm::cosmwasm_addr_to_account(ss58_addr.into()).unwrap();
+			// address binary to canonical AccountId works
+			let binary_addr = hex::decode(hex_addr).unwrap();
+			let rhs = Cosmwasm::canonical_addr_to_account(binary_addr.into()).unwrap();
+			assert_eq!(lhs, rhs);
+		}
+
+		let not_valid_ss58_addresses = [
+			// length is correct but with some garbage string
+			"5yasdX24n2eg7W6EVamaTXNQbWCwchhThEaSWB7V3GRjtHeL",
+			// total garbage
+			"someaddr",
+		];
+
+		for garbage_addr in not_valid_ss58_addresses {
+			assert!(Cosmwasm::cosmwasm_addr_to_account(garbage_addr.into()).is_err());
+		}
+	})
+}
+
 mod pallet_contracts {
 	use core::str::FromStr;
 

--- a/code/parachain/frame/cosmwasm/src/utils.rs
+++ b/code/parachain/frame/cosmwasm/src/utils.rs
@@ -53,6 +53,12 @@ impl<T: Config> Pallet<T> {
 		ContractToInfo::<T>::get(contract).ok_or(Error::<T>::ContractNotFound)
 	}
 
+	pub(crate) fn canonical_addr_to_account(
+		canonical: Vec<u8>,
+	) -> Result<AccountIdOf<T>, <T as VMPallet>::VmError> {
+		T::AccountToAddr::convert(canonical).map_err(|()| CosmwasmVMError::AccountConversionFailure)
+	}
+
 	/// Try to convert from a CosmWasm address to a native AccountId.
 	pub(crate) fn cosmwasm_addr_to_account(
 		cosmwasm_addr: String,

--- a/code/parachain/runtime/dali/Cargo.toml
+++ b/code/parachain/runtime/dali/Cargo.toml
@@ -94,7 +94,6 @@ transaction-payment = { package = "pallet-transaction-payment", path = "../../fr
 
 # cosmwasm support
 cosmwasm = { package = "pallet-cosmwasm", path = "../../frame/cosmwasm", default-features = false }
-hex = { version = "0.4.0", default-features = false }
 
 # Used for the node template's RPCs
 system-rpc-runtime-api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.33" }
@@ -242,7 +241,6 @@ std = [
   "democracy/std",
   "dex-router/std",
   "dutch-auction/std",
-  "hex/std",
   "executive/std",
   "frame-support/std",
   "frame-system/std",

--- a/code/parachain/runtime/dali/src/lib.rs
+++ b/code/parachain/runtime/dali/src/lib.rs
@@ -34,7 +34,7 @@ mod versions;
 mod weights;
 pub mod xcmp;
 
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use core::str::FromStr;
 pub use versions::*;
 
@@ -1094,29 +1094,37 @@ parameter_types! {
 /// Native <-> Cosmwasm account mapping
 /// TODO(hussein-aitlahcen): Probably nicer to have SS58 representation here.
 pub struct AccountToAddr;
+
 impl Convert<alloc::string::String, Result<AccountId, ()>> for AccountToAddr {
 	fn convert(a: alloc::string::String) -> Result<AccountId, ()> {
-		match a.strip_prefix("0x") {
-			Some(account_id) => Ok(<[u8; 32]>::try_from(hex::decode(account_id).map_err(|_| ())?)
-				.map_err(|_| ())?
-				.into()),
-			_ => Err(()),
-		}
+		let account =
+			ibc_primitives::runtime_interface::ss58_to_account_id_32(&a).map_err(|_| ())?;
+		Ok(account.into())
 	}
 }
+
 impl Convert<AccountId, alloc::string::String> for AccountToAddr {
 	fn convert(a: AccountId) -> alloc::string::String {
-		alloc::format!("0x{}", hex::encode(a))
+		let account = ibc_primitives::runtime_interface::account_id_to_ss58(a.into(), 49);
+		String::from_utf8_lossy(account.as_slice()).to_string()
+	}
+}
+
+impl Convert<Vec<u8>, Result<AccountId, ()>> for AccountToAddr {
+	fn convert(a: Vec<u8>) -> Result<AccountId, ()> {
+		Ok(<[u8; 32]>::try_from(a).map_err(|_| ())?.into())
 	}
 }
 
 /// Native <-> Cosmwasm asset mapping
 pub struct AssetToDenom;
+
 impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
 	fn convert(currency_id: alloc::string::String) -> Result<CurrencyId, ()> {
 		core::str::FromStr::from_str(&currency_id).map_err(|_| ())
 	}
 }
+
 impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
 	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
 		alloc::format!("{}", currency_id)


### PR DESCRIPTION
Contracts now are only able to use `ss58` format for their addresses.

See the previous PR for more: https://github.com/ComposableFi/composable/pull/2849