### PR TITLE
ci: change subsquid approval to 1

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -36,3 +36,18 @@ pull_request_rules:
       queue:
         priority: high
         name: default
+  # Reduce reviewers for subsquid since QA tests it vigorously anyway
+  - name: Automatic merge on approval (Subsquid)
+    conditions:
+      - and:
+          - "#approved-reviews-by>=1"
+          - approved-reviews-by=@ComposableFi/blockchain-integrations
+          - "#review-threads-unresolved=0"
+      - base=main
+      - files~=^subsquid\/
+      - branch-protection-review-decision=APPROVED
+
+    actions:
+      queue:
+        priority: high
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -31,11 +31,11 @@ pull_request_rules:
       - base=main
       - files~=^code\/parachain\/runtime\/picasso\/
       - branch-protection-review-decision=APPROVED
-
     actions:
       queue:
         priority: high
         name: default
+
   # Reduce reviewers for subsquid since QA tests it vigorously anyway
   - name: Automatic merge on approval (Subsquid)
     conditions:
@@ -46,8 +46,6 @@ pull_request_rules:
       - base=main
       - files~=^subsquid\/
       - branch-protection-review-decision=APPROVED
-
     actions:
       queue:
-        priority: high
         name: default


### PR DESCRIPTION
PR to reduce required approvals to 1 from blockchain integrations

- Subsquid PRs take longer due to the requirement to have 2+ approvals and not enough incentives for other developers to review.
- Also subsquid gets tested vigorously by QA so one approval should be enough to get the tests rolling out