### PR TITLE
Introduce globally unique deterministically derived Tinkernet multisig XCM configs to Picasso

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -5587,6 +5587,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "invarch-xcm-builder"
+version = "0.1.0"
+source = "git+https://github.com/InvArch/InvArch-XCM-Builder?rev=c704c0f2d4c436f96eff10d06c197527b46b3536#c704c0f2d4c436f96eff10d06c197527b46b3536"
+dependencies = [
+ "frame-support",
+ "log 0.4.17",
+ "parity-scale-codec",
+ "sp-core",
+ "sp-io",
+ "xcm",
+ "xcm-executor",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10010,6 +10024,7 @@ dependencies = [
  "ibc 0.15.0",
  "ibc-primitives",
  "ibc-runtime-api",
+ "invarch-xcm-builder",
  "log 0.4.17",
  "orml-tokens",
  "orml-traits",

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -318,6 +318,8 @@ mmr-rpc = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1
 
 subxt = { git = "https://github.com/paritytech/subxt", rev = "2a913a3aa99a07f7acaedbbaeed6925d34627303", default-features = false }
 
+# Only needed until the configs get merged into xcm-builder: https://github.com/paritytech/polkadot/pull/7165
+invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", rev = "c704c0f2d4c436f96eff10d06c197527b46b3536", default-features = false }
 
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -128,6 +128,8 @@ ibc-runtime-api = { workspace = true, default-features = false }
 pallet-ibc = { workspace = true, default-features = false }
 pallet-ibc-ping = { workspace = true, default-features = false }
 
+invarch-xcm-builder = { workspace = true, default-features = false }
+
 [features]
 builtin-wasm = []
 testnet = []

--- a/code/parachain/runtime/picasso/src/xcmp.rs
+++ b/code/parachain/runtime/picasso/src/xcmp.rs
@@ -27,7 +27,7 @@ use xcm_builder::{
 	AllowTopLevelPaidExecutionFrom, EnsureXcmOrigin, FixedWeightBounds, ParentIsPreset,
 	RelayChainAsNative, SiblingParachainAsNative, SiblingParachainConvertsVia,
 	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue,
-	TakeWeightCredit,
+	TakeWeightCredit, WithComputedOrigin,
 };
 use xcm_executor::{
 	traits::{ConvertOrigin, DropAssets},
@@ -55,6 +55,11 @@ pub type Barrier = (
 	AllowSubscriptionsFrom<ParentOrSiblings>,
 	AllowTopLevelPaidExecutionFrom<Everything>,
 	TakeWeightCredit,
+	WithComputedOrigin<
+		AllowTopLevelPaidExecutionFrom<invarch_xcm_builder::TinkernetMultisigMultiLocation>,
+		UniversalLocation,
+		ConstU32<8>,
+	>,
 );
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
@@ -78,6 +83,8 @@ pub type LocationToAccountId = (
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.
 	AccountId32Aliases<RelayNetwork, AccountId>,
+	// Mapping Tinkernet multisig to the correctly derived AccountId32.
+	invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
 );
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `Origin` instance,
@@ -97,6 +104,8 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `Origin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
+	// Derives signed AccountId32 origins for Tinkernet multisigs.
+	invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
 	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
 	XcmPassthrough<RuntimeOrigin>,
 );


### PR DESCRIPTION
This PR adds the XCM configs necessary to allow Tinkernet multisigs to transact on Picasso.

Tinkernet multisigs have the following MultiLocation pattern:
```rust
MultiLocation {
    parents: _, // ancestry depends on the point of reference. 0 if from parent, 1 if from sibling.
    interior: Junctions::X3(
        Junction::Parachain(2125), // Tinkernet ParaId in Kusama/Rococo.
        Junction::PalletInstance(71), // Pallet INV4, from which the multisigs originate.
        Junction::GeneralIndex(_) // Index from which the multisig account is derived.
    )
}
```

The following are the configs added by this PR to give the multisigs accounts and origins in Picasso:

### In Barrier
```rust
WithComputedOrigin<
  AllowTopLevelPaidExecutionFrom<invarch_xcm_builder::TinkernetMultisigMultiLocation>,
  UniversalLocation,
  ConstU32<8>,
>,
```
This is a barrier from the official xcm-builder crate that computes descended origins and by using `AllowTopLevelPaidExecution<TinkernetMultisigMultiLocation>>` within it allows for our multisig XCM messages to pass through.

### In LocationToAccountId
```rust
invarch_xcm_builder::TinkernetMultisigAsAccountId<AccountId>,
```
This MultiLocation converter derives an AccountId for locations matching the one described above, it does so by using the same exact derivation function used in Tinkernet, this is important to make sure the multisigs maintain the same address across all chains, providing the best UX possible.
Because this derivation happens in Picasso, it means the whole process is trustless and removes any possibility of account impersonation!

### In XcmOriginToTransactDispatchOrigin
```rust
invarch_xcm_builder::DeriveOriginFromTinkernetMultisig<RuntimeOrigin>,
```
Same as explained above, except here we need to derive the AccountId and wrap it with a RawOrigin::Signed origin so this account can use the `Transact` XCM instruction and thus call extrinsics in the Picasso runtime's pallets.

**Obs:** These XCM configs are being pulled from a [dependency](https://github.com/InvArch/InvArch-XCM-Builder), however this is only a temporary measure, as there is an [open PR](https://github.com/paritytech/polkadot/pull/7165) to merge them into paritytech/polkadot under the xcm-builder crate, which this runtime is already dependent on


- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR