### PR TITLE
gh does not allows empty inputs

### DIFF
--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/pr-workflow.yml
     with:
       github_event_name: ${{ github.event_name }}
-      github_event_pull_request_head_repo_id : ${{ github.event.pull_request.head.repo.id }}
+      github_event_pull_request_head_repo_id : ${{ github.event.pull_request.head.repo.id || 0 }}
       github_workflow: ${{ github.workflow }}
       github_event_pull_request_head_sha: ${{ github.event.pull_request.head.sha }}
       flow: ${{( github.event_name == 'push' && 'push' ) || ( github.event_name == 'merge_group' && 'merge_queue_check' ) || ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.id != 383289760 && 'pr_from_fork' ) || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == 383289760 && 'pr_from_branch' )}}      


### PR DESCRIPTION

- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR