### PR TITLE
picasso composable centauri clients build and runs

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -204,6 +204,50 @@ jobs:
           ls result
           tree result -L 3          
 
+  build-all-deps-packages:
+    name: build-all-deps-packages
+    strategy:
+      matrix:
+        arch: [x64-monster]
+    needs: 
+      - privilege-check
+      - lfs-check
+    runs-on:
+      - self-hosted
+      - ${{ matrix.arch }}
+    concurrency:
+      group: ${{ github.workflow }}-build-all-deps-packages-${{ matrix.arch }}-${{ github.event.pull_request.title }}
+      cancel-in-progress: true
+    steps:
+      - name: Set up Nix
+        uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
+        with:
+          install_url: https://releases.nixos.org/nix/${{ env.NIX_VERSION }}/install
+          nix_path: nixpkgs=channel:${{ env.NIXPKGS_CHANNEL }}
+          extra_nix_config: |
+            sandbox = relaxed
+            narinfo-cache-negative-ttl = 0      
+            system-features = kvm
+            
+      - name: Set up Cachix
+        uses: cachix/cachix-action@298387a7aea14d6564aa5d6ead79272878339c8b # v12
+        with:
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+          name: ${{ env.CACHIX_NAME }}
+      - name: Add tools needed for non-nix steps
+        run: |  
+          nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_CHANNEL }} nixpkgs
+          nix-channel --update
+          nix-env -iA nixpkgs.cachix nixpkgs.nodejs nixpkgs.git nixpkgs.git-lfs nixpkgs.tree nixpkgs.docker nixpkgs.coreutils
+      - uses: actions/checkout@v3
+        with:
+          lfs: true
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: build-all-deps-packages 
+        uses: "./.github/templates/watch-exec"
+        with:
+          command: nix -- build .#all-deps --keep-going       
 
   build-all-docs-packages:
     name: build-all-docs-packages

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -715,7 +715,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "beefy-light-client-primitives",
  "ckb-merkle-mountain-range 0.3.2",
@@ -738,7 +738,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "ckb-merkle-mountain-range 0.3.2",
  "derive_more",
@@ -4420,7 +4420,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -4442,7 +4442,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-verifier"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "anyhow",
  "finality-grandpa",
@@ -4863,7 +4863,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.15.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "derive_more",
  "flex-error",
@@ -4871,6 +4871,7 @@ dependencies = [
  "ibc-derive",
  "ibc-proto 0.18.0",
  "ics23 0.8.1",
+ "log 0.4.17",
  "num-traits",
  "parity-scale-codec",
  "primitive-types",
@@ -4922,7 +4923,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-crate 1.3.0",
@@ -4934,7 +4935,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "base58",
  "blake2",
@@ -4958,7 +4959,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.18.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.4.0",
@@ -4988,7 +4989,7 @@ dependencies = [
 [[package]]
 name = "ibc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "frame-system",
  "hex-literal",
@@ -5015,7 +5016,7 @@ dependencies = [
 [[package]]
 name = "ibc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "ibc-primitives",
  "pallet-ibc",
@@ -5027,7 +5028,7 @@ dependencies = [
 [[package]]
 name = "ics07-tendermint"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "bytes 1.4.0",
  "flex-error",
@@ -5047,7 +5048,7 @@ dependencies = [
 [[package]]
 name = "ics10-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5073,7 +5074,7 @@ dependencies = [
 [[package]]
 name = "ics11-beefy"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "anyhow",
  "beefy-light-client",
@@ -6340,17 +6341,22 @@ dependencies = [
 [[package]]
 name = "light-client-common"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "anyhow",
+ "async-trait",
  "derive_more",
  "hash-db",
  "ibc 0.15.0",
+ "ibc-proto 0.18.0",
  "parity-scale-codec",
  "serde",
+ "sp-beefy",
  "sp-core 7.0.0",
+ "sp-runtime 7.0.0",
  "sp-storage 7.0.0",
  "sp-trie 7.0.0",
+ "subxt 0.26.0",
 ]
 
 [[package]]
@@ -8201,7 +8207,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "beefy-light-client-primitives",
  "cumulus-primitives-core",
@@ -8247,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc-ping"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -10931,7 +10937,7 @@ dependencies = [
  "signal-hook",
  "signal-hook-tokio",
  "sp-arithmetic 6.0.0",
- "subxt",
+ "subxt 0.25.0",
  "tokio",
  "tokio-stream",
  "url 1.7.2",
@@ -13740,7 +13746,7 @@ dependencies = [
 [[package]]
 name = "simple-iavl"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=c8aa82d95c817024f814c76131dba99c305fa1c4#c8aa82d95c817024f814c76131dba99c305fa1c4"
+source = "git+https://github.com/dzmitry-lahoda-forks/centauri?rev=15b72401a8292f248c2f3afe1e29cf83bf359c36#15b72401a8292f248c2f3afe1e29cf83bf359c36"
 dependencies = [
  "bytes 1.4.0",
  "ics23 0.8.1",
@@ -15372,8 +15378,40 @@ dependencies = [
  "sp-core 11.0.0",
  "sp-core-hashing 6.0.0",
  "sp-runtime 12.0.0",
- "subxt-macro",
- "subxt-metadata",
+ "subxt-macro 0.25.0",
+ "subxt-metadata 0.25.0",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "subxt"
+version = "0.26.0"
+source = "git+https://github.com/paritytech/subxt?rev=d92352ad739836a4100e1ef1db607acc82ed8c5a#d92352ad739836a4100e1ef1db607acc82ed8c5a"
+dependencies = [
+ "base58",
+ "blake2",
+ "derivative",
+ "frame-metadata",
+ "futures 0.3.26",
+ "getrandom 0.2.8",
+ "hex",
+ "impl-serde 0.4.0",
+ "jsonrpsee 0.16.2",
+ "parity-scale-codec",
+ "parking_lot 0.12.1",
+ "primitive-types",
+ "scale-bits",
+ "scale-decode",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-core 11.0.0",
+ "sp-core-hashing 6.0.0",
+ "sp-runtime 12.0.0",
+ "subxt-macro 0.26.0",
+ "subxt-metadata 0.26.0",
  "thiserror",
  "tracing",
 ]
@@ -15393,7 +15431,27 @@ dependencies = [
  "proc-macro2 1.0.51",
  "quote 1.0.23",
  "scale-info",
- "subxt-metadata",
+ "subxt-metadata 0.25.0",
+ "syn 1.0.107",
+ "tokio",
+]
+
+[[package]]
+name = "subxt-codegen"
+version = "0.26.0"
+source = "git+https://github.com/paritytech/subxt?rev=d92352ad739836a4100e1ef1db607acc82ed8c5a#d92352ad739836a4100e1ef1db607acc82ed8c5a"
+dependencies = [
+ "darling",
+ "frame-metadata",
+ "heck 0.4.1",
+ "hex",
+ "jsonrpsee 0.16.2",
+ "parity-scale-codec",
+ "proc-macro-error",
+ "proc-macro2 1.0.51",
+ "quote 1.0.23",
+ "scale-info",
+ "subxt-metadata 0.26.0",
  "syn 1.0.107",
  "tokio",
 ]
@@ -15405,7 +15463,18 @@ source = "git+https://github.com/paritytech/subxt?rev=2a913a3aa99a07f7acaedbbaee
 dependencies = [
  "darling",
  "proc-macro-error",
- "subxt-codegen",
+ "subxt-codegen 0.25.0",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "subxt-macro"
+version = "0.26.0"
+source = "git+https://github.com/paritytech/subxt?rev=d92352ad739836a4100e1ef1db607acc82ed8c5a#d92352ad739836a4100e1ef1db607acc82ed8c5a"
+dependencies = [
+ "darling",
+ "proc-macro-error",
+ "subxt-codegen 0.26.0",
  "syn 1.0.107",
 ]
 
@@ -15413,6 +15482,17 @@ dependencies = [
 name = "subxt-metadata"
 version = "0.25.0"
 source = "git+https://github.com/paritytech/subxt?rev=2a913a3aa99a07f7acaedbbaeed6925d34627303#2a913a3aa99a07f7acaedbbaeed6925d34627303"
+dependencies = [
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core-hashing 6.0.0",
+]
+
+[[package]]
+name = "subxt-metadata"
+version = "0.26.0"
+source = "git+https://github.com/paritytech/subxt?rev=d92352ad739836a4100e1ef1db607acc82ed8c5a#d92352ad739836a4100e1ef1db607acc82ed8c5a"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -47,7 +47,7 @@ members = [
   "parachain/runtime/composable-wasm",
   "utils/common",
   "utils/collator-sidecar",
-  "utils/price-feed"
+  "utils/price-feed",
 ]
 resolver = "2"
 
@@ -72,12 +72,12 @@ rpath = false
 
 
 [workspace.dependencies]
-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
-ibc-rpc = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
-ibc-primitives = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
-ibc-runtime-api = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
-pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
-pallet-ibc-ping = { git = "https://github.com/ComposableFi/centauri", rev = "c8aa82d95c817024f814c76131dba99c305fa1c4", default-features = false }
+ibc = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
+ibc-rpc = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
+ibc-primitives = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
+ibc-runtime-api = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
+pallet-ibc = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
+pallet-ibc-ping = { git = "https://github.com/dzmitry-lahoda-forks/centauri", rev = "15b72401a8292f248c2f3afe1e29cf83bf359c36", default-features = false }
 
 pallet-proxy = { git = "https://github.com/paritytech/substrate", default-features = false, branch = "polkadot-v0.9.36" }
 

--- a/code/common-deps.nix
+++ b/code/common-deps.nix
@@ -1,6 +1,6 @@
 { self, ... }: {
-  perSystem =
-    { config, self', inputs', pkgs, system, crane, systemCommonRust, ... }: {
+  perSystem = { config, self', inputs', pkgs, system, crane, systemCommonRust
+    , subnix, ... }: {
       _module.args.systemCommonRust = rec {
 
         mkRustSrc = path:
@@ -44,18 +44,9 @@
             Security
             SystemConfiguration
           ]);
-        substrate-attrs = {
-          LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
-            pkgs.stdenv.cc.cc.lib
-            pkgs.llvmPackages.libclang.lib
-          ];
-          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-          PROTOC = "${pkgs.protobuf}/bin/protoc";
-          ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
-        };
 
         # Common env required to build the node
-        common-attrs = substrate-attrs // {
+        common-attrs = subnix.subattrs // {
           src = rustSrc;
           buildInputs = with pkgs; [ openssl zstd ];
           nativeBuildInputs = with pkgs;
@@ -67,7 +58,7 @@
         };
 
         # TODO: refactor as mkOverride common-attrs
-        common-test-deps-attrs = substrate-attrs // {
+        common-test-deps-attrs = subnix.subattrs // {
           src = rustSrc;
           buildInputs = with pkgs; [ openssl zstd ];
           nativeBuildInputs = with pkgs;

--- a/code/parachain/frame/assets-registry/src/lib.rs
+++ b/code/parachain/frame/assets-registry/src/lib.rs
@@ -172,10 +172,7 @@ pub mod pallet {
 	impl<T: Config> GenesisBuild<T> for GenesisConfig<T> {
 		fn build(&self) {
 			for (nonce, location, asset_info) in self.assets.clone() {
-				let asset_id = T::LocalAssetId::decode(
-					&mut ([0_u8, 0, 0, 0, 0, 0, 0, 0], nonce).encode().as_ref(),
-				)
-				.expect("genesis is correct");
+				let asset_id = <Pallet<T>>::generate_asset_id([0; 8], nonce);
 
 				<Pallet<T> as RemoteAssetRegistryMutate>::register_asset(
 					asset_id, location, asset_info,

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -385,6 +385,7 @@ pub mod pallet {
 		/// - `origin` the original dispatching the extrinsic.
 		/// - `code` the actual wasm code.
 		#[transactional]
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::upload(code.len() as u32))]
 		pub fn upload(origin: OriginFor<T>, code: ContractCodeOf<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -406,6 +407,7 @@ pub mod pallet {
 		/// * `funds` the assets transferred to the contract prior to calling it's `instantiate`
 		///   export.
 		/// * `gas` the maximum gas to use, the remaining is refunded at the end of the transaction.
+		#[pallet::call_index(1)]
 		#[transactional]
 		#[pallet::weight(T::WeightInfo::instantiate(funds.len() as u32).saturating_add(Weight::from_ref_time(*gas)))]
 		pub fn instantiate(
@@ -449,6 +451,7 @@ pub mod pallet {
 		/// * `funds` the assets transferred to the contract prior to calling it's `instantiate`
 		///   export.
 		/// * `gas` the maximum gas to use, the remaining is refunded at the end of the transaction.
+		#[pallet::call_index(2)]
 		#[transactional]
 		#[pallet::weight(T::WeightInfo::execute(funds.len() as u32).saturating_add(Weight::from_ref_time(*gas)))]
 		pub fn execute(
@@ -480,6 +483,7 @@ pub mod pallet {
 		/// * `new_code_identifier` the code identifier that we want to switch to.
 		/// * `gas` the maximum gas to use, the remaining is refunded at the end of the transaction.
 		/// * `message` MigrateMsg, that will be passed to the contract.
+		#[pallet::call_index(3)]
 		#[transactional]
 		#[pallet::weight(T::WeightInfo::migrate().saturating_add(Weight::from_ref_time(*gas)))]
 		pub fn migrate(
@@ -508,6 +512,7 @@ pub mod pallet {
 		/// * `contract` the address of the contract that we want to migrate.
 		/// * `new_admin` new admin of the contract that we want to update to.
 		/// * `gas` the maximum gas to use, the remaining is refunded at the end of the transaction.
+		#[pallet::call_index(4)]
 		#[transactional]
 		#[pallet::weight(T::WeightInfo::update_admin().saturating_add(Weight::from_ref_time(*gas)))]
 		pub fn update_admin(

--- a/code/parachain/frame/cosmwasm/src/tests/host_functions.rs
+++ b/code/parachain/frame/cosmwasm/src/tests/host_functions.rs
@@ -204,7 +204,8 @@ fn addr_canonicalize_humanize_validate() {
 		);
 
 		// 2. Canonical address is correct.
-		assert_eq!(canonical_addr.0.as_ref().as_ref(), valid_addr.1);
+		let canonical: &[u8; 32] = canonical_addr.0.as_ref().as_ref();
+		assert_eq!(canonical.to_vec(), valid_addr.1);
 
 		// 3. Fails if the address is invalid. (`Ok(Err)`)
 		assert!(vm.addr_canonicalize(invalid_addr).unwrap().is_err());

--- a/code/parachain/runtime/common/src/ibc.rs
+++ b/code/parachain/runtime/common/src/ibc.rs
@@ -1,5 +1,6 @@
 use composable_traits::xcm::assets::RemoteAssetRegistryInspect;
 use primitives::currency::{ForeignAssetId, PrefixedDenom};
+use sp_core::ConstU64;
 
 use crate::prelude::*;
 
@@ -28,3 +29,5 @@ where
 		}
 	}
 }
+
+pub type MinimumConnectionDelaySeconds = ConstU64<10>;

--- a/code/parachain/runtime/picasso/src/ibc.rs
+++ b/code/parachain/runtime/picasso/src/ibc.rs
@@ -2,7 +2,7 @@ use ::ibc::core::{
 	ics24_host::identifier::PortId,
 	ics26_routing::context::{Module, ModuleId},
 };
-use common::ibc::ForeignIbcIcs20Assets;
+use common::ibc::{ForeignIbcIcs20Assets, MinimumConnectionDelaySeconds};
 use frame_support::traits::EitherOf;
 use pallet_ibc::{
 	light_client_common::RelayChain, routing::ModuleRouter, DenomToAssetId, IbcAssetIds, IbcAssets,
@@ -130,7 +130,7 @@ impl pallet_ibc::Config for Runtime {
 	type Fungibles = Assets;
 	type ExpectedBlockTime = ConstU64<SLOT_DURATION>;
 	type Router = ();
-	type MinimumConnectionDelay = ConstU64<1>;
+	type MinimumConnectionDelay = MinimumConnectionDelaySeconds;
 	type ParaId = parachain_info::Pallet<Runtime>;
 	type RelayChain = RelayChainId;
 	type WeightInfo = weights::ibc::WeightInfo<Self>;

--- a/code/parachain/runtime/primitives/src/topology.rs
+++ b/code/parachain/runtime/primitives/src/topology.rs
@@ -55,7 +55,7 @@ pub struct Picasso;
 impl Picasso {
 	pub fn assets() -> Vec<(u64, Option<ForeignAssetId>, AssetInfo<Balance>)> {
 		let usdt = (
-			1984,
+			130,
 			Some(ForeignAssetId::Xcm(XcmAssetLocation::new(MultiLocation::new(
 				1,
 				X3(
@@ -75,11 +75,12 @@ impl Picasso {
 				),
 				decimals: Some(6),
 				existential_deposit: 10_000,
-				ratio: Some(rational!(375 / 1_000_000)),
+				ratio: Some(rational!(15 / 1_000_000_000)),
 			},
 		);
 		let mut dot = InnerPrefixedDenom::from_str("6").expect("genesis");
 		dot.add_trace_prefix(TracePrefix::new(PortId::transfer(), ChannelId::new(0)));
+
 		let dot = (
 			6,
 			Some(ForeignAssetId::IbcIcs20(PrefixedDenom(dot))),
@@ -92,9 +93,9 @@ impl Picasso {
 					BiBoundedAssetSymbol::from_vec(b"DOT".to_vec())
 						.expect("String is within bounds"),
 				),
-				decimals: Some(12),
-				existential_deposit: 1_000_000_000,
-				ratio: Some(rational!(375 / 1_000)),
+				decimals: Some(10),
+				existential_deposit: 1_000_000,
+				ratio: Some(rational!(2143 / 100_000_000)),
 			},
 		);
 
@@ -112,7 +113,7 @@ pub struct Composable;
 impl Composable {
 	pub fn assets() -> Vec<(u64, Option<ForeignAssetId>, AssetInfo<Balance>)> {
 		let usdt = (
-			1984,
+			140,
 			Some(ForeignAssetId::Xcm(XcmAssetLocation::new(MultiLocation::new(
 				1,
 				X3(
@@ -132,10 +133,10 @@ impl Composable {
 				),
 				decimals: Some(6),
 				existential_deposit: 10_000,
-				ratio: Some(rational!(375 / 1_000_000)),
+				ratio: Some(rational!(375 / 1_000_000_000)),
 			},
 		);
-		let mut pica = InnerPrefixedDenom::from_str("6").expect("genesis");
+		let mut pica = InnerPrefixedDenom::from_str("1").expect("genesis");
 		pica.add_trace_prefix(TracePrefix::new(PortId::transfer(), ChannelId::new(0)));
 		let pica = (
 			1,
@@ -154,8 +155,25 @@ impl Composable {
 				ratio: Some(rational!(1 / 1)),
 			},
 		);
+		let dot = (
+			6,
+			Some(ForeignAssetId::Xcm(XcmAssetLocation::new(MultiLocation::new(1, Here)))),
+			AssetInfo {
+				name: Some(
+					BiBoundedAssetName::from_vec(b"Polkadot".to_vec())
+						.expect("String is within bounds"),
+				),
+				symbol: Some(
+					BiBoundedAssetSymbol::from_vec(b"DOT".to_vec())
+						.expect("String is within bounds"),
+				),
+				decimals: Some(10),
+				existential_deposit: 1_000_000,
+				ratio: Some(rational!(2143 / 100_000_000)),
+			},
+		);
 
-		vec![usdt, pica]
+		vec![usdt, pica, dot]
 	}
 }
 

--- a/code/runtimes.nix
+++ b/code/runtimes.nix
@@ -90,19 +90,6 @@
           name = "composable";
           features = "runtime-benchmarks";
         };
-        rococo-wasm-runtime = pkgs.stdenv.mkDerivation {
-          name = "rococo-wasm-runtime";
-          dontUnpack = true;
-          src = pkgs.fetchurl {
-            url =
-              "https://github.com/paritytech/polkadot/releases/download/v0.9.33/rococo_runtime-v9330.compact.compressed.wasm";
-            hash = "sha256-lvjPqQVEdu/5EeZE2NMAROO2ypCeV6QENFHhNYf9SCI=";
-          };
-          installPhase = ''
-            mkdir -p $out/lib
-            cp $src $out/lib/rococo_runtime.compact.compressed.wasm
-          '';
-        };
       };
 
     };

--- a/devnets/all.nix
+++ b/devnets/all.nix
@@ -13,14 +13,31 @@
       devnet-centauri = pkgs.composable.mkDevnetProgram "devnet-centauri"
         (import ./specs/centauri.nix {
           inherit pkgs devnetTools packages;
-          devnet-a = packages.zombienet-dali-centauri-a;
-          devnet-b = packages.zombienet-dali-centauri-b;
+          devnet-a = packages.zombienet-picasso-centauri-a;
+          devnet-b = packages.zombienet-composable-centauri-b;
         });
 
-      devnet-dali-image = devnetTools.buildDevnetImage {
-        name = "devnet-dali";
+      devnet-centauri-no-relay =
+        pkgs.composable.mkDevnetProgram "devnet-centauri"
+        (import ./specs/centauri.nix {
+          inherit pkgs devnetTools packages;
+          devnet-a = packages.zombienet-picasso-centauri-a;
+          devnet-b = packages.zombienet-composable-centauri-b;
+          hyperspace-relay = false;
+        });
+
+      centauri-no-relay = pkgs.writeShellApplication rec {
+        name = "centauri-configure-and-run";
+        text = ''
+          cp --force ${self'.packages.hyperspace-config} /tmp/config.toml  
+          ${pkgs.lib.meta.getExe devnet-centauri-no-relay}       
+        '';
+      };
+
+      devnet-picasso-image = devnetTools.buildDevnetImage {
+        name = "devnet-picasso";
         container-tools = devnetTools.withDevNetContainerTools;
-        devNet = packages.zombienet-rococo-local-dali-dev;
+        devNet = packages.zombienet-rococo-local-picasso-dev;
       };
 
       devnet-picasso-complete = packages.zombienet-picasso-complete;

--- a/devnets/services/centauri.nix
+++ b/devnets/services/centauri.nix
@@ -1,14 +1,18 @@
 { name, execCommands, configPathSource, configPathContainer, dependsOn
 , restartPolicy, pkgs, packages, devnetTools }: {
   image = {
-    contents = [ packages.hyperspace-dali ]
+    contents = [ packages.hyperspace-composable-rococo-picasso-rococo ]
       ++ devnetTools.withBaseContainerTools;
     enableRecommendedContents = true;
   };
   service = {
     restart = restartPolicy;
-    environment = { RUST_LOG = "debug"; };
-    entrypoint = "${pkgs.lib.meta.getExe packages.hyperspace-dali}";
+    environment = {
+      RUST_LOG =
+        "trace,soketto=debug,tracing::span=debug,mio::poll=debug,trie=debug";
+    };
+    entrypoint = "${pkgs.lib.meta.getExe
+      packages.hyperspace-composable-rococo-picasso-rococo}";
     command = execCommands;
     volumes = [{
       source = configPathSource;

--- a/flake/all.nix
+++ b/flake/all.nix
@@ -1,6 +1,17 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, system, ... }: {
     packages = {
+
+      all-deps = pkgs.linkFarmFromDrvs "all-deps" (with self'.packages; [
+        acala-node
+        bifrost-node
+        polkadot-node-dep
+        polkadot-node-on-parity-kusama
+        polkadot-node-on-parity-polkadot
+        statemine-node
+        subwasm
+      ]);
+
       all-docs = pkgs.linkFarmFromDrvs "all-docs"
         (with self'.packages; [ docs-server docs-static ]);
       all-misc = pkgs.linkFarmFromDrvs "all-misc" (with self'.packages; [
@@ -14,9 +25,7 @@
       ]);
 
       all = pkgs.linkFarmFromDrvs "all-ci-packages" (with self'.packages; [
-        acala-node
         benchmarks-check
-        bifrost-node
         cargo-clippy-check
         cargo-deny-check
         check-composable-benchmarks-ci
@@ -28,28 +37,24 @@
         cmc-api-image
         composable-bench-node
         composable-node
-        dali-subxt-client
         devnet-centauri
-        devnet-dali
+        devnet-picasso
         devnet-dali-complete
-        devnet-dali-image
+        devnet-picasso-image
         devnet-initialize-script-picasso-persistent
         devnet-integration-tests
         devnet-picasso-complete
         frontend-static
-        hyperspace-dali
-        hyperspace-dali-image
-        polkadot-node-on-parity-kusama
-        statemine-node
-        subwasm
         unit-tests
+        hyperspace-composable-rococo-picasso-rococo
+        hyperspace-composable-rococo-picasso-rococo-image
       ]);
 
       docker-images-to-push = pkgs.linkFarmFromDrvs "docker-images-to-push"
         (with self'.packages; [
           cmc-api-image
-          devnet-dali-image
-          hyperspace-dali-image
+          hyperspace-composable-rococo-picasso-rococo-image
+          devnet-picasso-image
         ]);
     };
   };

--- a/flake/subxt.nix
+++ b/flake/subxt.nix
@@ -1,24 +1,32 @@
 { ... }: {
   perSystem = { self', pkgs, systemCommonRust, ... }: {
-    packages = {
-      dali-subxt-client = pkgs.stdenv.mkDerivation {
-        name = "dali-subxt-client";
-        dontUnpack = true;
-        buildInputs = [
-          self'.packages.centauri-codegen
-          self'.packages.dali-runtime
-          self'.packages.rococo-wasm-runtime
-        ];
-        nativeBuildInputs = with pkgs;
-          [ clang ] ++ systemCommonRust.darwin-deps;
-        installPhase = ''
-          mkdir --parents $out
-          ${pkgs.lib.meta.getExe self'.packages.centauri-codegen} \
-            --path $out \
-            --parachain-wasm=${self'.packages.dali-runtime}/lib/runtime.optimized.wasm \
-            --relaychain-wasm=${self'.packages.rococo-wasm-runtime}/lib/rococo_runtime.compact.compressed.wasm
-        '';
-      };
+    packages = let
+      mkSubxtClient = name: runtime:
+        pkgs.stdenv.mkDerivation {
+          inherit name;
+          dontUnpack = true;
+          buildInputs = [
+            self'.packages.centauri-codegen
+            runtime
+            self'.packages.rococo-wasm-runtime-current
+          ];
+          nativeBuildInputs = with pkgs;
+            [ clang ] ++ systemCommonRust.darwin-deps;
+
+          installPhase = ''
+            mkdir --parents $out
+            ${pkgs.lib.meta.getExe self'.packages.centauri-codegen} \
+              --path $out \
+              --parachain-wasm=${runtime}/lib/runtime.optimized.wasm \
+              --relaychain-wasm=${self'.packages.rococo-wasm-runtime-current}/lib/rococo_runtime.compact.compressed.wasm
+          '';
+        };
+    in {
+      composable-rococo-subxt-client =
+        mkSubxtClient "composable-rococo-subxt-client"
+        self'.packages.composable-runtime;
+      picasso-rococo-subxt-client = mkSubxtClient "picasso-rococo-subxt-client"
+        self'.packages.picasso-runtime;
     };
   };
 }

--- a/flake/zombienet.nix
+++ b/flake/zombienet.nix
@@ -4,15 +4,14 @@
       prelude = zombieTools.builder;
       relaychainBase = {
         chain = "rococo-local";
-        default_command =
-          pkgs.lib.meta.getExe self'.packages.polkadot-node-on-parity-kusama;
+        default_command = pkgs.lib.meta.getExe self'.packages.polkadot-node-dep;
         count = 3;
       };
 
       zombienet-rococo-local-composable-config = with prelude;
-        { chain ? "dali-dev", ws_port ? null, rpc_port ? null
-        , relay_ws_port ? null, relay_rpc_port ? null, rust_log_add ? null
-        , para-id ? 2087, command ? self'.packages.composable-node }:
+        { chain, ws_port ? null, rpc_port ? null, relay_ws_port ? null
+        , relay_rpc_port ? null, rust_log_add ? null, para-id ? 2087
+        , command ? self'.packages.composable-node }:
         mkZombienet {
           relaychain = relaychainBase
             // (pkgs.lib.optionalAttrs (relay_ws_port != null) {
@@ -121,16 +120,19 @@
             chain = "composable-dev";
           });
 
-        zombienet-dali-centauri-a =
-          zombieTools.writeZombienetShellApplication "zombienet-dali-centauri-a"
+        zombienet-picasso-centauri-a =
+          zombieTools.writeZombienetShellApplication
+          "zombienet-picasso-centauri-a"
           (zombienet-rococo-local-composable-config {
             rust_log_add =
               "runtime::contracts=debug,ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace";
-            command = self'.packages.composable-node-dali;
+            command = self'.packages.composable-node;
+            chain = "picasso-dev";
           });
 
-        zombienet-dali-centauri-b =
-          zombieTools.writeZombienetShellApplication "zombienet-dali-centauri-b"
+        zombienet-picasso-centauri-b =
+          zombieTools.writeZombienetShellApplication
+          "zombienet-picasso-centauri-b"
           (zombienet-rococo-local-composable-config {
             ws_port = 29988;
             rpc_port = 32201;
@@ -138,7 +140,22 @@
             relay_rpc_port = 31445;
             rust_log_add =
               "runtime::contracts=debug,ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace";
-            command = self'.packages.composable-node-dali;
+            command = self'.packages.composable-node;
+            chain = "picasso-dev";
+          });
+
+        zombienet-composable-centauri-b =
+          zombieTools.writeZombienetShellApplication
+          "zombienet-composable-centauri-b"
+          (zombienet-rococo-local-composable-config {
+            ws_port = 29988;
+            rpc_port = 32201;
+            relay_ws_port = 29944;
+            relay_rpc_port = 31445;
+            rust_log_add =
+              "runtime::contracts=debug,ibc_transfer=trace,pallet_ibc=trace,grandpa-verifier=trace";
+            command = self'.packages.composable-node;
+            chain = "composable-dev";
           });
       };
 
@@ -153,11 +170,6 @@
           program = self'.packages.zombienet-dali-complete;
         };
 
-        zombienet-dali-centauri-a = {
-          type = "app";
-          program = self'.packages.zombienet-dali-centauri-a;
-        };
-
         zombienet-picasso-complete = {
           type = "app";
           program = self'.packages.zombienet-picasso-complete;
@@ -167,7 +179,19 @@
           program = pkgs.writeShellApplication rec {
             name = "zombienet-log-follow";
             text = ''
-              docker exec -it composable-devnet-a-1   bash  -c 'LOG=$(find /tmp/ -name "zombie-*" | head --lines=1)/alice.log && tail --follow $LOG'
+              CONTAINER="''${1:-composable-devnet-a-1}"
+              docker exec -it "$CONTAINER"   bash  -c 'LOG=$(find /tmp/ -name "zombie-*" | head --lines=1)/alice.log && tail --follow $LOG'
+            '';
+          };
+          type = "app";
+        };
+
+        zombienet-log-cat = {
+          program = pkgs.writeShellApplication rec {
+            name = "zombienet-log-follow";
+            text = ''
+              CONTAINER="''${1:-composable-devnet-a-1}"
+              docker exec -it "$CONTAINER"   bash  -c 'LOG=$(find /tmp/ -name "zombie-*" | head --lines=1)/alice.log && cat $LOG'
             '';
           };
           type = "app";

--- a/inputs/centauri/composable.patch
+++ b/inputs/centauri/composable.patch
@@ -1,0 +1,15 @@
+--- composable.rs	1970-01-01 00:00:01.000000000 +0000
++++ composable.rs	2023-04-02 21:39:08.174185055 +0100
+@@ -32,9 +32,9 @@
+ use subxt::{
+ 	config::{
+ 		extrinsic_params::Era,
+-		polkadot::{
+-			PlainTip as Tip, PolkadotExtrinsicParams as ParachainExtrinsicParams,
+-			PolkadotExtrinsicParamsBuilder as ParachainExtrinsicsParamsBuilder,
++		substrate::{
++			AssetTip as Tip, SubstrateExtrinsicParams as ParachainExtrinsicParams,
++			SubstrateExtrinsicParamsBuilder as ParachainExtrinsicsParamsBuilder,
+ 		},
+ 		ExtrinsicParams,
+ 	},

--- a/inputs/centauri/flake-module.nix
+++ b/inputs/centauri/flake-module.nix
@@ -1,41 +1,75 @@
 { self, ... }: {
-  perSystem = { config, self', inputs', pkgs, system, crane, ... }:
+  perSystem = { config, self', inputs', pkgs, system, crane, subnix, ... }:
     let
-      centauri-src = pkgs.fetchFromGitHub {
+      protocattrs = {
+        BuildInputs = [ pkgs.protobuf ];
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        PROTOC_INCLUDE = "${pkgs.protobuf}/include";
+        PROTOC_NO_VENDOR = "1";
+      };
+
+      cargo-lock = builtins.fromTOML (builtins.readFile ../../code/Cargo.lock);
+      centauri-runtime-dep = builtins.head
+        (builtins.filter (x: x.name == "pallet-ibc") (cargo-lock.package));
+      centauri-runtime-commit =
+        builtins.elemAt (builtins.split "#" centauri-runtime-dep.source) 2;
+
+      centauri-src-current = pkgs.fetchFromGitHub {
+        owner = "dzmitry-lahoda-forks";
+        repo = "centauri";
+        rev = centauri-runtime-commit;
+        hash = "sha256-wgjOiIgfDlKVOnrW+eZQaurXY8BDSqjVOy7fFx0wbvg=";
+      };
+
+      centauri-src-release = pkgs.fetchFromGitHub {
         owner = "ComposableFi";
         repo = "centauri";
-        rev = "c8aa82d95c817024f814c76131dba99c305fa1c4";
-        hash = "sha256-TPxZD1zvDoDozkMNCLhKqTenILlkLpg0ddtq/QWMKZc=";
+        rev = "54a1c42553d18160f5e89542d87aea6fcc95b4b5";
+        hash = "sha256-rnKUfGcF9TTSockx/YqJzpsPPu23jplc4BiOyoOSsV8=";
       };
+
+      hyperspace-picasso-kusama-spec-a = {
+        channel_whitelist = [ ];
+        client_id = "10-grandpa-0";
+        commitment_prefix = "0x6962632f";
+        finality_protocol = "Grandpa";
+        connection_id = "connection-0";
+        key_type = "sr25519";
+        name = "picasso_1";
+        para_id = 2087;
+        parachain_rpc_url = "ws://devnet-a:9988";
+        private_key = "//Alice";
+        relay_chain_rpc_url = "ws://devnet-a:9944";
+        ss58_version = 49;
+        type = "picasso_kusama";
+      };
+
+      hyperspace-picasso-kusama-spec-b = hyperspace-picasso-kusama-spec-a // {
+        name = "picasso_2";
+        parachain_rpc_url = "ws://devnet-b:29988";
+        relay_chain_rpc_url = "ws://devnet-b:29944";
+      };
+
+      # so not yet finalizes connection, working on it
+      composable-polkadot-spec = {
+        type = "composable";
+        channel_whitelist = [ ];
+        client_id = "10-grandpa-0";
+        commitment_prefix = "0x6962632f";
+        connection_id = "connection-0";
+        finality_protocol = "Grandpa";
+        key_type = "sr25519";
+        name = "picasso_2";
+        para_id = 2087;
+        parachain_rpc_url = "ws://devnet-b:29988";
+        private_key = "//Alice";
+        relay_chain_rpc_url = "ws://devnet-b:29944";
+        ss58_version = 50;
+      };
+
       hyperspace-client-template = {
-        chain_a = {
-          channel_whitelist = [ ];
-          client_id = "10-grandpa-0";
-          commitment_prefix = "0x6962632f";
-          finality_protocol = "Grandpa";
-          key_type = "sr25519";
-          name = "picasso_1";
-          para_id = 2087;
-          parachain_rpc_url = "ws://devnet-a:9988";
-          private_key = "//Alice";
-          relay_chain_rpc_url = "ws://devnet-a:9944";
-          ss58_version = 49;
-          type = "parachain";
-        };
-        chain_b = {
-          channel_whitelist = [ ];
-          client_id = "10-grandpa-0";
-          commitment_prefix = "0x6962632f";
-          finality_protocol = "Grandpa";
-          key_type = "sr25519";
-          name = "picasso_2";
-          para_id = 2087;
-          parachain_rpc_url = "ws://devnet-b:29988";
-          private_key = "//Alice";
-          relay_chain_rpc_url = "ws://devnet-b:29944";
-          ss58_version = 49;
-          type = "parachain";
-        };
+        chain_a = hyperspace-picasso-kusama-spec-a;
+        chain_b = composable-polkadot-spec;
         core = { prometheus_endpoint = "https://127.0.0.1"; };
       };
 
@@ -52,86 +86,117 @@
         centauri-codegen = crane.stable.buildPackage {
           name = "centauri-codegen";
           cargoArtifacts = crane.stable.buildDepsOnly {
-            src = centauri-src;
+            src = centauri-src-current;
             doCheck = false;
             cargoExtraArgs = "-p codegen";
             cargoTestCommand = "";
           };
-          src = centauri-src;
+          src = centauri-src-current;
           doCheck = false;
           cargoExtraArgs = "-p codegen";
           cargoTestCommand = "";
           meta = { mainProgram = "codegen"; };
         };
+        centauri-hyperspace = crane.stable.buildPackage (subnix.subenv // {
+          name = "centauri-hyperspace";
+          cargoArtifacts = crane.stable.buildDepsOnly (subnix.subenv // {
+            src = centauri-src-current;
+            doCheck = false;
+            cargoExtraArgs = "-p hyperspace";
+            cargoTestCommand = "";
+          });
+          src = centauri-src-current;
+          doCheck = false;
+          cargoExtraArgs = "-p hyperspace";
+          cargoTestCommand = "";
+          meta = { mainProgram = "hyperspace"; };
+        });
 
-        dali-subxt-patch = pkgs.stdenv.mkDerivation rec {
-          name = "dali-subxt-patch";
-          pname = "${name}";
-          buildInputs = [ self'.packages.dali-subxt-client ];
-          src = centauri-src;
-          patchPhase = "true";
-          installPhase = ''
-            mkdir --parents $out
-            set +e
-            diff --exclude=lib.rs --recursive --unified $src/utils/subxt/generated/src/ ${self'.packages.dali-subxt-client}/ > $out/${name}.patch            
-            if [[ $? -ne 1 ]] ; then
-              echo "Failed diff"              
-            fi              
-            set -e 
-          '';
-          dontFixup = true;
-          dontStrip = true;
-        };
+        # no worries, long names not for public use, just to avoid mistakes
+        composable-rococo-picasso-rococo-subxt-hyperspace-patch =
+          pkgs.stdenv.mkDerivation rec {
+            name = "composable-rococo-picasso-rococo-subxt-hyperspace-patch";
+            pname = "${name}";
+            buildInputs = [
+              self'.packages.composable-rococo-subxt-client
+              self'.packages.picasso-rococo-subxt-client
+            ];
+            src = centauri-src-current;
+            patchPhase = "true";
+            installPhase = ''
+              mkdir --parents $out
+              set +e
+              diff --exclude=mod.rs --recursive --unified $src/utils/subxt/generated/src/composable ${self'.packages.composable-rococo-subxt-client}/ > $out/composable_polkadot.patch
+              if [[ $? -ne 1 ]] ; then
+                echo "Failed diff"              
+              fi                
+              diff --exclude=mod.rs --recursive --unified $src/utils/subxt/generated/src/picasso_kusama ${self'.packages.picasso-rococo-subxt-client}/ > $out/picasso_kusama.patch            
+              if [[ $? -ne 1 ]] ; then
+                echo "Failed diff"              
+              fi              
+              set -e 
+            '';
+            dontFixup = true;
+            dontStrip = true;
+          };
 
-        centauri-patched-src = pkgs.stdenv.mkDerivation rec {
-          name = "centauri-patched-src";
-          pname = "${name}";
-          buildInputs = [ self'.packages.dali-subxt-client ];
-          src = centauri-src;
-          patches = [ "${dali-subxt-patch}/dali-subxt-patch.patch" ];
-          patchFlags = "--strip=4";
-          installPhase = ''
-            mkdir --parents $out
-            cp --recursive --no-preserve=mode,ownership $src/. $out/
-            cd $out/utils/subxt/generated/src
-            patch ${patchFlags} -- < ${builtins.head patches}
-          '';
-          dontFixup = true;
-          dontStrip = true;
-        };
+        composable-rococo-picasso-rococo-centauri-patched-src =
+          pkgs.stdenv.mkDerivation rec {
+            name = "composable-rococo-picasso-rococo-centauri-patched-src";
+            pname = "${name}";
+            src = centauri-src-current;
+            buildInputs = with pkgs; [ sd git ];
+            patchFlags = "--strip=4";
+            installPhase = ''
+              mkdir --parents $out
+              cp --recursive --no-preserve=mode,ownership $src/. $out/
+              cp ${./composable.patch} "$out/hyperspace/core/src/substrate/"
+
+              cd $out/utils/subxt/generated/src/picasso_kusama
+              patch ${patchFlags} -- < "${composable-rococo-picasso-rococo-subxt-hyperspace-patch}/picasso_kusama.patch"
+
+              cd $out/utils/subxt/generated/src/composable
+              patch ${patchFlags} -- < "${composable-rococo-picasso-rococo-subxt-hyperspace-patch}/composable_polkadot.patch"
+              sd "rococo" "polkadot" "$out/utils/subxt/generated/src/composable/relaychain.rs"
+
+              cd "$out/hyperspace/core/src/substrate/"
+              patch -- < ${./composable.patch}
+
+            '';
+            dontFixup = true;
+            dontStrip = true;
+          };
 
         hyperspace-config = pkgs.writeText "config.toml"
           (self.inputs.nix-std.lib.serde.toTOML hyperspace-connection-template);
 
-        hyperspace-dali-image = pkgs.dockerTools.buildImage {
-          tag = "latest";
-          name = "hyperspace-dali";
-          config = { Entrypoint = [ "${hyperspace-dali}/bin/hyperspace" ]; };
-        };
-
-        hyperspace-dali = crane.stable.buildPackage rec {
-          name = "hyperspace-dali";
-          pname = "${name}";
-          cargoArtifacts = crane.stable.buildDepsOnly {
-            src = centauri-patched-src;
-            doCheck = false;
-            cargoExtraArgs = "--package hyperspace --features dali";
-            cargoTestCommand = "";
-            BuildInputs = [ pkgs.protobuf ];
-            PROTOC = "${pkgs.protobuf}/bin/protoc";
-            PROTOC_INCLUDE = "${pkgs.protobuf}/include";
-            PROTOC_NO_VENDOR = "1";
+        hyperspace-composable-rococo-picasso-rococo-image =
+          pkgs.dockerTools.buildImage {
+            tag = "latest";
+            name = "hyperspace-composable-rococo-picasso-rococo";
+            config = {
+              Entrypoint = [
+                "${hyperspace-composable-rococo-picasso-rococo}/bin/hyperspace"
+              ];
+            };
           };
-          src = centauri-patched-src;
-          BuildInputs = [ pkgs.protobuf ];
-          PROTOC = "${pkgs.protobuf}/bin/protoc";
-          PROTOC_INCLUDE = "${pkgs.protobuf}/include";
-          PROTOC_NO_VENDOR = "1";
-          doCheck = false;
-          cargoExtraArgs = "--package hyperspace --features dali";
-          cargoTestCommand = "";
-          meta = { mainProgram = "hyperspace"; };
-        };
+
+        hyperspace-composable-rococo-picasso-rococo = crane.stable.buildPackage
+          (protocattrs // rec {
+            name = "hyperspace-composable-rococo-picasso-rococo";
+            pname = "${name}";
+            cargoArtifacts = crane.stable.buildDepsOnly (protocattrs // {
+              src = composable-rococo-picasso-rococo-centauri-patched-src;
+              doCheck = false;
+              cargoExtraArgs = "--package hyperspace";
+              cargoTestCommand = "";
+            });
+            src = composable-rococo-picasso-rococo-centauri-patched-src;
+            doCheck = false;
+            cargoExtraArgs = "--package hyperspace";
+            cargoTestCommand = "";
+            meta = { mainProgram = "hyperspace"; };
+          });
       };
     };
 }

--- a/inputs/paritytech/polkadot.nix
+++ b/inputs/paritytech/polkadot.nix
@@ -1,35 +1,63 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, lib, system, crane
-    , systemCommonRust, subTools, ... }:
+    , systemCommonRust, subnix, ... }:
     let
+      _cargo-debug-attrs = {
+        CARGO_LOG = "debug";
+        CARGO_NET_GIT_FETCH_WITH_CLI = "true";
+        CARGO_HTTP_MULTIPLEXING = "false";
+        CARGO_HTTP_DEBUG = "true";
+        RUST_LOG = "debug";
+      };
       buildPolkadotNode =
         { name, version, repo, owner, rev, hash, cargoSha256 }:
-        pkgs.rustPlatform.buildRustPackage (rec {
+        pkgs.rustPlatform.buildRustPackage (subnix.subenv // rec {
           inherit name version cargoSha256;
+          # git may be different locally and remotely, so we freeze for determinism (because node builds wasm)
+          buildPackage = [ pkgs.git ];
           src = pkgs.fetchgit {
             url = "https://github.com/${owner}/${repo}.git";
             inherit rev;
             sha256 = hash;
             fetchSubmodules = false;
           };
-
+          # env = _cargo-debug-attrs;
           meta = { mainProgram = "polkadot"; };
 
           __noChroot = true;
 
-        } // subTools.subenv);
+        });
+      cargo-lock = builtins.fromTOML (builtins.readFile ../../code/Cargo.lock);
+      rococo-runtime-dep = builtins.head
+        (builtins.filter (x: x.name == "rococo-runtime") (cargo-lock.package));
+      rococo-runtime-commit =
+        builtins.elemAt (builtins.split "#" rococo-runtime-dep.source) 2;
     in {
       packages = rec {
-        # current version for centauri
-        polkadot-node-9370 = let version = "v0.9.37";
+        rococo-wasm-runtime-9360 = pkgs.stdenv.mkDerivation {
+          name = "rococo-wasm-runtime";
+          dontUnpack = true;
+          src = pkgs.fetchurl {
+            url =
+              "https://github.com/paritytech/polkadot/releases/download/v0.9.36/rococo_runtime-v9360.compact.compressed.wasm";
+            hash = "sha256-inq526PxU2f4+m4RSTiv5oOpfSZfnQpXkhpYmqZ9gOs=";
+          };
+          installPhase = ''
+            mkdir -p $out/lib
+            cp $src $out/lib/rococo_runtime.compact.compressed.wasm
+          '';
+        };
+        rococo-wasm-runtime-current = rococo-wasm-runtime-9360;
+
+        polkadot-node-dep = let version = "current";
         in buildPolkadotNode rec {
-          name = "polkadot-node-current";
+          name = rococo-runtime-commit;
           inherit version;
           repo = "polkadot";
           owner = "paritytech";
-          rev = "refs/tags/${version}";
-          hash = "sha256-TTi4cKqQT/2ZZ/acGvcilqTlh2D9t4cfAtQQyVZWdmg=";
-          cargoSha256 = "sha256-9ljw5lG6OeB4k+w9nMxBfMsIN5YGikvYnanC8M/Dpwo=";
+          rev = rococo-runtime-commit;
+          hash = "sha256-x2IEIHxH8Hg+jFIpnPrTsqISEAZHFuXhJD+H1S+G3nk=";
+          cargoSha256 = "sha256-ZvHdlFpord1uPGsnQlGt4wDdYti07D4tpWuc2HWHtII=";
         };
         # for xcmv3 release and centauri client asap they upgrade
         polkadot-node-9390 = let version = "v0.9.39";
@@ -43,8 +71,8 @@
           cargoSha256 = "sha256-RG/FvtrMCJB1BbMosSPlGJCKmIbRJT7ZUDkj1dVKWKg=";
         };
 
-        polkadot-node-on-parity-kusama = polkadot-node-9370;
-        polkadot-node-on-parity-polkadot = polkadot-node-9370;
+        polkadot-node-on-parity-kusama = polkadot-node-dep;
+        polkadot-node-on-parity-polkadot = polkadot-node-dep;
         polkadot-node-on-parity-rococo = polkadot-node-9390;
       };
     };

--- a/inputs/paritytech/statemine.nix
+++ b/inputs/paritytech/statemine.nix
@@ -1,6 +1,6 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, lib, system, crane
-    , systemCommonRust, subTools, ... }: {
+    , systemCommonRust, subnix, ... }: {
       packages = {
         statemine-node = let version = "release-parachains-v9380";
         in pkgs.stdenv.mkDerivation (rec {
@@ -25,7 +25,7 @@
           installPhase = ''
             mkdir --parents $out/bin && mv ./target/release/polkadot-parachain $out/bin
           '';
-        } // subTools.subenv);
+        } // subnix.subenv);
       };
     };
 }

--- a/inputs/paritytech/substrate.nix
+++ b/inputs/paritytech/substrate.nix
@@ -1,6 +1,17 @@
 { self, ... }: {
   perSystem = { config, self', inputs', pkgs, system, lib, ... }:
     let
+
+      subattrs = {
+        LD_LIBRARY_PATH = pkgs.lib.strings.makeLibraryPath [
+          pkgs.stdenv.cc.cc.lib
+          pkgs.llvmPackages.libclang.lib
+        ];
+        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+        PROTOC = "${pkgs.protobuf}/bin/protoc";
+        ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
+      };
+
       subenv = {
         doCheck = false;
         buildInputs = with pkgs; [ openssl zstd ];
@@ -11,15 +22,8 @@
             Security
             SystemConfiguration
           ]);
-        LD_LIBRARY_PATH = lib.strings.makeLibraryPath [
-          pkgs.stdenv.cc.cc.lib
-          pkgs.llvmPackages.libclang.lib
-        ];
-        LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
-        PROTOC = "${pkgs.protobuf}/bin/protoc";
-        ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib";
         RUST_BACKTRACE = "full";
-      };
+      } // subattrs;
       check-pallet = pkgs.writeShellApplication {
         name = "check-pallet";
         runtimeInputs = [ self'.packages.rust-nightly ];
@@ -30,7 +34,7 @@
         '';
       };
     in {
-      _module.args.subTools = rec { inherit subenv; };
+      _module.args.subnix = rec { inherit subenv subattrs; };
       packages = { inherit check-pallet; };
     };
 }

--- a/inputs/paritytech/zombienet/default.nix
+++ b/inputs/paritytech/zombienet/default.nix
@@ -29,7 +29,7 @@ in with prelude; rec {
       env = [{
         name = "RUST_LOG";
         value =
-          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace"
+          "info,runtime=debug,parachain=trace,cumulus-collator=trace,aura=trace,xcm=trace,pallet_ibc=trace,hyperspace=trace,hyperspace_parachain=trace,ics=trace,ics::routing=trace,ics::channel=trace"
           # RUST_LOG does not eats extra comma well, so fixed conditionally
           + (if rust_log_add != null then "," + rust_log_add else "");
       }];

--- a/tools/devnet-tools.nix
+++ b/tools/devnet-tools.nix
@@ -16,7 +16,6 @@
         ++ withUserContainerTools;
 
       buildDevnetImage = { name, devNet, container-tools }:
-        pkgs.lib.trace "Run Dali runtime on Composable node"
         pkgs.dockerTools.buildImage {
           inherit name;
           tag = "latest";


### PR DESCRIPTION
**Picasso Composable hyperspace runs and DOT transfered**

- updated centauri to version without beefy
- hyperspace image and binary with patched clients of picasso and composvble
- updated relay runtime (allowed to use exact version composable depends on)
- deleted dali runtime from hyperspace
- made chains explicit in devnet configs to prevent config errors
- tuned debug prameters for hyperspace and devnet rust builds
- split out substrate rust build parameters more
 