### PR TITLE
feat: add rococo option to endpoints

### DIFF
--- a/frontend/packages/shared/endpoints.ts
+++ b/frontend/packages/shared/endpoints.ts
@@ -46,7 +46,7 @@ export function getEnvironment(target: AvailableEndpoints) {
   return fetched === "" ? endpointPresets.mainnet[target] : fetched;
 }
 
-export type EndpointPreset = "local" | "stage" | "mainnet" | "dali";
+export type EndpointPreset = "local" | "stage" | "mainnet" | "dali" | "rococo";
 export type EndpointPresets = {
   [key in EndpointPreset]: {
     [key in AvailableEndpoints]: string;
@@ -85,6 +85,13 @@ export const endpointPresets: EndpointPresets = {
     picasso: "wss://picasso-rpc-lb.composablenodes.tech",
     karura: "wss://karura-rpc-0.aca-api.network",
     kusama: "wss://kusama-rpc.polkadot.io",
+    statemine: "wss://statemine-rpc.polkadot.io",
+    subsquid: "https://stats.composablenodes.tech/graphql",
+  },
+  rococo: {
+    picasso: "wss://picasso-rococo-rpc-lb.composablenodes.tech",
+    karura: "wss://karura-rpc-0.aca-api.network",
+    kusama: "wss://rococo-rpc.polkadot.io",
     statemine: "wss://statemine-rpc.polkadot.io",
     subsquid: "https://stats.composablenodes.tech/graphql",
   },


### PR DESCRIPTION
PR to add Rococo to Picasso endpoint list
Note that only Kusama and Picasso has actually been changed so any other xcm transfer will probably fail