### PR TITLE
devnet updates dor xcmv3 compatiblity #PICA-232

### DIFF
--- a/.github/templates/watch-exec/action.yml
+++ b/.github/templates/watch-exec/action.yml
@@ -20,8 +20,8 @@ runs:
         INPUTS_COMMAND="${{ inputs.command }}"        
         CACHIX="cachix watch-exec --compression-level ${CACHIX_COMPRESSION_LEVEL:-16} --compression-method ${CACHIX_COMPRESSION_METHOD:-"zstd"} --jobs ${CACHIX_JOBS:-8} composable-community"
         NIX_DEBUG_COMMAND="" && [[ $ACTIONS_RUNNER_DEBUG = "true" ]] && NIX_DEBUG_COMMAND='--print-build-logs --debug --show-trace --verbose'
-        HAPPY_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file ${NIX_DEBUG_COMMAND} -L 2> >(tee --append $LOG_FILE >&2)" 
-        SLOW_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --show-trace --fallback -L 2 ${NIX_DEBUG_COMMAND} > >(tee --append $LOG_FILE >&2)" 
+        HAPPY_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --accept-flake-config ${NIX_DEBUG_COMMAND} -L 2> >(tee --append $LOG_FILE >&2)" 
+        SLOW_CMD="${CACHIX?} ${INPUTS_COMMAND?} --no-update-lock-file --accept-flake-config --show-trace --fallback -L 2 ${NIX_DEBUG_COMMAND} > >(tee --append $LOG_FILE >&2)" 
         
         printf "will try execute '${HAPPY_CMD?}'"
 

--- a/.github/workflows/nix-flake-check.sh
+++ b/.github/workflows/nix-flake-check.sh
@@ -1,6 +1,6 @@
 NIX_DEBUG_COMMAND="" && [[ $ACTIONS_RUNNER_DEBUG = "true" ]] && NIX_DEBUG_COMMAND='--print-build-logs --debug --show-trace --verbose'
 set -o pipefail -o errexit
-NIXPKGS_ALLOW_BROKEN=1 nix flake check --keep-going --no-build --allow-import-from-derivation  --no-update-lock-file --fallback -L ${NIX_DEBUG_COMMAND} --impure --option sandbox relaxed --impure 2>&1 | tee "nix.check.log"  || true
+NIXPKGS_ALLOW_BROKEN=1 nix flake check --keep-going --no-build --allow-import-from-derivation  --no-update-lock-file --accept-flake-config --fallback -L ${NIX_DEBUG_COMMAND} --impure --option sandbox relaxed --impure 2>&1 | tee "nix.check.log"  || true
 set +o pipefail +o errexit
 echo "exited with(https://github.com/NixOS/nix/issues/7464) ${$?}" 
 cat "nix.check.log" | grep --invert-match  "error: path [']/nix/store/[a-zA-Z0-9]\+-[a-zA-Z0-9\.-]\+['] is not valid" \

--- a/.github/workflows/nix-flake-check.sh
+++ b/.github/workflows/nix-flake-check.sh
@@ -1,6 +1,6 @@
 NIX_DEBUG_COMMAND="" && [[ $ACTIONS_RUNNER_DEBUG = "true" ]] && NIX_DEBUG_COMMAND='--print-build-logs --debug --show-trace --verbose'
 set -o pipefail -o errexit
-NIXPKGS_ALLOW_BROKEN=1 nix flake check --keep-going --no-build --allow-import-from-derivation  --no-update-lock-file --accept-flake-config --fallback -L ${NIX_DEBUG_COMMAND} --impure --option sandbox relaxed --impure 2>&1 | tee "nix.check.log"  || true
+NIXPKGS_ALLOW_BROKEN=1 nix flake check --keep-going --no-build --allow-import-from-derivation --no-update-lock-file --accept-flake-config --fallback -L ${NIX_DEBUG_COMMAND} --impure --option sandbox relaxed --impure 2>&1 | tee "nix.check.log"  || true
 set +o pipefail +o errexit
 echo "exited with(https://github.com/NixOS/nix/issues/7464) ${$?}" 
 cat "nix.check.log" | grep --invert-match  "error: path [']/nix/store/[a-zA-Z0-9]\+-[a-zA-Z0-9\.-]\+['] is not valid" \

--- a/code/composable-nodes.nix
+++ b/code/composable-nodes.nix
@@ -53,7 +53,6 @@
           meta = { mainProgram = "composable"; };
         }));
     in {
-      # Add the npm-buildpackage overlay to the perSystem's pkgs
       packages = rec {
 
         composable-node = makeComposableNode (node: node);

--- a/flake.lock
+++ b/flake.lock
@@ -891,17 +891,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1679438962,
-        "narHash": "sha256-twICxcu8UnjlBIiekelhAq76ctDYrVk3n1h66tMuC60=",
+        "lastModified": 1679481392,
+        "narHash": "sha256-hQStHcNFjzhL765LXmysv/UOZbDwl0x9hvruUh7r9c4=",
         "owner": "dzmitry-lahoda-forks",
         "repo": "zombienet",
-        "rev": "5122c59a33c9ec3eab60e3b6d5020732836f8c95",
+        "rev": "4d2eff2fd5a165aceb1fd11b218482710bd35d77",
         "type": "github"
       },
       "original": {
         "owner": "dzmitry-lahoda-forks",
         "repo": "zombienet",
-        "rev": "5122c59a33c9ec3eab60e3b6d5020732836f8c95",
+        "rev": "4d2eff2fd5a165aceb1fd11b218482710bd35d77",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -274,6 +274,24 @@
         "type": "github"
       }
     },
+    "flake-parts_4": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
+        "lastModified": 1677714448,
+        "narHash": "sha256-Hq8qLs8xFu28aDjytfxjdC96bZ6pds21Yy09mSC156I=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "dc531e3a9ce757041e1afaff8ee932725ca60002",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -591,6 +609,24 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1677407201,
+        "narHash": "sha256-3blwdI9o1BAprkvlByHvtEm5HAIRn/XPjtcfiunpY7s=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7f5639fa3b68054ca0b062866dc62b22c3f11505",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -775,7 +811,8 @@
         "nixpkgs": "nixpkgs_5",
         "nixpkgs-working-nixops": "nixpkgs-working-nixops",
         "npm-buildpackage": "npm-buildpackage",
-        "rust-overlay": "rust-overlay_3"
+        "rust-overlay": "rust-overlay_3",
+        "zombienet": "zombienet"
       }
     },
     "rust-overlay": {
@@ -843,6 +880,28 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "zombienet": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1679438962,
+        "narHash": "sha256-twICxcu8UnjlBIiekelhAq76ctDYrVk3n1h66tMuC60=",
+        "owner": "dzmitry-lahoda-forks",
+        "repo": "zombienet",
+        "rev": "5122c59a33c9ec3eab60e3b6d5020732836f8c95",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dzmitry-lahoda-forks",
+        "repo": "zombienet",
+        "rev": "5122c59a33c9ec3eab60e3b6d5020732836f8c95",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
     devenv.url = "github:cachix/devenv";
     zombienet = {
       url =
-        "github:dzmitry-lahoda-forks/zombienet/5122c59a33c9ec3eab60e3b6d5020732836f8c95";
+        "github:dzmitry-lahoda-forks/zombienet/4d2eff2fd5a165aceb1fd11b218482710bd35d77";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -45,13 +45,13 @@
         ./inputs/bifrost-finance/bifrost/flake-module.nix
         ./inputs/centauri/flake-module.nix
         ./inputs/chevdor/subwasm.nix
-        ./flake/subxt.nix
-        ./inputs/CosmosContracts/juno.nix
         ./inputs/cosmos/cosmwasm.nix
         ./inputs/cosmos/gex.nix
+        ./inputs/CosmosContracts/juno.nix
         ./inputs/CosmWasm/wasmvm.nix
         ./inputs/paritytech/polkadot.nix
         ./inputs/paritytech/statemine.nix
+        ./inputs/paritytech/substrate.nix
         ./inputs/paritytech/zombienet/flake-module.nix
         ./inputs/Wasmswap/wasmswap-contracts.nix
 
@@ -86,6 +86,7 @@
         ./flake/nixops-config.nix
         ./flake/overlays.nix
         ./flake/release.nix
+        ./flake/subxt.nix
         ./flake/zombienet.nix
       ];
       systems =

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,11 @@
     };
     nix-std.url = "github:chessai/nix-std";
     devenv.url = "github:cachix/devenv";
+    zombienet = {
+      url =
+        "github:dzmitry-lahoda-forks/zombienet/5122c59a33c9ec3eab60e3b6d5020732836f8c95";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   nixConfig = {

--- a/flake/all.nix
+++ b/flake/all.nix
@@ -41,7 +41,6 @@
         subwasm
         taplo-check
         unit-tests
-        zombienet
       ]);
 
       docker-images-to-push = pkgs.linkFarmFromDrvs "docker-images-to-push"

--- a/inputs/paritytech/polkadot.nix
+++ b/inputs/paritytech/polkadot.nix
@@ -1,10 +1,10 @@
 { self, ... }: {
-  perSystem =
-    { config, self', inputs', pkgs, lib, system, crane, systemCommonRust, ... }:
+  perSystem = { config, self', inputs', pkgs, lib, system, crane
+    , systemCommonRust, subTools, ... }:
     let
       buildPolkadotNode =
         { name, version, repo, owner, rev, hash, cargoSha256 }:
-        pkgs.rustPlatform.buildRustPackage rec {
+        pkgs.rustPlatform.buildRustPackage (rec {
           inherit name version cargoSha256;
           src = pkgs.fetchgit {
             url = "https://github.com/${owner}/${repo}.git";
@@ -16,30 +16,19 @@
           meta = { mainProgram = "polkadot"; };
 
           __noChroot = true;
-          doCheck = false;
-          buildInputs = with pkgs; [ openssl zstd ];
-          nativeBuildInputs = with pkgs;
-            [ clang pkg-config ] ++ [ self'.packages.rust-nightly ]
-            ++ systemCommonRust.darwin-deps;
-          LD_LIBRARY_PATH = lib.strings.makeLibraryPath [
-            pkgs.stdenv.cc.cc.lib
-            pkgs.llvmPackages.libclang.lib
-          ];
-          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-          PROTOC = "${pkgs.protobuf}/bin/protoc";
-          ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
-        };
+
+        } // subTools.subenv);
     in {
       packages = {
-        polkadot-node = let version = "v0.9.36";
+        polkadot-node = let version = "v0.9.38";
         in buildPolkadotNode rec {
           name = "polkadot-node";
           inherit version;
           repo = "polkadot";
           owner = "paritytech";
           rev = "refs/tags/${version}";
-          hash = "sha256-x2IEIHxH8Hg+jFIpnPrTsqISEAZHFuXhJD+H1S+G3nk=";
-          cargoSha256 = "sha256-6/94Uj6MG8VRnV4/yvEwUXdZBCEDSFUgqPTDcK7kiss=";
+          hash = "sha256-byUC+6SQ+TgvQCXdQWIGf/BAyxitnT1q69RdyZL8AAc=";
+          cargoSha256 = "sha256-BYJzMagEhXEa6rjy862ESBZW2FQXopRTyRESefa4rqo=";
         };
       };
     };

--- a/inputs/paritytech/statemine.nix
+++ b/inputs/paritytech/statemine.nix
@@ -1,8 +1,8 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, lib, system, crane
-    , systemCommonRust, ... }: {
+    , systemCommonRust, subTools, ... }: {
       packages = {
-        statemine-node = let version = "release-parachains-v9360";
+        statemine-node = let version = "release-parachains-v9380";
         in pkgs.stdenv.mkDerivation (rec {
           name = "statemine-node";
           inherit version;
@@ -10,13 +10,10 @@
           src = pkgs.fetchgit {
             url = "https://github.com/paritytech/cumulus.git";
             rev = "refs/heads/${version}";
-            sha256 = "sha256-Ue3NkPiZxAKDvEIA5Q06lOS64eu6Mxp9iTDzPr1KYm4=";
+            sha256 = "sha256-Arc7eK9RekqbSDyHZRLxfyqLBCNUgO12YwwI3XxcXR4=";
             fetchSubmodules = false;
           };
-
-          doCheck = false;
           __noChroot = true;
-          buildInputs = with pkgs; [ openssl zstd ];
           configurePhase = ''
             mkdir home
             export HOME=$PWD/home
@@ -28,17 +25,7 @@
           installPhase = ''
             mkdir --parents $out/bin && mv ./target/release/polkadot-parachain $out/bin
           '';
-
-          nativeBuildInputs = with pkgs;
-            [ self'.packages.rust-nightly clang pkg-config ]
-            ++ systemCommonRust.darwin-deps;
-          LD_LIBRARY_PATH = lib.strings.makeLibraryPath
-            (with pkgs; [ stdenv.cc.cc.lib llvmPackages.libclang.lib ]);
-          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-          PROTOC = "${pkgs.protobuf}/bin/protoc";
-          ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
-          RUST_BACKTRACE = "full";
-        });
+        } // subTools.subenv);
       };
     };
 }

--- a/inputs/paritytech/substrate.nix
+++ b/inputs/paritytech/substrate.nix
@@ -1,0 +1,24 @@
+{ self, ... }: {
+  perSystem = { config, self', inputs', pkgs, system, lib, ... }:
+    let
+      subenv = {
+        doCheck = false;
+        buildInputs = with pkgs; [ openssl zstd ];
+        nativeBuildInputs = with pkgs;
+          [ clang pkg-config self'.packages.rust-nightly ]
+          ++ lib.optional stdenv.isDarwin
+          (with pkgs.darwin.apple_sdk.frameworks; [
+            Security
+            SystemConfiguration
+          ]);
+        LD_LIBRARY_PATH = lib.strings.makeLibraryPath [
+          pkgs.stdenv.cc.cc.lib
+          pkgs.llvmPackages.libclang.lib
+        ];
+        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+        RUST_BACKTRACE = "full";
+      };
+    in { _module.args.subTools = rec { inherit subenv; }; };
+}

--- a/inputs/paritytech/zombienet/default.nix
+++ b/inputs/paritytech/zombienet/default.nix
@@ -8,7 +8,8 @@ let
     map = builtins.map;
     filter = builtins.filter;
   };
-in with prelude; rec {
+in
+with prelude; rec {
   mkChannel = sender: recipient: {
     max_capacity = 8;
     max_message_size = 4096;
@@ -18,8 +19,13 @@ in with prelude; rec {
 
   mkBidirectionalChannel = a: b: (mkChannel a b) ++ (mkChannel b a);
 
-  mkCollator = { name ? "alice", command, rpc_port ? null, ws_port ? null
-    , rust_log_add ? "" }:
+  mkCollator =
+    { name ? "alice"
+    , command
+    , rpc_port ? null
+    , ws_port ? null
+    , rust_log_add ? ""
+    }:
     {
       command = command;
       args = [
@@ -29,7 +35,7 @@ in with prelude; rec {
       env = [{
         name = "RUST_LOG";
         value =
-          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace,"
+          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace"
           + (if rust_log_add != null then rust_log_add else "");
       }];
       name = name;
@@ -37,15 +43,24 @@ in with prelude; rec {
     } // optionalAttrs (rpc_port != null) { inherit rpc_port; }
     // optionalAttrs (ws_port != null) { inherit ws_port; };
 
-  mkParachain = { command, rpc_port ? 32200, ws_port ? 9988, chain ? "dali-dev"
-    , names ? default-node-names, collators ? 2, id ? 2087, rust_log_add ? null
+  mkParachain =
+    { command
+    , rpc_port ? 32200
+    , ws_port ? 9988
+    , chain ? "dali-dev"
+    , names ? default-node-names
+    , collators ? 2
+    , id ? 2087
+    , rust_log_add ? null
     }:
     let
       generated = lib.lists.zipListsWith
         (_increment: name: mkCollator { inherit command name rust_log_add; })
-        (lib.lists.range 0 (collators - 2)) (builtins.tail names);
+        (lib.lists.range 0 (collators - 2))
+        (builtins.tail names);
 
-    in {
+    in
+    {
       add_to_genesis = true;
       chain = chain;
       cumulus_based = true;
@@ -68,32 +83,44 @@ in with prelude; rec {
         recipient = ids;
       };
       unique = filter (x: x.sender != x.recipient) cross;
-    in map (pair: mkChannel pair.sender pair.recipient) unique;
+    in
+    map (pair: mkChannel pair.sender pair.recipient) unique;
 
   mkRelaychainNode = { rpc_port ? null, ws_port ? null, name }:
     {
       name = name;
       validator = true;
-      env = [{
+            env = [{
         name = "RUST_LOG";
         value =
-          "debug,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,tokio-runtime-worker=warn";
+          "debug,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace";
       }];
-    } // optionalAttrs (rpc_port != null) { inherit rpc_port; }
-    // optionalAttrs (ws_port != null) { inherit ws_port; };
+    } // optionalAttrs
+      (rpc_port != null)
+      { inherit rpc_port; }
+    // optionalAttrs
+      (ws_port != null)
+      { inherit ws_port; };
 
-  mkRelaychainNodes = { chain, rpc_port ? 30444, ws_port ? 9944, count ? 2
-    , names ? default-node-names }:
+  mkRelaychainNodes =
+    { chain
+    , rpc_port ? 30444
+    , ws_port ? 9944
+    , count ? 2
+    , names ? default-node-names
+    }:
     let
       prefixName = name: "${chain}-${name}";
       generated = lib.lists.zipListsWith
         (_increment: name: mkRelaychainNode { name = prefixName name; })
-        (lib.lists.range 0 (count - 1)) (builtins.tail names);
+        (lib.lists.range 0 (count - 1))
+        (builtins.tail names);
       bootstrap = mkRelaychainNode {
         inherit ws_port rpc_port;
         name = prefixName "alice";
       };
-    in [ bootstrap ] ++ generated;
+    in
+    [ bootstrap ] ++ generated;
 
   mkRelaychain =
     { chain, default_command, rpc_port ? 30444, ws_port ? 9944, count ? 2 }: {
@@ -150,7 +177,8 @@ in with prelude; rec {
         builtins.filter (e: e != null) (builtins.map ops-node collators);
       driedParachains = parachains:
         builtins.map (e: driedCollators e.collators) parachains;
-    in {
+    in
+    {
       parachain-nodes = driedParachains zombienet.parachains;
       relaychain-nodes = builtins.filter (e: e != null)
         (builtins.map ops-node zombienet.relaychain.nodes);

--- a/inputs/paritytech/zombienet/default.nix
+++ b/inputs/paritytech/zombienet/default.nix
@@ -8,8 +8,7 @@ let
     map = builtins.map;
     filter = builtins.filter;
   };
-in
-with prelude; rec {
+in with prelude; rec {
   mkChannel = sender: recipient: {
     max_capacity = 8;
     max_message_size = 4096;
@@ -19,13 +18,8 @@ with prelude; rec {
 
   mkBidirectionalChannel = a: b: (mkChannel a b) ++ (mkChannel b a);
 
-  mkCollator =
-    { name ? "alice"
-    , command
-    , rpc_port ? null
-    , ws_port ? null
-    , rust_log_add ? ""
-    }:
+  mkCollator = { name ? "alice", command, rpc_port ? null, ws_port ? null
+    , rust_log_add ? "" }:
     {
       command = command;
       args = [
@@ -43,24 +37,15 @@ with prelude; rec {
     } // optionalAttrs (rpc_port != null) { inherit rpc_port; }
     // optionalAttrs (ws_port != null) { inherit ws_port; };
 
-  mkParachain =
-    { command
-    , rpc_port ? 32200
-    , ws_port ? 9988
-    , chain ? "dali-dev"
-    , names ? default-node-names
-    , collators ? 2
-    , id ? 2087
-    , rust_log_add ? null
+  mkParachain = { command, rpc_port ? 32200, ws_port ? 9988, chain ? "dali-dev"
+    , names ? default-node-names, collators ? 2, id ? 2087, rust_log_add ? null
     }:
     let
       generated = lib.lists.zipListsWith
         (_increment: name: mkCollator { inherit command name rust_log_add; })
-        (lib.lists.range 0 (collators - 2))
-        (builtins.tail names);
+        (lib.lists.range 0 (collators - 2)) (builtins.tail names);
 
-    in
-    {
+    in {
       add_to_genesis = true;
       chain = chain;
       cumulus_based = true;
@@ -83,44 +68,33 @@ with prelude; rec {
         recipient = ids;
       };
       unique = filter (x: x.sender != x.recipient) cross;
-    in
-    map (pair: mkChannel pair.sender pair.recipient) unique;
+    in map (pair: mkChannel pair.sender pair.recipient) unique;
 
   mkRelaychainNode = { rpc_port ? null, ws_port ? null, name }:
     {
       name = name;
       validator = true;
-            env = [{
+      env = [{
         name = "RUST_LOG";
         value =
-          "debug,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace";
+          "into,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,wasmtime_cranelift=warn,wasm-heap=warn,"
+          + "netlink_proto=warn,libp2p_ping=warn,multistream_select=warn,trie-cache=warn,wasm_overrides=warn,libp2p_core=warn,libp2p_swarm=warn,sub-libp2p=warn,sync=warn";
       }];
-    } // optionalAttrs
-      (rpc_port != null)
-      { inherit rpc_port; }
-    // optionalAttrs
-      (ws_port != null)
-      { inherit ws_port; };
+    } // optionalAttrs (rpc_port != null) { inherit rpc_port; }
+    // optionalAttrs (ws_port != null) { inherit ws_port; };
 
-  mkRelaychainNodes =
-    { chain
-    , rpc_port ? 30444
-    , ws_port ? 9944
-    , count ? 2
-    , names ? default-node-names
-    }:
+  mkRelaychainNodes = { chain, rpc_port ? 30444, ws_port ? 9944, count ? 2
+    , names ? default-node-names }:
     let
       prefixName = name: "${chain}-${name}";
       generated = lib.lists.zipListsWith
         (_increment: name: mkRelaychainNode { name = prefixName name; })
-        (lib.lists.range 0 (count - 1))
-        (builtins.tail names);
+        (lib.lists.range 0 (count - 1)) (builtins.tail names);
       bootstrap = mkRelaychainNode {
         inherit ws_port rpc_port;
         name = prefixName "alice";
       };
-    in
-    [ bootstrap ] ++ generated;
+    in [ bootstrap ] ++ generated;
 
   mkRelaychain =
     { chain, default_command, rpc_port ? 30444, ws_port ? 9944, count ? 2 }: {
@@ -177,8 +151,7 @@ with prelude; rec {
         builtins.filter (e: e != null) (builtins.map ops-node collators);
       driedParachains = parachains:
         builtins.map (e: driedCollators e.collators) parachains;
-    in
-    {
+    in {
       parachain-nodes = driedParachains zombienet.parachains;
       relaychain-nodes = builtins.filter (e: e != null)
         (builtins.map ops-node zombienet.relaychain.nodes);

--- a/inputs/paritytech/zombienet/default.nix
+++ b/inputs/paritytech/zombienet/default.nix
@@ -29,7 +29,7 @@ in with prelude; rec {
       env = [{
         name = "RUST_LOG";
         value =
-          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace"
+          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace,"
           + (if rust_log_add != null then rust_log_add else "");
       }];
       name = name;
@@ -74,6 +74,11 @@ in with prelude; rec {
     {
       name = name;
       validator = true;
+      env = [{
+        name = "RUST_LOG";
+        value =
+          "debug,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,tokio-runtime-worker=warn";
+      }];
     } // optionalAttrs (rpc_port != null) { inherit rpc_port; }
     // optionalAttrs (ws_port != null) { inherit ws_port; };
 

--- a/inputs/paritytech/zombienet/flake-module.nix
+++ b/inputs/paritytech/zombienet/flake-module.nix
@@ -1,37 +1,6 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, system, devnetTools, ... }:
     let
-      # paritytech-zombienet = pkgs.stdenv.mkDerivation {
-      #   name = "zombienet";
-      #   inherit version;
-      #   src = "${paritytech-zombienet-src}/javascript";
-      #   buildInputs = with pkgs; [ nodejs ];
-      #   nativeBuildInputs = with pkgs;
-      #     [
-      #       yarn
-      #       nodejs
-      #       python3
-      #       nodePackages.node-gyp-build
-      #       nodePackages.node-gyp
-      #       nodePackages.typescript
-
-      #       vips
-      #       pkg-config
-      #     ] ++ devnetTools.withBaseContainerTools;
-      #   buildPhase = ''
-      #     mkdir home
-      #     export HOME=$PWD/home
-      #     npm install
-      #     npm run build
-      #   '';
-      #   installPhase = ''
-      #     mkdir --parents $out
-      #     cp . $out --recursive
-      #   '';
-      #   # https://app.clickup.com/t/3w8y83f
-      #   __noChroot = true;
-      # };
-
       prelude = pkgs.callPackage ./default.nix { };
       runtimeDeps = with pkgs;
         [ git git-lfs ] ++ devnetTools.withBaseContainerTools

--- a/inputs/paritytech/zombienet/flake-module.nix
+++ b/inputs/paritytech/zombienet/flake-module.nix
@@ -1,43 +1,36 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, system, devnetTools, ... }:
     let
-      version = "v1.3.34";
-      paritytech-zombienet-src = pkgs.fetchgit {
-        url = "https://github.com/paritytech/zombienet.git";
-        rev = "a12f56f5d1d4443e6f1a6c5be4088c982d876ebc";
-        sha256 = "sha256-i7P2dw10x4zGq8RnKBR2Tc+gWR+pV9SRbNY8Z1GEKmE=";
-        fetchSubmodules = true;
-      };
-      paritytech-zombienet = pkgs.stdenv.mkDerivation {
-        name = "zombienet";
-        inherit version;
-        src = "${paritytech-zombienet-src}/javascript";
-        buildInputs = with pkgs; [ nodejs ];
-        nativeBuildInputs = with pkgs;
-          [
-            yarn
-            nodejs
-            python3
-            nodePackages.node-gyp-build
-            nodePackages.node-gyp
-            nodePackages.typescript
+      # paritytech-zombienet = pkgs.stdenv.mkDerivation {
+      #   name = "zombienet";
+      #   inherit version;
+      #   src = "${paritytech-zombienet-src}/javascript";
+      #   buildInputs = with pkgs; [ nodejs ];
+      #   nativeBuildInputs = with pkgs;
+      #     [
+      #       yarn
+      #       nodejs
+      #       python3
+      #       nodePackages.node-gyp-build
+      #       nodePackages.node-gyp
+      #       nodePackages.typescript
 
-            vips
-            pkg-config
-          ] ++ devnetTools.withBaseContainerTools;
-        buildPhase = ''
-          mkdir home
-          export HOME=$PWD/home
-          npm install
-          npm run build
-        '';
-        installPhase = ''
-          mkdir --parents $out
-          cp . $out --recursive
-        '';
-        # https://app.clickup.com/t/3w8y83f
-        __noChroot = true;
-      };
+      #       vips
+      #       pkg-config
+      #     ] ++ devnetTools.withBaseContainerTools;
+      #   buildPhase = ''
+      #     mkdir home
+      #     export HOME=$PWD/home
+      #     npm install
+      #     npm run build
+      #   '';
+      #   installPhase = ''
+      #     mkdir --parents $out
+      #     cp . $out --recursive
+      #   '';
+      #   # https://app.clickup.com/t/3w8y83f
+      #   __noChroot = true;
+      # };
 
       prelude = pkgs.callPackage ./default.nix { };
       runtimeDeps = with pkgs;
@@ -47,7 +40,8 @@
       writeZombienetShellApplication = name: config:
         pkgs.writeShellApplication rec {
           inherit name;
-          runtimeInputs = [ pkgs.nodejs paritytech-zombienet ] ++ runtimeDeps;
+          runtimeInputs = with pkgs;
+            [ nodejs zombienet.default ] ++ runtimeDeps;
           text = ''
             ACTIONS_RUNNER_DEBUG=''${ACTIONS_RUNNER_DEBUG:-false} 
             LEVEL=''${1:-error}
@@ -61,8 +55,7 @@
               mkdir --parents /tmp && chown 777 /tmp
             fi               
             printf '${builtins.toJSON config}' > /tmp/${name}.json
-            cd ${paritytech-zombienet}            
-            npm run zombie spawn /tmp/${name}.json
+            zombienet spawn /tmp/${name}.json            
           '';
         };
     in with prelude; {
@@ -70,25 +63,6 @@
         inherit zombienet-rococo-local-composable-config
           writeZombienetShellApplication zombienet-to-ops;
         builder = prelude;
-      };
-      packages = rec {
-        inherit paritytech-zombienet;
-
-        zombienet = pkgs.writeShellApplication {
-          name = "zombienet";
-          runtimeInputs = [ pkgs.nodejs paritytech-zombienet ] ++ runtimeDeps;
-          text = ''
-            cd ${paritytech-zombienet}
-            npm run zombie
-          '';
-        };
-      };
-
-      apps = rec {
-        zombienet = {
-          type = "app";
-          program = self'.packages.zombienet;
-        };
       };
     };
 }

--- a/tools/pkgs.nix
+++ b/tools/pkgs.nix
@@ -6,6 +6,7 @@
         self.overlays.default
         npm-buildpackage.overlays.default
         rust-overlay.overlays.default
+        zombienet.overlays.default
       ];
     };
     # remove me when the `nixops_unstable` works again on the latest unstable


### PR DESCRIPTION
for https://app.clickup.com/t/20465559/PICA-232

this one upgrades statemine to 0.9.38 for manual testing of XCM USDT. or manual run of UI tests on `devnet-picasso`

**XCVMv3 is incomaptible, need upgrade**

what was done:
- used release compiled zombinet from parity repo (faster starup)
- upgraded statemine and relay to 0.9.38
- tuned cross chain logs for better debug
- united substrate nix deps
- asked on plans https://matrix.to/#/!QXMnIJzxlnVrvRzhUA:matrix.parity.io/$aXf5MlrDfqrDZlvzTRkJaBg50uTP9UBbFuxkwjqxlSo?via=matrix.org&via=corepaper.org&via=matrix.parity.io 

other chains works:
- https://github.com/AcalaNetwork/Acala/pull/2480/files
- https://github.com/AcalaNetwork/Acala/issues/2461
- https://github.com/PureStake/moonbeam/pull/2145/files