### PR TITLE
added `needs-benchmarks` to github labels to allow trigger relevant job

### DIFF
--- a/terraform/github.com/labels.tf
+++ b/terraform/github.com/labels.tf
@@ -4,6 +4,7 @@ locals {
     "misc"          = "I marked PR by `misc` label if it should not be in release notes"
     "dependencies"  = "bot"
     "lfs-detected!" = "bot: Warning Label for use when LFS is detected in the commits of a Pull Request"
+    "needs-benchmarks" = "bot: Runs benchmarks on target hardware"    
   }
 }
 


### PR DESCRIPTION
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github issue if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `Effect gate, automatically merged if passed`(effects-job) to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR