### PR TITLE
More fixes to CI and modes of operation of our runtime

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -437,8 +437,10 @@ jobs:
 
   build-product-darwin:
     name: "build-product-darwin"
+    outputs:
+      ok: ${{ steps.ok.outputs.ok }}       
     continue-on-error: false
-    if: ${{ inputs.github_event_name == 'push' || inputs.github_event_name == 'merge_group' || (inputs.github_event_name == 'pull_request' && inputs.github_event_pull_request_head_repo_id == 383289760) }}    
+    if: ${{ inputs.github_event_name == 'merge_group' || (inputs.github_event_name == 'pull_request' && inputs.github_event_pull_request_head_repo_id == 383289760) }}    
     strategy:
       matrix:
         arch: [aarch64-darwin]
@@ -469,6 +471,8 @@ jobs:
             nix build .#devnet-picasso
             nix-store --query --references $(realpath result) | xargs nix-store --realise | xargs nix-store  --query --requisites | cachix push --compression-level 16 --compression-method zstd --jobs 16 composable-community
           )
+      - id: ok
+        run: echo "ok=true" >> "$GITHUB_OUTPUT"
 
   build-all-docs-packages:
     outputs:
@@ -536,15 +540,16 @@ jobs:
         - build-all-production-deps
         - dependency-review
         - nix-flake-check
+        - build-product-darwin
       steps:           
-        - if: ${{ needs.nix-flake-check.outputs.ok == 'true' && needs.dependency-review.outputs.ok == 'true' && needs.build-all-production-deps.outputs.ok == 'true' && needs.build-all-misc-packages.outputs.ok == 'true' && needs.build-all-docs-packages.outputs.ok == 'true' && needs.build-all-ci-packages.outputs.ok == 'true' && needs.build-all-benchmarks-packages.outputs.ok == 'true' }}
+        - if: ${{ needs.nix-flake-check.outputs.ok == 'true' && needs.dependency-review.outputs.ok == 'true' && needs.build-all-production-deps.outputs.ok == 'true' && needs.build-all-misc-packages.outputs.ok == 'true' && needs.build-all-docs-packages.outputs.ok == 'true' && needs.build-all-ci-packages.outputs.ok == 'true' && needs.build-all-benchmarks-packages.outputs.ok == 'true' && needs.build-product-darwin.outputs.ok == 'true' }}
           run: |
             echo "+"
-        - if: ${{ needs.nix-flake-check.outputs.ok != 'true' || needs.dependency-review.outputs.ok != 'true' || needs.build-all-production-deps.outputs.ok != 'true' || needs.build-all-misc-packages.outputs.ok != 'true' || needs.build-all-docs-packages.outputs.ok != 'true' || needs.build-all-ci-packages.outputs.ok != 'true' || needs.build-all-benchmarks-packages.outputs.ok != 'true' }}
+        - if: ${{ needs.nix-flake-check.outputs.ok != 'true' || needs.dependency-review.outputs.ok != 'true' || needs.build-all-production-deps.outputs.ok != 'true' || needs.build-all-misc-packages.outputs.ok != 'true' || needs.build-all-docs-packages.outputs.ok != 'true' || needs.build-all-ci-packages.outputs.ok != 'true' || needs.build-all-benchmarks-packages.outputs.ok != 'true' || needs.build-product-darwin.outputs.ok != 'true' }}
           run: |
             echo "-"      
             exit 42
-        - if: ${{ always() && (needs.nix-flake-check.outputs.ok != 'true' || needs.dependency-review.outputs.ok != 'true' || needs.build-all-production-deps.outputs.ok != 'true' || needs.build-all-misc-packages.outputs.ok != 'true' || needs.build-all-docs-packages.outputs.ok != 'true' || needs.build-all-ci-packages.outputs.ok != 'true' || needs.build-all-benchmarks-packages.outputs.ok != 'true') }}
+        - if: ${{ always() && (needs.nix-flake-check.outputs.ok != 'true' || needs.dependency-review.outputs.ok != 'true' || needs.build-all-production-deps.outputs.ok != 'true' || needs.build-all-misc-packages.outputs.ok != 'true' || needs.build-all-docs-packages.outputs.ok != 'true' || needs.build-all-ci-packages.outputs.ok != 'true' || needs.build-all-benchmarks-packages.outputs.ok != 'true' || needs.build-product-darwin.outputs.ok != 'true' ) }}
           uses: andymckay/cancel-action@0.3
           with:     
             token: ${{ secrets.CANCEL_GITHUB_TOKEN }}

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -442,13 +442,11 @@ jobs:
     strategy:
       matrix:
         arch: [aarch64-darwin]
-    timeout-minutes: 45
     needs: 
       - privilege-check
     runs-on:
       - ${{ matrix.arch }}
     concurrency:
-      # this intentionally fails all other jobs because mac is one and used only to cache
       group: ${{ inputs.github_workflow }}-build-product-darwin-${{ matrix.arch }}
       cancel-in-progress: true
     steps:            
@@ -717,7 +715,6 @@ jobs:
       group: ${{ inputs.github_workflow }}-devnet-integration-tests-${{ matrix.arch }}-${{ github.event.pull_request.title }}
       cancel-in-progress: true
     steps:
-      # This isn't templated, since checkout needs to happen before templating occurs.
       - name: Set up Nix
         uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,4 @@ override.tf.json
 terraform.rc
 
 data/**
+data-agent/**

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,7 @@
 {
   description = "Composable Finance";
   inputs = {
-    # basically this is old release locked, better not to updated as long as possible as it can break anything
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    # needed as some tools of old version on stable releases, so can start using new tooling until full switch to release
     nixpkgs-latest.url =
       "github:NixOS/nixpkgs/0135b7a556ee60144b143b071724fa44348a188e";
     flake-parts.url = "github:hercules-ci/flake-parts";
@@ -37,7 +35,6 @@
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    # for mac builder
     darwin = {
       url = "github:lnl7/nix-darwin/master";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake/all.nix
+++ b/flake/all.nix
@@ -49,6 +49,9 @@
         benchmarks-check
       ]);
 
+      all-production = pkgs.linkFarmFromDrvs "all-production"
+        (with self'.packages; [ livenet-composable ]);
+
       all-platforms = pkgs.linkFarmFromDrvs "all-platforms"
         (with self'.packages; [
           cmc-api
@@ -63,7 +66,6 @@
           devnet-initialize-script-picasso-persistent
           devnet-integration-tests
           devnet-picasso-complete
-          livenet-composable
           hyperspace-composable-rococo-picasso-rococo
           hyperspace-composable-rococo-picasso-rococo-image
         ]);

--- a/flake/darwin-configurations.nix
+++ b/flake/darwin-configurations.nix
@@ -2,7 +2,7 @@
 }: {
   flake = {
     darwinConfigurations = {
-      "62260" = self.inputs.darwin.lib.darwinSystem {
+      default = self.inputs.darwin.lib.darwinSystem {
         system = "aarch64-darwin";
         modules = [
           ({ config, pkgs, ... }: {

--- a/inputs/chevdor/subwasm.nix
+++ b/inputs/chevdor/subwasm.nix
@@ -3,24 +3,24 @@
     , subnix, ... }: {
       packages = rec {
         subwasm = let
-          version = "v0.19.0";
+          name = "subwasm";
           src = pkgs.fetchFromGitHub {
             owner = "chevdor";
-            repo = "subwasm";
-            rev = "refs/tags/${version}";
-            hash = "sha256-DCPpGn0CrngmDP1QuK+Y9hffoD04yS+FenjQ5d/f49U=";
+            repo = name;
+            rev = "8c7c1457f203b056bb0c9d28a1d644a6047db30b";
+            hash = "sha256-3c7sl6j3CfWCuHDhlKCkoyehXnghtaxe508rhYdLjDc=";
           };
         in crane.stable.buildPackage (subnix.subenv // {
-          name = "subwasm";
+          name = name;
           cargoArtifacts = crane.stable.buildDepsOnly (subnix.subenv // {
             inherit src;
             doCheck = false;
             cargoTestCommand = "";
             nativeBuildInputs = systemCommonRust.darwin-deps;
           });
-          inherit src version;
+          inherit src;
           cargoTestCommand = "";
-          meta = { mainProgram = "subwasm"; };
+          meta = { mainProgram = name; };
         });
 
         subwasm-release-body = let


### PR DESCRIPTION
- some binary blob in chain spec must start from 0x
- kusama spec name (as in kusama spec) referenced by proper id
- fixes from subwasm to generate proper scale encode subxt rust client to substrate node and scale serde
- easier to shell on m1 for anybody
- ignore data folder produced by metrics agent
- removed building livedevnet all the time from main ci flow
- made m1 must for build

does not require redeploy, all should work as before (and better for indexers as per spec i guess)

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR