### PR TITLE
Use call_index attribute to fix warning and CI step build-all-benchmarks-packages

### DIFF
--- a/code/parachain/frame/assets/src/lib.rs
+++ b/code/parachain/frame/assets/src/lib.rs
@@ -153,6 +153,7 @@ pub mod pallet {
 		///  - If the account has insufficient free balance to make the transfer, or if `keep_alive`
 		///    cannot be respected.
 		///  - If the `dest` cannot be looked up.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::transfer())]
 		pub fn transfer(
 			origin: OriginFor<T>,
@@ -175,6 +176,7 @@ pub mod pallet {
 		///  - If the account has insufficient free balance to make the transfer, or if `keep_alive`
 		///    cannot be respected.
 		///  - If the `dest` cannot be looked up.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::transfer_native())]
 		pub fn transfer_native(
 			origin: OriginFor<T>,
@@ -195,6 +197,7 @@ pub mod pallet {
 		///  - If the account has insufficient free balance to make the transfer, or if `keep_alive`
 		///    cannot be respected.
 		///  - If the `dest` cannot be looked up.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::force_transfer())]
 		pub fn force_transfer(
 			origin: OriginFor<T>,
@@ -219,6 +222,7 @@ pub mod pallet {
 		///    cannot be respected.
 		///  - If the `dest` cannot be looked up.
 		#[pallet::weight(T::WeightInfo::force_transfer_native())]
+		#[pallet::call_index(3)]
 		pub fn force_transfer_native(
 			origin: OriginFor<T>,
 			source: <T::Lookup as StaticLookup>::Source,
@@ -239,6 +243,7 @@ pub mod pallet {
 		///  - When `origin` is not signed.
 		///  - If the `dest` cannot be looked up.
 		#[pallet::weight(T::WeightInfo::transfer_all())]
+		#[pallet::call_index(4)]
 		pub fn transfer_all(
 			origin: OriginFor<T>,
 			asset: T::AssetId,
@@ -265,6 +270,7 @@ pub mod pallet {
 		///  - When `origin` is not signed.
 		///  - If the `dest` cannot be looked up.
 		#[pallet::weight(T::WeightInfo::transfer_all_native())]
+		#[pallet::call_index(5)]
 		pub fn transfer_all_native(
 			origin: OriginFor<T>,
 			dest: <T::Lookup as StaticLookup>::Source,
@@ -286,6 +292,7 @@ pub mod pallet {
 		/// Creates a new asset, minting `amount` of funds into the `dest` account. Intended to be
 		/// used for creating wrapped assets, not associated with any project.
 		#[pallet::weight(T::WeightInfo::mint_initialize())]
+		#[pallet::call_index(6)]
 		pub fn mint_initialize(
 			origin: OriginFor<T>,
 			#[pallet::compact] amount: T::Balance,
@@ -302,6 +309,7 @@ pub mod pallet {
 		/// account can use the democracy pallet to mint further assets, or if the governance_origin
 		/// is set to an owned account, using signed transactions. In general the
 		/// `governance_origin` should be generated from the pallet id.
+		#[pallet::call_index(7)]
 		#[pallet::weight(T::WeightInfo::mint_initialize())]
 		pub fn mint_initialize_with_governance(
 			origin: OriginFor<T>,
@@ -319,6 +327,7 @@ pub mod pallet {
 		}
 
 		/// Mints `amount` of `asset_id` into the `dest` account.
+		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::mint_into())]
 		pub fn mint_into(
 			origin: OriginFor<T>,
@@ -333,6 +342,7 @@ pub mod pallet {
 		}
 
 		/// Burns `amount` of `asset_id` into the `dest` account.
+		#[pallet::call_index(9)]
 		#[pallet::weight(T::WeightInfo::burn_from())]
 		pub fn burn_from(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/bonded-finance/src/lib.rs
+++ b/code/parachain/frame/bonded-finance/src/lib.rs
@@ -203,6 +203,7 @@ pub mod pallet {
 		/// parameter.
 		///
 		/// Emits a `NewOffer`.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::offer())]
 		pub fn offer(
 			origin: OriginFor<T>,
@@ -231,6 +232,7 @@ pub mod pallet {
 		///
 		/// Emits a `NewBond`.
 		/// Possibly Emits a `OfferCompleted`.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::bond())]
 		pub fn bond(
 			origin: OriginFor<T>,
@@ -251,6 +253,7 @@ pub mod pallet {
 		/// The dispatch origin for this call must be _Signed_ and the sender must be `AdminOrigin`
 		///
 		/// Emits a `OfferCancelled`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::cancel())]
 		#[transactional]
 		pub fn cancel(origin: OriginFor<T>, offer_id: T::BondOfferId) -> DispatchResult {

--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -267,6 +267,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Initialize the pallet at the current timestamp.
+		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::initialize(TotalContributors::<T>::get()))]
 		pub fn initialize(origin: OriginFor<T>) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
@@ -275,6 +276,7 @@ pub mod pallet {
 		}
 
 		/// Initialize the pallet at the given timestamp.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::initialize(TotalContributors::<T>::get()))]
 		pub fn initialize_at(origin: OriginFor<T>, at: MomentOf<T>) -> DispatchResult {
 			T::AdminOrigin::ensure_origin(origin)?;
@@ -290,6 +292,7 @@ pub mod pallet {
 		/// already has a reward, it will be replaced by the new reward value.
 		///
 		/// Can only be called before `initialize`.
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::populate(rewards.len() as _))]
 		pub fn populate(
 			origin: OriginFor<T>,
@@ -308,6 +311,7 @@ pub mod pallet {
 		/// ```haskell
 		/// proof = sign (concat prefix (hex reward_account))
 		/// ```
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::associate(TotalContributors::<T>::get()))]
 		pub fn associate(
 			origin: OriginFor<T>,
@@ -321,6 +325,7 @@ pub mod pallet {
 		/// Claim a reward from the associated reward account.
 		/// A previous call to `associate` should have been made.
 		/// If logic gate pass, no fees are applied.
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::claim(TotalContributors::<T>::get()))]
 		pub fn claim(origin: OriginFor<T>) -> DispatchResultWithPostInfo {
 			let reward_account = ensure_signed(origin)?;
@@ -331,6 +336,7 @@ pub mod pallet {
 			Ok(Pays::No.into())
 		}
 
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::unlock_rewards_for(reward_accounts.len() as _))]
 		pub fn unlock_rewards_for(
 			origin: OriginFor<T>,
@@ -343,6 +349,7 @@ pub mod pallet {
 
 		/// Adds all accounts in the `additions` vector. Add may be called even if the pallet has
 		/// been initialized.
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::populate(additions.len() as _))]
 		pub fn add(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/currency-factory/src/lib.rs
+++ b/code/parachain/frame/currency-factory/src/lib.rs
@@ -133,6 +133,7 @@ pub mod pallet {
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::add_range())]
 		pub fn add_range(origin: OriginFor<T>, length: u64) -> DispatchResultWithPostInfo {
 			T::AddOrigin::ensure_origin(origin)?;
@@ -149,6 +150,7 @@ pub mod pallet {
 		}
 
 		/// Sets metadata
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_metadata())]
 		pub fn set_metadata(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/governance-registry/src/lib.rs
+++ b/code/parachain/frame/governance-registry/src/lib.rs
@@ -74,6 +74,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Sets the value of an `asset_id` to the signed account id. Only callable by root.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::set())]
 		pub fn set(
 			origin: OriginFor<T>,
@@ -87,6 +88,7 @@ pub mod pallet {
 		}
 
 		/// Sets the value of an `asset_id` to root. Only callable by root.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::grant_root())]
 		pub fn grant_root(
 			origin: OriginFor<T>,
@@ -99,6 +101,7 @@ pub mod pallet {
 		}
 
 		/// Removes mapping of an `asset_id`. Only callable by root.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::remove())]
 		pub fn remove(origin: OriginFor<T>, asset_id: T::AssetId) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -345,6 +345,7 @@ pub mod pallet {
 		/// assets already exists in the runtime.
 		///
 		/// Emits `PoolCreated` event when successful.
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::create())]
 		pub fn create(origin: OriginFor<T>, pool: PoolInitConfigurationOf<T>) -> DispatchResult {
 			T::PoolCreationOrigin::ensure_origin(origin)?;
@@ -355,6 +356,7 @@ pub mod pallet {
 		/// Execute a buy order on pool.
 		///
 		/// Emits `Swapped` event when successful.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::buy())]
 		pub fn buy(
 			origin: OriginFor<T>,
@@ -373,6 +375,7 @@ pub mod pallet {
 		/// The `quote_amount` is always the quote asset amount (A/B => B), (B/A => A).
 		///
 		/// Emits `Swapped` event when successful.
+		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::swap())]
 		pub fn swap(
 			origin: OriginFor<T>,
@@ -389,6 +392,7 @@ pub mod pallet {
 		/// Add liquidity to the given pool.
 		///
 		/// Emits `LiquidityAdded` event when successful.
+		#[pallet::call_index(3)]
 		#[pallet::weight(T::WeightInfo::add_liquidity())]
 		pub fn add_liquidity(
 			origin: OriginFor<T>,
@@ -405,6 +409,7 @@ pub mod pallet {
 		/// Remove liquidity from the given pool.
 		///
 		/// Emits `LiquidityRemoved` event when successful.
+		#[pallet::call_index(4)]
 		#[pallet::weight(T::WeightInfo::remove_liquidity())]
 		pub fn remove_liquidity(
 			origin: OriginFor<T>,
@@ -417,6 +422,7 @@ pub mod pallet {
 			Ok(())
 		}
 
+		#[pallet::call_index(5)]
 		#[pallet::weight(10_000)]
 		#[transactional]
 		pub fn enable_twap(origin: OriginFor<T>, pool_id: T::PoolId) -> DispatchResult {

--- a/code/parachain/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/code/parachain/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -192,7 +192,7 @@ pub mod pallet {
 		///
 		/// If `asset_id` is `None`, then native asset is used.
 		/// Else new asset is configured and ED is on hold.
-		#[pallet::call_index(1)]
+		#[pallet::call_index(0)]
 		#[pallet::weight(T::WeightInfo::set_payment_asset())]
 		pub fn set_payment_asset(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/transaction-payment/asset-tx-payment/src/lib.rs
+++ b/code/parachain/frame/transaction-payment/asset-tx-payment/src/lib.rs
@@ -192,6 +192,7 @@ pub mod pallet {
 		///
 		/// If `asset_id` is `None`, then native asset is used.
 		/// Else new asset is configured and ED is on hold.
+		#[pallet::call_index(1)]
 		#[pallet::weight(T::WeightInfo::set_payment_asset())]
 		pub fn set_payment_asset(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/vault/src/lib.rs
+++ b/code/parachain/frame/vault/src/lib.rs
@@ -380,6 +380,7 @@ pub mod pallet {
 		///  - When the origin is not signed.
 		///  - When `deposit < CreationDeposit`.
 		///  - Origin has insufficient funds to lock the deposit.
+		#[pallet::call_index(0)]
 		#[transactional]
 		#[pallet::weight(<T as Config>::WeightInfo::create())]
 		pub fn create(
@@ -422,6 +423,7 @@ pub mod pallet {
 		///
 		/// A tombstoned vault still allows for withdrawals but blocks deposits, and requests all
 		/// strategies to return their funds.
+		#[pallet::call_index(1)]
 		#[pallet::weight(<T as Config>::WeightInfo::claim_surcharge())]
 		pub fn claim_surcharge(
 			origin: OriginFor<T>,
@@ -469,7 +471,7 @@ pub mod pallet {
 				}
 			})
 		}
-
+		#[pallet::call_index(2)]
 		#[pallet::weight(<T as Config>::WeightInfo::add_surcharge())]
 		pub fn add_surcharge(
 			origin: OriginFor<T>,
@@ -495,6 +497,7 @@ pub mod pallet {
 			})
 		}
 
+		#[pallet::call_index(3)]
 		#[pallet::weight(<T as Config>::WeightInfo::delete_tombstoned())]
 		pub fn delete_tombstoned(
 			origin: OriginFor<T>,
@@ -542,6 +545,7 @@ pub mod pallet {
 		/// # Errors
 		///  - When the origin is not signed.
 		///  - When `deposit < MinimumDeposit`.
+		#[pallet::call_index(4)]
 		#[pallet::weight(<T as Config>::WeightInfo::deposit())]
 		pub fn deposit(
 			origin: OriginFor<T>,
@@ -563,6 +567,7 @@ pub mod pallet {
 		///  - When the origin is not signed.
 		///  - When `lp_amount < MinimumWithdrawal`.
 		///  - When the vault has insufficient amounts reserved.
+		#[pallet::call_index(5)]
 		#[pallet::weight(<T as Config>::WeightInfo::withdraw())]
 		pub fn withdraw(
 			origin: OriginFor<T>,
@@ -583,6 +588,7 @@ pub mod pallet {
 		/// # Errors
 		///  - When the origin is not root.
 		///  - When `vault` does not exist.
+		#[pallet::call_index(6)]
 		#[pallet::weight(<T as Config>::WeightInfo::emergency_shutdown())]
 		pub fn emergency_shutdown(
 			origin: OriginFor<T>,
@@ -602,6 +608,7 @@ pub mod pallet {
 		/// # Errors
 		///  - When the origin is not root.
 		///  - When `vault` does not exist.
+		#[pallet::call_index(7)]
 		#[pallet::weight(<T as Config>::WeightInfo::start_())]
 		pub fn start(origin: OriginFor<T>, vault: T::VaultId) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
@@ -618,6 +625,7 @@ pub mod pallet {
 		///
 		/// # Emits
 		///  - Event::LiquidateStrategy
+		#[pallet::call_index(8)]
 		#[pallet::weight(10_000)]
 		pub fn liquidate_strategy(
 			origin: OriginFor<T>,

--- a/code/parachain/frame/vault/src/mocks/strategy.rs
+++ b/code/parachain/frame/vault/src/mocks/strategy.rs
@@ -67,6 +67,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Mints new tokens and sends them to self, mocking the generating of revenue through DeFi.
+		#[pallet::call_index(0)]
 		#[pallet::weight(10_000)]
 		pub fn generate_revenue(
 			origin: OriginFor<T>,
@@ -81,6 +82,7 @@ pub mod pallet {
 		}
 
 		/// Reports the current balance to the vault.
+		#[pallet::call_index(1)]
 		#[pallet::weight(10_000)]
 		pub fn report(origin: OriginFor<T>, vault: VaultIdOf<T>) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;
@@ -92,6 +94,7 @@ pub mod pallet {
 		}
 
 		/// Queries the vault for the current re-balance strategy and executes it.
+		#[pallet::call_index(2)]
 		#[pallet::weight(10_000)]
 		pub fn rebalance(origin: OriginFor<T>, vault: VaultIdOf<T>) -> DispatchResultWithPostInfo {
 			ensure_root(origin)?;


### PR DESCRIPTION
- use `#[pallet::call_index(0)]` for each callable function in pallet
- it is by recommendation:

```
 Please ensure that all calls have the `pallet::call_index` attribute or that the
                     `dev-mode` of the pallet is enabled. For more info see:
                     <https://github.com/paritytech/substrate/pull/12891> and
                     <https://github.com/paritytech/substrate/pull/11381>.
```
- it will fix CI step build-all-benchmarks-packages