### PR TITLE
release v6.10021.0 along with release configuration improvements 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
+
+
 - [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
 - [ ] I marked PR by `misc` label if it should not be in release notes
-- [ ] I have linked Zenhub/Github issue if one exists
+- [ ] I have linked Zenhub/Github or any other reference item if one exists
 - [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
 - [ ] I waited and did best effort for `Effect gate, automatically merged if passed`(effects-job) to finish with success(green check mark) with my changes
 - [ ] I have added at least one reviewer in reviewers list

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "composable"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "color-eyre",
  "composable-node",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "composable-node"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "assets-rpc",
  "assets-runtime-api",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "composable-runtime"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "assets-runtime-api",
  "common",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "composable-runtime-wasm"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "composable-runtime",
 ]
@@ -9972,7 +9972,7 @@ dependencies = [
 
 [[package]]
 name = "picasso-runtime"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "assets-runtime-api",
  "common",
@@ -10067,7 +10067,7 @@ dependencies = [
 
 [[package]]
 name = "picasso-runtime-wasm"
-version = "6.10020.0"
+version = "6.10021.0"
 dependencies = [
  "picasso-runtime",
 ]

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -6,7 +6,7 @@ name = "composable"
 version = { workspace = true }
 
 [workspace.package]
-version = "6.10020.0"
+version = "6.10021.0"
 
 [[bin]]
 name = "composable"

--- a/code/parachain/runtime/composable/src/version.rs
+++ b/code/parachain/runtime/composable/src/version.rs
@@ -13,7 +13,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10020,
+	spec_version: 10021,
 	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/code/parachain/runtime/picasso/src/version.rs
+++ b/code/parachain/runtime/picasso/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10020,
+	spec_version: 10021,
 	impl_version: 2,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/flake/release.nix
+++ b/flake/release.nix
@@ -56,12 +56,12 @@
           name = "tag-release";
           runtimeInputs = [ pkgs.git pkgs.yq ];
           text = ''
-            git tag --sign "release-v$1" --message "RC" && git push origin "release-v$1"
+            git tag --sign "release-v$1" --message "RC" && git push origin "release-v$1" --force
           '';
         };
 
         delete-release-tag-unsafe = pkgs.writeShellApplication {
-          name = "tag-release";
+          name = "delete-release-tag-unsafe";
           runtimeInputs = [ pkgs.git pkgs.yq ];
           text = ''
             # shellcheck disable=SC2015

--- a/terraform/github.com/labels.tf
+++ b/terraform/github.com/labels.tf
@@ -1,9 +1,10 @@
 
 locals {
   labels = {
-    "misc"          = "I marked PR by `misc` label if it should not be in release notes"
-    "dependencies"  = "bot"
-    "lfs-detected!" = "bot: Warning Label for use when LFS is detected in the commits of a Pull Request"
+    "misc"             = "I marked PR by `misc` label if it should not be in release notes"
+    "dependencies"     = "bot"
+    "lfs-detected!"    = "bot: Warning Label for use when LFS is detected in the commits of a Pull Request"
+    "needs-benchmarks" = "bot: Runs benchmarks on target hardware"
   }
 }
 

--- a/terraform/github.com/team.tf
+++ b/terraform/github.com/team.tf
@@ -40,7 +40,7 @@ resource "github_repository_collaborators" "roles" {
   }
 
   user {
-    permission = "push"
+    permission = "maintain"
     username   = "RustNinja"
   }
 


### PR DESCRIPTION
- **Bumped release versions**
- made @RustNinja to be maintainer to allow do releases
- ensured benchmarks label job is always here 
- have run `nix run .#tag-release 6.10021.0` on this PR (https://github.com/ComposableFi/composable/actions/runs/4891575811)
- improved PR template by asking adding more context from any reference

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github issue if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `Effect gate, automatically merged if passed`(effects-job) to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR