### PR TITLE
Added amount parameter to farming pallet for deposit extrinsic

### DIFF
--- a/code/parachain/frame/farming/src/benchmarking.rs
+++ b/code/parachain/frame/farming/src/benchmarking.rs
@@ -59,6 +59,7 @@ fn deposit_lp_tokens<T: Config>(
 	assert_ok!(Farming::<T>::deposit(
 		RawOrigin::Signed(account_id.clone()).into(),
 		pool_currency_id.into(),
+		amount
 	));
 }
 
@@ -104,7 +105,7 @@ benchmarks! {
 			100u32.into(),
 		));
 
-	}: _(RawOrigin::Signed(origin), pool_currency_id.into())
+	}: _(RawOrigin::Signed(origin), pool_currency_id.into(), 100u32.into())
 
 	withdraw {
 		let origin: T::AccountId = account("Origin", 0, 0);

--- a/code/parachain/frame/farming/src/lib.rs
+++ b/code/parachain/frame/farming/src/lib.rs
@@ -323,10 +323,13 @@ pub mod pallet {
 		#[pallet::call_index(2)]
 		#[pallet::weight(T::WeightInfo::deposit())]
 		#[transactional]
-		pub fn deposit(origin: OriginFor<T>, pool_currency_id: AssetIdOf<T>) -> DispatchResult {
+		pub fn deposit(
+			origin: OriginFor<T>,
+			pool_currency_id: AssetIdOf<T>,
+			amount: BalanceOf<T>,
+		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 			// reserve lp tokens to prevent spending
-			let amount = T::MultiCurrency::free_balance(pool_currency_id, &who);
 			T::MultiCurrency::reserve(pool_currency_id, &who, amount)?;
 
 			// deposit lp tokens as stake

--- a/code/parachain/frame/farming/src/tests.rs
+++ b/code/parachain/frame/farming/src/tests.rs
@@ -128,7 +128,7 @@ fn should_overwrite_existing_schedule() {
 fn mint_and_deposit(account_id: AccountId, amount: Balance) {
 	assert_ok!(Tokens::set_balance(RuntimeOrigin::root(), account_id, POOL_CURRENCY_ID, amount, 0));
 
-	assert_ok!(Farming::deposit(RuntimeOrigin::signed(account_id), POOL_CURRENCY_ID,));
+	assert_ok!(Farming::deposit(RuntimeOrigin::signed(account_id), POOL_CURRENCY_ID, amount));
 }
 
 #[test]


### PR DESCRIPTION
This PR introduced additional parameter `amount` to allow user `deposit` to specify any amount of LP tokens.
issue https://github.com/ComposableFi/composable/issues/3582
- upgrade runtime
- no node update

@kkast 