### PR TITLE
[PICA-278] Use Pallet Account as reward pot instead of inflation

### DIFF
--- a/code/parachain/frame/oracle/src/lib.rs
+++ b/code/parachain/frame/oracle/src/lib.rs
@@ -71,13 +71,12 @@ pub mod pallet {
 	use sp_runtime::{
 		offchain::{http, Duration},
 		traits::{
-			AtLeast32Bit, AtLeast32BitUnsigned, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub,
-			Saturating, UniqueSaturatedInto as _, Zero,
+			AccountIdConversion, AtLeast32Bit, AtLeast32BitUnsigned, CheckedAdd, CheckedDiv,
+			CheckedMul, CheckedSub, Saturating, UniqueSaturatedInto as _, Zero,
 		},
 		AccountId32, ArithmeticError, FixedPointNumber, FixedU128, KeyTypeId as CryptoKeyTypeId,
 		PerThing, Percent, RuntimeDebug,
 	};
-	use sp_runtime::traits::AccountIdConversion;
 	use sp_std::{
 		borrow::ToOwned, collections::btree_set::BTreeSet, fmt::Debug, str, vec, vec::Vec,
 	};

--- a/code/parachain/frame/oracle/src/lib.rs
+++ b/code/parachain/frame/oracle/src/lib.rs
@@ -58,7 +58,6 @@ pub mod pallet {
 		},
 		transactional, PalletId,
 	};
-	use frame_support::traits::ExistenceRequirement;
 	use frame_system::{
 		offchain::{
 			AppCrypto, CreateSignedTransaction, SendSignedTransaction, SignedPayload, Signer,
@@ -884,7 +883,7 @@ pub mod pallet {
 			asset_id: T::AssetId,
 			reward_amount: BalanceOf<T>,
 		) -> DispatchResult {
-			T::Currency::transfer(&Self::account_id(), &controller, reward_amount, ExistenceRequirement::KeepAlive)?;
+			T::Currency::transfer(&Self::account_id(), &controller, reward_amount, KeepAlive)?;
 			Self::deposit_event(Event::OracleRewarded(who, asset_id, reward_amount));
 			Ok(())
 		}

--- a/code/parachain/frame/oracle/src/tests.rs
+++ b/code/parachain/frame/oracle/src/tests.rs
@@ -1023,6 +1023,7 @@ fn test_payout_slash() {
 		reward_tracker.current_block_reward = 100;
 		reward_tracker.total_reward_weight = 82;
 		RewardTrackerStore::<Test>::set(Option::from(reward_tracker));
+		Balances::make_free_balance_be(&Oracle::account_id(), 100);
 		assert_ok!(Oracle::set_signer(RuntimeOrigin::signed(account_5), account_2));
 
 		let one = PrePrice { price: 79, block: 0, who: account_1 };
@@ -1044,6 +1045,7 @@ fn test_payout_slash() {
 		// doesn't panic when percent not set
 		assert_ok!(Oracle::handle_payout(&vec![one, two, three, four, five], 100, 0, &asset_info));
 		assert_eq!(Balances::free_balance(account_1), 100);
+		assert_eq!(Balances::free_balance(Oracle::account_id()), 100);
 
 		assert_ok!(Oracle::add_asset_and_info(
 			RuntimeOrigin::signed(account_2),
@@ -1092,6 +1094,8 @@ fn test_payout_slash() {
 		assert_eq!(Oracle::oracle_stake(account_4), Some(0));
 		// treasury gets 1 from both account1 and account4's stake
 		assert_eq!(Balances::free_balance(treasury_account), 102);
+		// 18/100 of the reward goes to the oracle accounts as rewards
+		assert_eq!(Balances::free_balance(Oracle::account_id()), 82);
 
 		assert_ok!(Oracle::add_asset_and_info(
 			RuntimeOrigin::signed(account_2),
@@ -1123,6 +1127,8 @@ fn test_payout_slash() {
 		assert_eq!(Oracle::oracle_stake(account_4), Some(0));
 		assert_eq!(Balances::free_balance(treasury_account), 102);
 		assert_eq!(Balances::free_balance(account_4), 100);
+		// 36/100 of the reward goes to the oracle accounts as rewards
+		assert_eq!(Balances::free_balance(Oracle::account_id()), 64);
 	});
 }
 
@@ -1255,6 +1261,7 @@ fn halborn_test_bypass_slashing() {
 		reward_tracker.current_block_reward = 100;
 		reward_tracker.total_reward_weight = 100;
 		RewardTrackerStore::<Test>::set(Option::from(reward_tracker));
+		Balances::make_free_balance_be(&Oracle::account_id(), 100);
 
 		//assert_ok!(Oracle::set_reward_rate(RuntimeOrigin::root(), REWARD_RATE));
 		let account_1 = get_account_1();


### PR DESCRIPTION
- Remove PICA inflation for rewarding
- Use the pallet account as reward pot which must contain the total allocation for rewarding the oracles