### PR TITLE
centauri testing: reduce SpamProtectionDeposit to 1

### DIFF
--- a/code/parachain/runtime/composable/src/ibc.rs
+++ b/code/parachain/runtime/composable/src/ibc.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
-use ::ibc::core::{
+use common::governance::native::EnsureRootOrOneThirdNativeTechnical;
+use frame_support::traits::EitherOf;
+use ibc::core::{
 	ics24_host::identifier::PortId,
 	ics26_routing::context::{Module, ModuleId},
 };
-use common::governance::native::EnsureRootOrOneThirdNativeTechnical;
-use frame_support::traits::EitherOf;
 use pallet_ibc::{
 	light_client_common::RelayChain, routing::ModuleRouter, DenomToAssetId, IbcAssetIds, IbcAssets,
 };
@@ -57,7 +57,7 @@ impl DenomToAssetId<Runtime> for IbcDenomToAssetIdConversion {
 
 parameter_types! {
 	pub const RelayChainId: RelayChain = RelayChain::Rococo;
-	pub const SpamProtectionDeposit: Balance = 1_000_000_000_000_000;
+	pub const SpamProtectionDeposit: Balance = 1;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]

--- a/code/parachain/runtime/picasso/src/ibc.rs
+++ b/code/parachain/runtime/picasso/src/ibc.rs
@@ -1,9 +1,9 @@
-use ::ibc::core::{
+use common::ibc::{ForeignIbcIcs20Assets, MinimumConnectionDelaySeconds};
+use frame_support::traits::EitherOf;
+use ibc::core::{
 	ics24_host::identifier::PortId,
 	ics26_routing::context::{Module, ModuleId},
 };
-use common::ibc::{ForeignIbcIcs20Assets, MinimumConnectionDelaySeconds};
-use frame_support::traits::EitherOf;
 use pallet_ibc::{
 	light_client_common::RelayChain, routing::ModuleRouter, DenomToAssetId, IbcAssetIds, IbcAssets,
 };
@@ -55,7 +55,7 @@ impl DenomToAssetId<Runtime> for IbcDenomToAssetIdConversion {
 
 parameter_types! {
 	pub const RelayChainId: RelayChain = RelayChain::Rococo;
-	pub const SpamProtectionDeposit: Balance = 1_000_000_000_000_000;
+	pub const SpamProtectionDeposit: Balance = 1;
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Default)]


### PR DESCRIPTION
This is in order to avoid having too many tokens being reserved
while testing the DOT<>KSM bridge. Still safe as all extrinsics
are guarded by the techincal committee.

## Issue

<!-- Please replace this line with either a link to the ClickUp issue, or a reference to the GitHub issue. -->

## Additional Changes

<!-- Please replace this line with info that is not in the ClickUp ticket, eg: "also bumps dependency foo version". -->

## Checklist

- [ ] Updated the rust/typescript docs.
- [ ] Updated the `docs/`.