### PR TITLE
Release commit with some cleanup to trigger build

### DIFF
--- a/rfcs/0011-releases.md
+++ b/rfcs/0011-releases.md
@@ -80,47 +80,6 @@ Create a tag `staging-fe-v[MAJOR].[MINOR]-picasso-[FE_VERSION_NUMBER]`
 
 **[FE_VERSION_NUMBER] is a number incremented on each release.**
 
-
-### 3.2.4 Security
-
-Tip of the branch from which runtime release is considered should be signed by at least 2 keys owned by Technical committee or by Council members.
-
-#### 3.2.4.1 Examples
-
-Alice and Bob review changes and sign.
-
-Charlie verifies.
-
-Releasing from a branch:
-```shell
-
- # All
- git switch release-vx.y.3
- 
- # Alice signs
- git tag --sign "release-vx.y.3/alice" --message "reviewed"
- git push origin "release-vx.y.3/alice"
-
- # Bob signs
- git tag --sign "release-vx.y.3/bob" --message "reviewed"
- 
- # Charlie looks that each tag is signed and references relevant commit
- git tag --list | grep release-vx.y.3 | xargs git tag --verify 
-```
-
-In case of release from tag:
-```shell
-# Checkout old tag
-git checkout release-v1.10001.0 --force
-
-# Make diff with new release tag to review changes
-git merge release-v1.10002.0 --no-commit --squash
-
-# Sign new tag
-git checkout release-v1.10002.0 --force
-git tag --sign "release-v1.10002.0-alice" --message "reviewed"
-```
-
 ## 4. Implementation
 
 The following section lays out the release steps for each release in a checklist form.


### PR DESCRIPTION
I am going to release from this commit with recently reverted Farming/Reward and CW pallets and fixes.

It will require node update for RPC and Runtime upgrade for pallets.

Removed not used security procedure form docs.
 
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR