### PR TITLE
enable DEX/AMM pallet precompile in CW contracts in Picasso runtime

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -10016,6 +10016,8 @@ dependencies = [
  "composable-support",
  "composable-traits",
  "cosmwasm-runtime-api",
+ "cosmwasm-vm",
+ "cosmwasm-vm-wasmi",
  "crowdloan-rewards-runtime-api",
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -3123,6 +3123,7 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-vm",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -10099,7 +10100,6 @@ dependencies = [
  "reward",
  "reward-rpc-runtime-api",
  "scale-info",
- "serde-json-wasm",
  "serde_json",
  "smallvec 1.10.0",
  "sp-api",
@@ -14233,15 +14233,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-json-wasm"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2150,31 +2150,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmwasm-crypto"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75836a10cb9654c54e77ee56da94d592923092a10b369cdb0dbd56acefc16340"
-dependencies = [
- "digest 0.10.6",
- "ed25519-zebra",
- "k256",
- "rand_core 0.6.4",
- "thiserror",
-]
-
-[[package]]
 name = "cosmwasm-derive"
 version = "1.2.0"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=34af48221c90e6818fe341d6d5b15116dfeab671#34af48221c90e6818fe341d6d5b15116dfeab671"
-dependencies = [
- "syn 1.0.109",
-]
-
-[[package]]
-name = "cosmwasm-derive"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9f7f0e51bfc7295f7b2664fe8513c966428642aa765dad8a74acdab5e0c773"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -2208,31 +2186,11 @@ version = "1.2.0"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=34af48221c90e6818fe341d6d5b15116dfeab671#34af48221c90e6818fe341d6d5b15116dfeab671"
 dependencies = [
  "base64 0.13.1",
- "cosmwasm-derive 1.2.0",
+ "cosmwasm-derive",
  "derivative",
  "hex",
  "serde",
  "sha2 0.10.6",
- "uint",
-]
-
-[[package]]
-name = "cosmwasm-std"
-version = "1.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49b85345e811c8e80ec55d0d091e4fcb4f00f97ab058f9be5f614c444a730cb"
-dependencies = [
- "base64 0.13.1",
- "cosmwasm-crypto",
- "cosmwasm-derive 1.2.5",
- "derivative",
- "forward_ref",
- "hex",
- "schemars",
- "serde",
- "serde-json-wasm",
- "sha2 0.10.6",
- "thiserror",
  "uint",
 ]
 
@@ -2241,7 +2199,7 @@ name = "cosmwasm-vm"
 version = "0.1.0"
 source = "git+https://github.com/ComposableFi/cosmwasm-vm?rev=c2a4fe2c764710c0db15c571135bc37619a289d5#c2a4fe2c764710c0db15c571135bc37619a289d5"
 dependencies = [
- "cosmwasm-std 1.2.0",
+ "cosmwasm-std",
  "log 0.4.17",
  "num",
  "serde",
@@ -2253,7 +2211,7 @@ name = "cosmwasm-vm-wasmi"
 version = "0.1.0"
 source = "git+https://github.com/ComposableFi/cosmwasm-vm?rev=c2a4fe2c764710c0db15c571135bc37619a289d5#c2a4fe2c764710c0db15c571135bc37619a289d5"
 dependencies = [
- "cosmwasm-std 1.2.0",
+ "cosmwasm-std",
  "cosmwasm-vm",
  "either",
  "hex",
@@ -3160,10 +3118,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
-name = "cw-pablo"
+name = "cw-dex-router"
 version = "0.1.0"
 dependencies = [
- "cosmwasm-std 1.2.5",
+ "cosmwasm-vm",
  "serde",
 ]
 
@@ -3616,7 +3574,6 @@ dependencies = [
  "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
- "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -4101,12 +4058,6 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding 2.2.0",
 ]
-
-[[package]]
-name = "forward_ref"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "fragile"
@@ -10085,6 +10036,7 @@ dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
+ "cw-dex-router",
  "farming",
  "frame-benchmarking",
  "frame-executive",
@@ -10147,6 +10099,7 @@ dependencies = [
  "reward",
  "reward-rpc-runtime-api",
  "scale-info",
+ "serde_json",
  "smallvec 1.10.0",
  "sp-api",
  "sp-block-builder",
@@ -14073,30 +14026,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "serde_derive_internals",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "schnellru"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14306,15 +14235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-json-wasm"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14332,17 +14252,6 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.27",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
-dependencies = [
- "proc-macro2 1.0.56",
- "quote 1.0.27",
- "syn 1.0.109",
 ]
 
 [[package]]

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -2150,9 +2150,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-crypto"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75836a10cb9654c54e77ee56da94d592923092a10b369cdb0dbd56acefc16340"
+dependencies = [
+ "digest 0.10.6",
+ "ed25519-zebra",
+ "k256",
+ "rand_core 0.6.4",
+ "thiserror",
+]
+
+[[package]]
 name = "cosmwasm-derive"
 version = "1.2.0"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=34af48221c90e6818fe341d6d5b15116dfeab671#34af48221c90e6818fe341d6d5b15116dfeab671"
+dependencies = [
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "cosmwasm-derive"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c9f7f0e51bfc7295f7b2664fe8513c966428642aa765dad8a74acdab5e0c773"
 dependencies = [
  "syn 1.0.109",
 ]
@@ -2186,7 +2208,7 @@ version = "1.2.0"
 source = "git+https://github.com/ComposableFi/cosmwasm?rev=34af48221c90e6818fe341d6d5b15116dfeab671#34af48221c90e6818fe341d6d5b15116dfeab671"
 dependencies = [
  "base64 0.13.1",
- "cosmwasm-derive",
+ "cosmwasm-derive 1.2.0",
  "derivative",
  "hex",
  "serde",
@@ -2195,11 +2217,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "cosmwasm-std"
+version = "1.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a49b85345e811c8e80ec55d0d091e4fcb4f00f97ab058f9be5f614c444a730cb"
+dependencies = [
+ "base64 0.13.1",
+ "cosmwasm-crypto",
+ "cosmwasm-derive 1.2.5",
+ "derivative",
+ "forward_ref",
+ "hex",
+ "schemars",
+ "serde",
+ "serde-json-wasm",
+ "sha2 0.10.6",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
 name = "cosmwasm-vm"
 version = "0.1.0"
 source = "git+https://github.com/ComposableFi/cosmwasm-vm?rev=c2a4fe2c764710c0db15c571135bc37619a289d5#c2a4fe2c764710c0db15c571135bc37619a289d5"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.2.0",
  "log 0.4.17",
  "num",
  "serde",
@@ -2211,7 +2253,7 @@ name = "cosmwasm-vm-wasmi"
 version = "0.1.0"
 source = "git+https://github.com/ComposableFi/cosmwasm-vm?rev=c2a4fe2c764710c0db15c571135bc37619a289d5#c2a4fe2c764710c0db15c571135bc37619a289d5"
 dependencies = [
- "cosmwasm-std",
+ "cosmwasm-std 1.2.0",
  "cosmwasm-vm",
  "either",
  "hex",
@@ -3118,6 +3160,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
+name = "cw-pablo"
+version = "0.1.0"
+dependencies = [
+ "cosmwasm-std 1.2.5",
+ "serde",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3566,6 +3616,7 @@ dependencies = [
  "hashbrown 0.12.3",
  "hex",
  "rand_core 0.6.4",
+ "serde",
  "sha2 0.9.9",
  "zeroize",
 ]
@@ -4050,6 +4101,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding 2.2.0",
 ]
+
+[[package]]
+name = "forward_ref"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8cbd1169bd7b4a0a20d92b9af7a7e0422888bd38a6f5ec29c1fd8c1558a272e"
 
 [[package]]
 name = "fragile"
@@ -14016,6 +14073,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "serde_derive_internals",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14225,6 +14306,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-json-wasm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14242,6 +14332,17 @@ dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.27",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2 1.0.56",
+ "quote 1.0.27",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -10099,6 +10099,7 @@ dependencies = [
  "reward",
  "reward-rpc-runtime-api",
  "scale-info",
+ "serde-json-wasm",
  "serde_json",
  "smallvec 1.10.0",
  "sp-api",
@@ -14232,6 +14233,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-json-wasm"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16a62a1fad1e1828b24acac8f2b468971dade7b8c3c2e672bcadefefb1f8c137"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -341,6 +341,8 @@ serde_json = { version = "1.0.82", default-features = false, features = [
   "alloc",
 ] }
 
+serde-json-wasm = { version = "0.5.1" }
+
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT
 # PATCHES APPEAR AND GO AWAY ALL THE TIME

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -37,6 +37,7 @@ exclude = [
 members = [
   "services/cmc-api",
   "parachain/frame/*",
+  "parachain/frame/dex-router/cosmwasm",
   "parachain/node",
   "parachain/runtime/*",
   "utils/common",
@@ -332,6 +333,9 @@ cosmwasm-vm-wasmi = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev =
   "iterator",
   "stargate",
 ] }
+
+
+serde = { version = '1.0.136', default-features= false, features = ["derive"] }
 
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -337,6 +337,10 @@ cosmwasm-vm-wasmi = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev =
 
 serde = { version = '1.0.136', default-features= false, features = ["derive"] }
 
+serde_json = { version = "1.0.82", default-features = false, features = [
+  "alloc",
+] }
+
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT
 # PATCHES APPEAR AND GO AWAY ALL THE TIME

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -341,7 +341,7 @@ serde_json = { version = "1.0.82", default-features = false, features = [
   "alloc",
 ] }
 
-serde-json-wasm = { version = "0.5.1" }
+serde-json-wasm = { version = "0.5.1", default-features = false }
 
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -322,12 +322,22 @@ subxt = { git = "https://github.com/paritytech/subxt", rev = "2a913a3aa99a07f7ac
 # Only needed until the configs get merged into xcm-builder: https://github.com/paritytech/polkadot/pull/7165
 invarch-xcm-builder = { git = "https://github.com/InvArch/InvArch-XCM-Builder", rev = "c704c0f2d4c436f96eff10d06c197527b46b3536", default-features = false }
 
+
+cosmwasm-vm = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "c2a4fe2c764710c0db15c571135bc37619a289d5", default-features = false, features = [
+  "ibc3",
+  "iterator",
+  "stargate",
+] }
+cosmwasm-vm-wasmi = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "c2a4fe2c764710c0db15c571135bc37619a289d5", default-features = false, features = [
+  "iterator",
+  "stargate",
+] }
+
 #######################################
 # DO NOT DELETE PATCHES, BUT COMMENT OUT
 # PATCHES APPEAR AND GO AWAY ALL THE TIME
 # HARD TO RESTORE LIST OF ALL DEPS TO PATCH
 #######################################
-
 [patch."https://github.com/paritytech/polkadot"]
 kusama-runtime = { git = "https://github.com/ComposableFi/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1" }
 polkadot-cli = { git = "https://github.com/ComposableFi/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1" }

--- a/code/parachain/frame/call-filter/src/lib.rs
+++ b/code/parachain/frame/call-filter/src/lib.rs
@@ -97,6 +97,7 @@ pub mod pallet {
 		/// Possibly emits a `Disabled` event.
 		#[pallet::weight(T::WeightInfo::disable())]
 		#[transactional]
+		#[pallet::call_index(0)]
 		pub fn disable(origin: OriginFor<T>, entry: CallFilterEntryOf<T>) -> DispatchResult {
 			T::DisableOrigin::ensure_origin(origin)?;
 			ensure!(entry.valid(), Error::<T>::InvalidString);
@@ -117,6 +118,7 @@ pub mod pallet {
 		/// Possibly emits an `Enabled` event.
 		#[pallet::weight(T::WeightInfo::enable())]
 		#[transactional]
+		#[pallet::call_index(1)]
 		pub fn enable(origin: OriginFor<T>, entry: CallFilterEntryOf<T>) -> DispatchResult {
 			T::EnableOrigin::ensure_origin(origin)?;
 			ensure!(entry.valid(), Error::<T>::InvalidString);

--- a/code/parachain/frame/composable-traits/Cargo.toml
+++ b/code/parachain/frame/composable-traits/Cargo.toml
@@ -25,7 +25,7 @@ plotters = { version = "0.3.1", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = [
   "derive",
 ] }
-serde = { version = '1.0.136', optional = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 proptest = { version = "1.0.0" }
@@ -39,7 +39,6 @@ version = "3.0.0"
 [features]
 default = ["std"]
 std = [
-  "serde",
   "codec/std",
   "frame-support/std",
   "frame-system/std",

--- a/code/parachain/frame/composable-traits/Cargo.toml
+++ b/code/parachain/frame/composable-traits/Cargo.toml
@@ -25,7 +25,7 @@ plotters = { version = "0.3.1", optional = true }
 scale-info = { version = "2.1.1", default-features = false, features = [
   "derive",
 ] }
-serde = { workspace = true }
+serde = { workspace = true, default-features = false}
 
 [dev-dependencies]
 proptest = { version = "1.0.0" }

--- a/code/parachain/frame/composable-traits/src/defi.rs
+++ b/code/parachain/frame/composable-traits/src/defi.rs
@@ -81,7 +81,9 @@ impl<AssetId: PartialEq, Balance: MathBalance> Sell<AssetId, Balance> {
 /// Example, can do - give `base`, how much `quote` needed for unit.
 /// Can be local `Copy` `AssetId` or remote XCM asset id pair.
 #[repr(C)]
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(
+	Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, serde::Serialize, serde::Deserialize,
+)]
 pub struct CurrencyPair<AssetId> {
 	/// See [Base Currency](https://www.investopedia.com/terms/b/basecurrency.asp).
 	/// Also can be named `native`(to the market) currency.

--- a/code/parachain/frame/composable-traits/src/defi.rs
+++ b/code/parachain/frame/composable-traits/src/defi.rs
@@ -81,7 +81,7 @@ impl<AssetId: PartialEq, Balance: MathBalance> Sell<AssetId, Balance> {
 /// Example, can do - give `base`, how much `quote` needed for unit.
 /// Can be local `Copy` `AssetId` or remote XCM asset id pair.
 #[repr(C)]
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CurrencyPair<AssetId> {
 	/// See [Base Currency](https://www.investopedia.com/terms/b/basecurrency.asp).
 	/// Also can be named `native`(to the market) currency.

--- a/code/parachain/frame/composable-traits/src/defi.rs
+++ b/code/parachain/frame/composable-traits/src/defi.rs
@@ -81,7 +81,7 @@ impl<AssetId: PartialEq, Balance: MathBalance> Sell<AssetId, Balance> {
 /// Example, can do - give `base`, how much `quote` needed for unit.
 /// Can be local `Copy` `AssetId` or remote XCM asset id pair.
 #[repr(C)]
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone)]//, serde::Serialize, serde::Deserialize)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct CurrencyPair<AssetId> {
 	/// See [Base Currency](https://www.investopedia.com/terms/b/basecurrency.asp).
 	/// Also can be named `native`(to the market) currency.

--- a/code/parachain/frame/composable-traits/src/defi.rs
+++ b/code/parachain/frame/composable-traits/src/defi.rs
@@ -81,7 +81,7 @@ impl<AssetId: PartialEq, Balance: MathBalance> Sell<AssetId, Balance> {
 /// Example, can do - give `base`, how much `quote` needed for unit.
 /// Can be local `Copy` `AssetId` or remote XCM asset id pair.
 #[repr(C)]
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Debug, Clone)]//, serde::Serialize, serde::Deserialize)]
 pub struct CurrencyPair<AssetId> {
 	/// See [Base Currency](https://www.investopedia.com/terms/b/basecurrency.asp).
 	/// Also can be named `native`(to the market) currency.

--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -17,7 +17,19 @@ use sp_runtime::{
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, ops::Mul, vec::Vec};
 
 /// Specifies and amount together with the asset ID of the amount.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, Serialize, Deserialize)]
+#[derive(
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	TypeInfo,
+	Clone,
+	PartialEq,
+	Eq,
+	Copy,
+	RuntimeDebug,
+	Serialize,
+	Deserialize,
+)]
 pub struct AssetAmount<AssetId, Balance> {
 	pub asset_id: AssetId,
 	pub amount: Balance,
@@ -30,7 +42,19 @@ impl<AssetId, Balance> AssetAmount<AssetId, Balance> {
 }
 
 /// The (expected or executed) result of a swap operation.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, Serialize, Deserialize)]
+#[derive(
+	Encode,
+	Decode,
+	MaxEncodedLen,
+	TypeInfo,
+	Clone,
+	PartialEq,
+	Eq,
+	Copy,
+	RuntimeDebug,
+	Serialize,
+	Deserialize,
+)]
 pub struct SwapResult<AssetId, Balance> {
 	pub value: AssetAmount<AssetId, Balance>,
 	pub fee: AssetAmount<AssetId, Balance>,
@@ -130,7 +154,6 @@ pub trait Amm {
 		min_receive: BTreeMap<Self::AssetId, Self::Balance>,
 	) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError>;
 
-
 	/// Buy given `amount` of given asset from the pool.
 	/// In buy user does not know how much assets he/she has to exchange to get desired amount.
 	fn do_buy(
@@ -140,7 +163,7 @@ pub trait Amm {
 		out_asset: AssetAmount<Self::AssetId, Self::Balance>,
 		keep_alive: bool,
 	) -> Result<SwapResult<Self::AssetId, Self::Balance>, DispatchError>;
-		
+
 	/// Perform an exchange effectively trading the in_asset against the min_receive one.
 	fn do_swap(
 		who: &Self::AccountId,

--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -31,7 +31,7 @@ impl<AssetId, Balance> AssetAmount<AssetId, Balance> {
 }
 
 /// The (expected or executed) result of a swap operation.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, serde::Serialize, serde::Deserialize)]
 pub struct SwapResult<AssetId, Balance> {
 	pub value: AssetAmount<AssetId, Balance>,
 	pub fee: AssetAmount<AssetId, Balance>,

--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -8,7 +8,6 @@ use frame_support::{
 	BoundedVec, CloneNoBound, EqNoBound, PartialEqNoBound, RuntimeDebug, RuntimeDebugNoBound,
 };
 use scale_info::TypeInfo;
-#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 use sp_runtime::{
@@ -18,7 +17,7 @@ use sp_runtime::{
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, ops::Mul, vec::Vec};
 
 /// Specifies and amount together with the asset ID of the amount.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, serde::Serialize, serde::Deserialize)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, Serialize, Deserialize)]
 pub struct AssetAmount<AssetId, Balance> {
 	pub asset_id: AssetId,
 	pub amount: Balance,
@@ -31,7 +30,7 @@ impl<AssetId, Balance> AssetAmount<AssetId, Balance> {
 }
 
 /// The (expected or executed) result of a swap operation.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, serde::Serialize, serde::Deserialize)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, Serialize, Deserialize)]
 pub struct SwapResult<AssetId, Balance> {
 	pub value: AssetAmount<AssetId, Balance>,
 	pub fee: AssetAmount<AssetId, Balance>,

--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -109,16 +109,6 @@ pub trait Amm {
 		calculate_with_fees: bool,
 	) -> Result<SwapResult<Self::AssetId, Self::Balance>, DispatchError>;
 
-	/// Buy given `amount` of given asset from the pool.
-	/// In buy user does not know how much assets he/she has to exchange to get desired amount.
-	fn do_buy(
-		who: &Self::AccountId,
-		pool_id: Self::PoolId,
-		in_asset_id: Self::AssetId,
-		out_asset: AssetAmount<Self::AssetId, Self::Balance>,
-		keep_alive: bool,
-	) -> Result<SwapResult<Self::AssetId, Self::Balance>, DispatchError>;
-
 	/// Deposit coins into the pool
 	/// `amounts` - list of amounts of coins to deposit,
 	/// `min_mint_amount` - minimum amount of LP tokens to mint from the deposit.
@@ -141,6 +131,17 @@ pub trait Amm {
 		min_receive: BTreeMap<Self::AssetId, Self::Balance>,
 	) -> Result<BTreeMap<Self::AssetId, Self::Balance>, DispatchError>;
 
+
+	/// Buy given `amount` of given asset from the pool.
+	/// In buy user does not know how much assets he/she has to exchange to get desired amount.
+	fn do_buy(
+		who: &Self::AccountId,
+		pool_id: Self::PoolId,
+		in_asset_id: Self::AssetId,
+		out_asset: AssetAmount<Self::AssetId, Self::Balance>,
+		keep_alive: bool,
+	) -> Result<SwapResult<Self::AssetId, Self::Balance>, DispatchError>;
+		
 	/// Perform an exchange effectively trading the in_asset against the min_receive one.
 	fn do_swap(
 		who: &Self::AccountId,

--- a/code/parachain/frame/composable-traits/src/dex.rs
+++ b/code/parachain/frame/composable-traits/src/dex.rs
@@ -18,7 +18,7 @@ use sp_runtime::{
 use sp_std::{collections::btree_map::BTreeMap, fmt::Debug, ops::Mul, vec::Vec};
 
 /// Specifies and amount together with the asset ID of the amount.
-#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug)]
+#[derive(Encode, Decode, MaxEncodedLen, TypeInfo, Clone, PartialEq, Eq, Copy, RuntimeDebug, serde::Serialize, serde::Deserialize)]
 pub struct AssetAmount<AssetId, Balance> {
 	pub asset_id: AssetId,
 	pub amount: Balance,

--- a/code/parachain/frame/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/cosmwasm/Cargo.toml
@@ -13,12 +13,12 @@ version = "3.0.0"
 
 [dependencies]
 composable-support = { path = "../composable-support", default-features = false }
-cosmwasm-vm = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "c2a4fe2c764710c0db15c571135bc37619a289d5", default-features = false, features = [
+cosmwasm-vm = { workspace = true, default-features = false, features = [
   "ibc3",
   "iterator",
   "stargate",
 ] }
-cosmwasm-vm-wasmi = { git = "https://github.com/ComposableFi/cosmwasm-vm", rev = "c2a4fe2c764710c0db15c571135bc37619a289d5", default-features = false, features = [
+cosmwasm-vm-wasmi = { workspace = true, default-features = false, features = [
   "iterator",
   "stargate",
 ] }

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -167,6 +167,8 @@ pub mod pallet {
 		CodeNotFound,
 		ContractAlreadyExists,
 		ContractNotFound,
+		SubstrateDispatch,
+		AssetConversion,
 		TransferFailed,
 		LabelTooBig,
 		UnknownDenom,
@@ -181,6 +183,7 @@ pub mod pallet {
 		IteratorValueNotFound,
 		NotAuthorized,
 		Unsupported,
+		ExecuteDeserialize,
 		Ibc,
 		FailedToSerialize,
 		OutOfGas,
@@ -725,7 +728,7 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::OutOfGas => Error::<T>::OutOfGas,
 					CosmwasmVMError::Interpreter(_) => Error::<T>::Interpreter,
 					CosmwasmVMError::VirtualMachine(_) => Error::<T>::VirtualMachine,
-					CosmwasmVMError::AccountConversionFailure =>
+					CosmwasmVMError::AccountConvert =>
 						Error::<T>::AccountConversionFailure,
 					CosmwasmVMError::Aborted(_) => Error::<T>::Aborted,
 					CosmwasmVMError::ReadOnlyViolation => Error::<T>::ReadOnlyViolation,
@@ -734,6 +737,9 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::ContractNotFound => Error::<T>::ContractNotFound,
 					CosmwasmVMError::Rpc(_) => Error::<T>::Rpc,
 					CosmwasmVMError::Ibc(_) => Error::<T>::Ibc,
+					CosmwasmVMError::SubstrateDispatch(_) => Error::<T>::SubstrateDispatch,
+					CosmwasmVMError::AssetConversion => Error::<T>::AssetConversion,
+
 				};
 				Err(DispatchErrorWithPostInfo { error: error.into(), post_info })
 			},

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -730,6 +730,7 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::Aborted(_) => Error::<T>::Aborted,
 					CosmwasmVMError::ReadOnlyViolation => Error::<T>::ReadOnlyViolation,
 					CosmwasmVMError::Unsupported => Error::<T>::Unsupported,
+					CosmwasmVMError::ExecuteDeserialize => Error::<T>::ExecuteDeserialize,
 					CosmwasmVMError::ContractNotFound => Error::<T>::ContractNotFound,
 					CosmwasmVMError::Rpc(_) => Error::<T>::Rpc,
 					CosmwasmVMError::Ibc(_) => Error::<T>::Ibc,

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -728,8 +728,7 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::OutOfGas => Error::<T>::OutOfGas,
 					CosmwasmVMError::Interpreter(_) => Error::<T>::Interpreter,
 					CosmwasmVMError::VirtualMachine(_) => Error::<T>::VirtualMachine,
-					CosmwasmVMError::AccountConvert =>
-						Error::<T>::AccountConversionFailure,
+					CosmwasmVMError::AccountConvert => Error::<T>::AccountConversionFailure,
 					CosmwasmVMError::Aborted(_) => Error::<T>::Aborted,
 					CosmwasmVMError::ReadOnlyViolation => Error::<T>::ReadOnlyViolation,
 					CosmwasmVMError::Unsupported => Error::<T>::Unsupported,
@@ -739,7 +738,6 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::Ibc(_) => Error::<T>::Ibc,
 					CosmwasmVMError::SubstrateDispatch(_) => Error::<T>::SubstrateDispatch,
 					CosmwasmVMError::AssetConversion => Error::<T>::AssetConversion,
-
 				};
 				Err(DispatchErrorWithPostInfo { error: error.into(), post_info })
 			},

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -738,6 +738,7 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::Ibc(_) => Error::<T>::Ibc,
 					CosmwasmVMError::SubstrateDispatch(_) => Error::<T>::SubstrateDispatch,
 					CosmwasmVMError::AssetConversion => Error::<T>::AssetConversion,
+					CosmwasmVMError::QuerySerialize => Error::<T>::FailedToSerialize,
 				};
 				Err(DispatchErrorWithPostInfo { error: error.into(), post_info })
 			},

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -730,6 +730,7 @@ impl<T: Config> Pallet<T> {
 					CosmwasmVMError::Aborted(_) => Error::<T>::Aborted,
 					CosmwasmVMError::ReadOnlyViolation => Error::<T>::ReadOnlyViolation,
 					CosmwasmVMError::Unsupported => Error::<T>::Unsupported,
+					CosmwasmVMError::ContractNotFound => Error::<T>::ContractNotFound,
 					CosmwasmVMError::Rpc(_) => Error::<T>::Rpc,
 					CosmwasmVMError::Ibc(_) => Error::<T>::Ibc,
 				};

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -1,6 +1,7 @@
 use super::abstraction::{CanonicalCosmwasmAccount, CosmwasmAccount, Gas};
 use crate::{runtimes::abstraction::GasOutcome, types::*, weights::WeightInfo, Config, Pallet};
 use alloc::{borrow::ToOwned, string::String};
+use sp_runtime::DispatchError;
 use core::marker::{Send, Sync};
 use cosmwasm_vm::{
 	cosmwasm_std::{CodeInfoResponse, Coin, ContractInfoResponse, Empty, Env, MessageInfo},
@@ -49,7 +50,8 @@ pub enum CosmwasmVMError<T: Config> {
 	Interpreter(wasmi::Error),
 	VirtualMachine(WasmiVMError),
 	Pallet(crate::Error<T>),
-	AccountConversionFailure,
+	SubstrateDispatch(DispatchError),
+	AccountConvert,
 	Aborted(String),
 	ReadOnlyViolation,
 	OutOfGas,

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -55,8 +55,10 @@ pub enum CosmwasmVMError<T: Config> {
 	OutOfGas,
 	Unsupported,
 	ContractNotFound,
+	ExecuteDeserialize,
 	Rpc(String),
 	Ibc(String),
+	AssetConversion,
 }
 
 impl<T: Config + core::marker::Send + core::marker::Sync + 'static> HostError

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -54,6 +54,7 @@ pub enum CosmwasmVMError<T: Config> {
 	ReadOnlyViolation,
 	OutOfGas,
 	Unsupported,
+	ContractNotFound,
 	Rpc(String),
 	Ibc(String),
 }

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -1,7 +1,6 @@
 use super::abstraction::{CanonicalCosmwasmAccount, CosmwasmAccount, Gas};
 use crate::{runtimes::abstraction::GasOutcome, types::*, weights::WeightInfo, Config, Pallet};
 use alloc::{borrow::ToOwned, string::String};
-use sp_runtime::DispatchError;
 use core::marker::{Send, Sync};
 use cosmwasm_vm::{
 	cosmwasm_std::{CodeInfoResponse, Coin, ContractInfoResponse, Empty, Env, MessageInfo},
@@ -15,6 +14,7 @@ use cosmwasm_vm::{
 use cosmwasm_vm_wasmi::{
 	OwnedWasmiVM, WasmiContext, WasmiInput, WasmiModule, WasmiOutput, WasmiVMError,
 };
+use sp_runtime::DispatchError;
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
 use wasmi::{core::HostError, Instance, Memory};
 

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -58,6 +58,7 @@ pub enum CosmwasmVMError<T: Config> {
 	Unsupported,
 	ContractNotFound,
 	ExecuteDeserialize,
+	QuerySerialize,
 	Rpc(String),
 	Ibc(String),
 	AssetConversion,

--- a/code/parachain/frame/cosmwasm/src/utils.rs
+++ b/code/parachain/frame/cosmwasm/src/utils.rs
@@ -71,8 +71,7 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn cosmwasm_addr_to_account(
 		cosmwasm_addr: String,
 	) -> Result<AccountIdOf<T>, <T as VMPallet>::VmError> {
-		T::AccountToAddr::convert(cosmwasm_addr)
-			.map_err(|()| CosmwasmVMError::AccountConvert)
+		T::AccountToAddr::convert(cosmwasm_addr).map_err(|()| CosmwasmVMError::AccountConvert)
 	}
 
 	/// Convert from a native ahttps://app.clickup.com/20465559/v/l/6-210281072-1ccount to a CosmWasm address.

--- a/code/parachain/frame/cosmwasm/src/utils.rs
+++ b/code/parachain/frame/cosmwasm/src/utils.rs
@@ -65,7 +65,7 @@ impl<T: Config> Pallet<T> {
 	pub(crate) fn canonical_addr_to_account(
 		canonical: Vec<u8>,
 	) -> Result<AccountIdOf<T>, <T as VMPallet>::VmError> {
-		T::AccountToAddr::convert(canonical).map_err(|()| CosmwasmVMError::AccountConversionFailure)
+		T::AccountToAddr::convert(canonical).map_err(|()| CosmwasmVMError::AccountConvert)
 	}
 
 	/// Try to convert from a CosmWasm address to a native AccountId.
@@ -73,7 +73,7 @@ impl<T: Config> Pallet<T> {
 		cosmwasm_addr: String,
 	) -> Result<AccountIdOf<T>, <T as VMPallet>::VmError> {
 		T::AccountToAddr::convert(cosmwasm_addr)
-			.map_err(|()| CosmwasmVMError::AccountConversionFailure)
+			.map_err(|()| CosmwasmVMError::AccountConvert)
 	}
 
 	/// Convert from a native ahttps://app.clickup.com/20465559/v/l/6-210281072-1ccount to a CosmWasm address.

--- a/code/parachain/frame/cosmwasm/src/utils.rs
+++ b/code/parachain/frame/cosmwasm/src/utils.rs
@@ -12,7 +12,6 @@ use crate::{
 	Config, ContractToInfo, Error, Pallet,
 };
 
-// TODO(cor): move these out of the `impl` as they do not refer to `self` or `Self`.
 impl<T: Config> Pallet<T> {
 	pub(crate) fn derive_contract_address(
 		creator: &AccountIdOf<T>,

--- a/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
@@ -5,6 +5,8 @@ version = "0.1.0"
 
 [features]
 library = []
+default = ["std"]
+std = []
 
 [dependencies]
 cosmwasm-vm = { workspace = true, default-features = false, features = [
@@ -12,4 +14,8 @@ cosmwasm-vm = { workspace = true, default-features = false, features = [
   "iterator",
   "stargate",
 ] }
+
 serde = { workspace = true, default-features = false, features = ["derive"] }
+serde_json = { workspace = true, default-features = false, features = [
+  "alloc",
+] }

--- a/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+edition = "2021"
+name = "cw-pablo"
+version = "0.1.0"
+
+[features]
+library = []
+
+[dependencies]
+cosmwasm-std = "1.0.0"
+serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/dex-router/cosmwasm/Cargo.toml
@@ -1,11 +1,15 @@
 [package]
 edition = "2021"
-name = "cw-pablo"
+name = "cw-dex-router"
 version = "0.1.0"
 
 [features]
 library = []
 
 [dependencies]
-cosmwasm-std = "1.0.0"
-serde = { version = "1.0", default-features = false, features = ["derive"] }
+cosmwasm-vm = { workspace = true, default-features = false, features = [
+  "ibc3",
+  "iterator",
+  "stargate",
+] }
+serde = { workspace = true, default-features = false, features = ["derive"] }

--- a/code/parachain/frame/dex-router/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod msg;

--- a/code/parachain/frame/dex-router/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/lib.rs
@@ -1,1 +1,4 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+extern crate alloc;
+
 pub mod msg;

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -13,7 +13,7 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-	GetRoute { input_denom: Coin, output_denom: String }
+	Price { in_asset: Coin, output_denom: String, pool_id: Uint128 }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -1,8 +1,6 @@
-extern crate alloc;
-
-use serde::{Deserialize, Serialize};
+use alloc::{string::String, vec::Vec};
 use cosmwasm_vm::cosmwasm_std::{Coin, Uint128, Uint64};
-
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -13,27 +11,25 @@ pub enum ExecuteMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-	Price { in_asset: Coin, output_denom: String, pool_id: Uint128 }
+	Price { in_asset: Coin, output_denom: String, pool_id: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct GetRouteResponse {
-    pub pool_route: Vec<SwapAmountInRoute>,
+	pub pool_route: Vec<SwapAmountInRoute>,
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SwapAmountInRoute {
-    pub pool_id: Vec<Uint64>,
+	pub pool_id: Vec<Uint64>,
 }
-
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SwapResponse {
-    pub original_sender: String,
-    pub token_out_denom: String,
-    pub amount: Uint128,
+	pub original_sender: String,
+	pub token_out_denom: String,
+	pub amount: Uint128,
 }

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -1,5 +1,5 @@
-use alloc::{string::String, vec::Vec};
-use cosmwasm_vm::cosmwasm_std::{Coin, Uint128, Uint64};
+use alloc::string::String;
+use cosmwasm_vm::cosmwasm_std::{Coin, Uint128};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -1,13 +1,13 @@
 extern crate alloc;
 
 use serde::{Deserialize, Serialize};
-use cosmwasm_std::{Coin, Uint128};
+use cosmwasm_vm::cosmwasm_std::{Coin, Uint128, Uint64};
 
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-	Swap { in_asset: Coin, min_receive: Coin },
+	Swap { in_asset: Coin, min_receive: Coin, pool_id: Uint64 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -26,7 +26,7 @@ pub struct GetRouteResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SwapAmountInRoute {
-    pub pool_id: Vec<cosmwasm_std::Uint64>,
+    pub pool_id: Vec<Uint64>,
 }
 
 

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -1,0 +1,39 @@
+extern crate alloc;
+
+use serde::{Deserialize, Serialize};
+use cosmwasm_std::{Coin, Uint128};
+
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecuteMsg {
+	Swap { in_asset: Coin, min_receive: Coin },
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryMsg {
+	GetRoute { input_denom: Coin, output_denom: String }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct GetRouteResponse {
+    pub pool_route: Vec<SwapAmountInRoute>,
+}
+
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SwapAmountInRoute {
+    pub pool_id: Vec<cosmwasm_std::Uint64>,
+}
+
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SwapResponse {
+    pub original_sender: String,
+    pub token_out_denom: String,
+    pub amount: Uint128,
+}

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -13,23 +13,3 @@ pub enum ExecuteMsg {
 pub enum QueryMsg {
 	Price { in_asset: Coin, output_denom: String, pool_id: Uint128 },
 }
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub struct GetRouteResponse {
-	pub pool_route: Vec<SwapAmountInRoute>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub struct SwapAmountInRoute {
-	pub pool_id: Vec<Uint64>,
-}
-
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub struct SwapResponse {
-	pub original_sender: String,
-	pub token_out_denom: String,
-	pub amount: Uint128,
-}

--- a/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
+++ b/code/parachain/frame/dex-router/cosmwasm/src/msg.rs
@@ -7,7 +7,7 @@ use cosmwasm_vm::cosmwasm_std::{Coin, Uint128, Uint64};
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-	Swap { in_asset: Coin, min_receive: Coin, pool_id: Uint64 },
+	Swap { in_asset: Coin, min_receive: Coin, pool_id: Uint128 },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -73,6 +73,7 @@ crowdloan-rewards = { package = "pallet-crowdloan-rewards", path = "../../frame/
 currency-factory = { package = "pallet-currency-factory", path = "../../frame/currency-factory", default-features = false }
 governance-registry = { package = "pallet-governance-registry", path = "../../frame/governance-registry", default-features = false }
 pablo = { package = "pallet-pablo", path = "../../frame/pablo", default-features = false }
+cw-dex-router = { path = "../../frame/dex-router/cosmwasm", default-features = false }
 oracle = { package = "pallet-oracle", path = "../../frame/oracle", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 vesting = { package = "pallet-vesting", path = "../../frame/vesting", default-features = false }
@@ -139,6 +140,10 @@ cosmwasm-vm-wasmi = { workspace = true, default-features = false, features = [
   "iterator",
   "stargate",
 ] }
+
+serde_json = { workspace = true, default-features = false}
+
+
 
 [features]
 builtin-wasm = []

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -130,6 +130,16 @@ pallet-ibc-ping = { workspace = true, default-features = false }
 
 invarch-xcm-builder = { workspace = true, default-features = false }
 
+cosmwasm-vm = { workspace = true, default-features = false, features = [
+  "ibc3",
+  "iterator",
+  "stargate",
+] }
+cosmwasm-vm-wasmi = { workspace = true, default-features = false, features = [
+  "iterator",
+  "stargate",
+] }
+
 [features]
 builtin-wasm = []
 testnet = []

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -142,9 +142,6 @@ cosmwasm-vm-wasmi = { workspace = true, default-features = false, features = [
 ] }
 
 serde_json = { workspace = true, default-features = false}
-serde-json-wasm = { workspace = true}
-
-
 
 [features]
 builtin-wasm = []
@@ -210,6 +207,7 @@ std = [
   "composable-traits/std",
   "cosmwasm-runtime-api/std",
   "cosmwasm/std",
+  "cw-dex-router/std",
   "crowdloan-rewards-runtime-api/std",
   "crowdloan-rewards/std",
   "cumulus-pallet-aura-ext/std",

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -142,6 +142,7 @@ cosmwasm-vm-wasmi = { workspace = true, default-features = false, features = [
 ] }
 
 serde_json = { workspace = true, default-features = false}
+serde-json-wasm = { workspace = true}
 
 
 

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -252,7 +252,9 @@ impl PalletHook<Runtime> for Precompiles {
 						);
 						match result {
 							Ok(result) => {
-								let result = serde_json::to_vec(&result).unwrap().into();
+								let result = serde_json::to_vec(&result)
+									.map_err(|x| CosmwasmVMError::QuerySerialize)?
+									.into();
 								Ok(ContractResult::Ok(result))
 							},
 							Err(err) => Ok(ContractResult::Err(alloc::format!("{:?}", err))),

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -145,9 +145,6 @@ impl cosmwasm::Config for Runtime {
 pub struct Precompiles;
 
 impl PalletHook<Runtime> for Precompiles {
-	// This mocked hook shows two pallets with contract hooks that currently exhibit the same
-	// behavior. The behavior does not need to be identical in practice.
-
 	fn info(
 		contract_address: &AccountIdOf<Runtime>,
 	) -> Option<
@@ -175,11 +172,17 @@ impl PalletHook<Runtime> for Precompiles {
 		entrypoint: EntryPoint,
 		message: &[u8],
 	) -> Result<
-		ContractResult<Response<<OwnedWasmiVM<CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
-		VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>,
+	ContractResult<Response<<OwnedWasmiVM<CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
+	VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>,
 	> {		
-	  log::error!("{:?}{:?}{:?}", &vm.0.data().contract_address, &entrypoint, String::from_utf8_lossy(message));
-	  Err(CosmwasmVMError::ContractNotFound)
+	 log::error!("{:?}{:?}{:?}", &vm.0.data().contract_address, &entrypoint, String::from_utf8_lossy(message));
+	 let dex: AccountIdOf<Runtime> = PabloPalletId::get().into_account_truncating();
+	  match contract_address {
+		address if address == &dex => {
+			panic!()	
+		} 
+		_ => Err(CosmwasmVMError::ContractNotFound)
+	  }
 	}
 
 	fn run<'a>(
@@ -195,6 +198,12 @@ impl PalletHook<Runtime> for Precompiles {
 		message: &[u8],
 	) -> Result<ContractResult<QueryResponse>, VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>> {
 		log::error!("{:?}{:?}", &vm.0.data().contract_address, String::from_utf8_lossy(message));
-		Err(CosmwasmVMError::ContractNotFound)
+		let dex: AccountIdOf<Runtime> = PabloPalletId::get().into_account_truncating();
+		match contract_address {
+		  address if address == &dex => {
+			  panic!()	
+		  } 
+		  _ => Err(CosmwasmVMError::ContractNotFound)
+		}
 	}
 }

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -1,0 +1,168 @@
+
+use ::cosmwasm::pallet_hook::PalletHook;
+use sp_core::ConstU32;
+use cosmwasm::instrument::CostRules;
+
+
+use super::*;
+
+/// Native <-> Cosmwasm account mapping
+pub struct AccountToAddr;
+
+impl Convert<alloc::string::String, Result<AccountId, ()>> for AccountToAddr {
+	fn convert(a: alloc::string::String) -> Result<AccountId, ()> {
+		let account =
+			ibc_primitives::runtime_interface::ss58_to_account_id_32(&a).map_err(|_| ())?;
+		Ok(account.into())
+	}
+}
+
+impl Convert<AccountId, alloc::string::String> for AccountToAddr {
+	fn convert(a: AccountId) -> alloc::string::String {
+		let account = ibc_primitives::runtime_interface::account_id_to_ss58(a.into(), 49);
+		String::from_utf8_lossy(account.as_slice()).to_string()
+	}
+}
+
+impl Convert<Vec<u8>, Result<AccountId, ()>> for AccountToAddr {
+	fn convert(a: Vec<u8>) -> Result<AccountId, ()> {
+		Ok(<[u8; 32]>::try_from(a).map_err(|_| ())?.into())
+	}
+}
+
+/// Native <-> Cosmwasm asset mapping
+pub struct AssetToDenom;
+
+impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
+	fn convert(currency_id: alloc::string::String) -> Result<CurrencyId, ()> {
+		core::str::FromStr::from_str(&currency_id).map_err(|_| ())
+	}
+}
+
+impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
+	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
+		alloc::format!("{}", currency_id)
+	}
+}
+
+
+parameter_types! {
+	pub const CosmwasmPalletId: PalletId = PalletId(*b"cosmwasm");
+	pub const ChainId: &'static str = "composable-network-picasso";
+	pub const MaxInstrumentedCodeSize: u32 = 1024 * 1024;
+	pub const MaxContractLabelSize: u32 = 64;
+	pub const MaxContractTrieIdSize: u32 = Hash::len_bytes() as u32;
+	pub const MaxInstantiateSaltSize: u32 = 128;
+	pub const MaxFundsAssets: u32 = 32;
+	pub const CodeTableSizeLimit: u32 = 4096;
+	pub const CodeGlobalVariableLimit: u32 = 256;
+	pub const CodeParameterLimit: u32 = 128;
+	pub const CodeBranchTableSizeLimit: u32 = 256;
+
+	// TODO: benchmark for proper values
+	pub const CodeStorageByteDeposit: u32 = 1_000_000;
+	pub const ContractStorageByteReadPrice: u32 = 1;
+	pub const ContractStorageByteWritePrice: u32 = 1;
+	pub WasmCostRules: CostRules<Runtime> = Default::default();
+}
+
+impl cosmwasm::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type AccountIdExtended = AccountId;
+	type PalletId = CosmwasmPalletId;
+	type MaxFrames = ConstU32<64>;
+	type MaxCodeSize = ConstU32<{ 512 * 1024 }>;
+	type MaxInstrumentedCodeSize = MaxInstrumentedCodeSize;
+
+	#[cfg(feature = "testnet")]
+	type MaxMessageSize = ConstU32<{ 128 * 1024 }>;
+
+	#[cfg(not(feature = "testnet"))]
+	type MaxMessageSize = ConstU32<{ 32 * 1024 }>;
+
+	type AccountToAddr = AccountToAddr;
+
+	type AssetToDenom = AssetToDenom;
+
+	type Balance = Balance;
+	type AssetId = CurrencyId;
+	type Assets = AssetsTransactorRouter;
+	type NativeAsset = Balances;
+	type ChainId = ChainId;
+	type MaxContractLabelSize = MaxContractLabelSize;
+	type MaxContractTrieIdSize = MaxContractTrieIdSize;
+	type MaxInstantiateSaltSize = MaxInstantiateSaltSize;
+	type MaxFundsAssets = MaxFundsAssets;
+
+	type CodeTableSizeLimit = CodeTableSizeLimit;
+	type CodeGlobalVariableLimit = CodeGlobalVariableLimit;
+	type CodeStackLimit = ConstU32<{ u32::MAX }>;
+
+	type CodeParameterLimit = CodeParameterLimit;
+	type CodeBranchTableSizeLimit = CodeBranchTableSizeLimit;
+	type CodeStorageByteDeposit = CodeStorageByteDeposit;
+	type ContractStorageByteReadPrice = ContractStorageByteReadPrice;
+	type ContractStorageByteWritePrice = ContractStorageByteWritePrice;
+
+	type WasmCostRules = WasmCostRules;
+	type UnixTime = Timestamp;
+	type WeightInfo = cosmwasm::weights::SubstrateWeight<Runtime>;
+	type IbcRelayerAccount = TreasuryAccount;
+
+	type IbcRelayer = cosmwasm::NoRelayer<Runtime>;
+
+	type PalletHook = ();
+
+	#[cfg(feature = "testnet")]
+	type UploadWasmOrigin = system::EnsureSigned<Self::AccountId>;
+
+	#[cfg(feature = "testnet")]
+	type ExecuteWasmOrigin = system::EnsureSigned<Self::AccountId>;
+
+	// really need to do EnsureOnOf<Sudo::key, >
+	#[cfg(not(feature = "testnet"))]
+	type UploadWasmOrigin = system::EnsureSignedBy<TechnicalCommitteeMembership, Self::AccountId>;
+
+	#[cfg(not(feature = "testnet"))]
+	type ExecuteWasmOrigin = frame_support::traits::EitherOfDiverse<
+		system::EnsureSignedBy<TechnicalCommitteeMembership, Self::AccountId>,
+		system::EnsureSignedBy<ReleaseMembership, Self::AccountId>,
+	>;
+}
+
+pub struct Precompiles;
+
+
+// impl PalletHook<Runtime> for Precompiles {
+//     fn info(
+// 		contract_address: &::cosmwasm::types::AccountIdOf<Runtime>,
+// 	) -> Option<::cosmwasm::types::PalletContractCodeInfo<::cosmwasm::types::AccountIdOf<Runtime>, ::cosmwasm::types::ContractLabelOf<Runtime>, ::cosmwasm::types::ContractTrieIdOf<Runtime>>> {
+//         todo!()
+//     }
+
+//     fn execute<'a>(
+// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
+// 		entrypoint: ::cosmwasm::types::EntryPoint,
+// 		message: &[u8],
+// 	) -> Result<
+// 		ContractResult<Response<<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
+// 		VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>,
+// 	> {
+//         todo!()
+//     }
+
+//     fn run<'a>(
+// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
+// 		entrypoint: ::cosmwasm::types::EntryPoint,
+// 		message: &[u8],
+// 	) -> Result<Vec<u8>, VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>> {
+//         todo!()
+//     }
+
+//     fn query<'a>(
+// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
+// 		message: &[u8],
+// 	) -> Result<ContractResult<QueryResponse>, VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>> {
+//         todo!()
+//     }
+// }

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -253,7 +253,7 @@ impl PalletHook<Runtime> for Precompiles {
 						match result {
 							Ok(result) => {
 								let result = serde_json::to_vec(&result)
-									.map_err(|x| CosmwasmVMError::QuerySerialize)?
+									.map_err(|_| CosmwasmVMError::QuerySerialize)?
 									.into();
 								Ok(ContractResult::Ok(result))
 							},

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -181,13 +181,16 @@ impl PalletHook<Runtime> for Precompiles {
 		let dex: AccountIdOf<Runtime> = PabloPalletId::get().into_account_truncating();
 		match contract_address {
 			address if address == dex => {
-				let message: cw_dex_router::msg::ExecuteMsg =
-					serde_json::from_slice(message).map_err(|_| CosmwasmVMError::ExecuteDeserialize)?;
+				let message: cw_dex_router::msg::ExecuteMsg = serde_json::from_slice(message)
+					.map_err(|_| CosmwasmVMError::ExecuteDeserialize)?;
 				match message {
 					cw_dex_router::msg::ExecuteMsg::Swap { in_asset, min_receive, pool_id } => {
 						//<Pablo>::do_swap(contract_address, pool_id, in_asset, min_receive, keep_alive)
-						let in_asset = AssetToDenom::convert(in_asset.denom).map_err(|_| CosmwasmVMError::AssetConversion)?;
-						<Pablo>::do_swap(contract_address, pool_id, in_asset, min_receive, true)
+						let in_asset_id = AssetToDenom::convert(in_asset.denom).map_err(|_| CosmwasmVMError::AssetConversion)?;
+						let in_asset_amount = in_asset.amount.into();
+						<Pablo>::do_swap(contract_address, pool_id.into(), AssetAmount::new(in_asset_id, in_asset_amount), 
+						min_receive, 
+						true)
 							.unwrap();
 						todo!()
 					},

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -186,7 +186,7 @@ impl PalletHook<Runtime> for Precompiles {
 				match message {
 					cw_dex_router::msg::ExecuteMsg::Swap { in_asset, min_receive, pool_id } => {
 						//<Pablo>::do_swap(contract_address, pool_id, in_asset, min_receive, keep_alive)
-						let in_asset = AssetToDenom::convert(in_asset.denom).map_err(|_| CosmwasmVMError::AssetConversion)?
+						let in_asset = AssetToDenom::convert(in_asset.denom).map_err(|_| CosmwasmVMError::AssetConversion)?;
 						<Pablo>::do_swap(contract_address, pool_id, in_asset, min_receive, true)
 							.unwrap();
 						todo!()

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -1,7 +1,9 @@
 
 use ::cosmwasm::pallet_hook::PalletHook;
+use cosmwasm_vm::{vm::{VMBase, VmErrorOf}, cosmwasm_std::{ContractResult, Response}, executor::QueryResponse};
+use cosmwasm_vm_wasmi::OwnedWasmiVM;
 use sp_core::ConstU32;
-use cosmwasm::instrument::CostRules;
+use cosmwasm::{instrument::CostRules, types::{AccountIdOf, PalletContractCodeInfo, ContractLabelOf, ContractTrieIdOf, EntryPoint}, runtimes::vm::CosmwasmVM};
 
 
 use super::*;
@@ -132,37 +134,43 @@ impl cosmwasm::Config for Runtime {
 
 pub struct Precompiles;
 
+impl PalletHook<Runtime> for Precompiles {
+	// This mocked hook shows two pallets with contract hooks that currently exhibit the same
+	// behavior. The behavior does not need to be identical in practice.
 
-// impl PalletHook<Runtime> for Precompiles {
-//     fn info(
-// 		contract_address: &::cosmwasm::types::AccountIdOf<Runtime>,
-// 	) -> Option<::cosmwasm::types::PalletContractCodeInfo<::cosmwasm::types::AccountIdOf<Runtime>, ::cosmwasm::types::ContractLabelOf<Runtime>, ::cosmwasm::types::ContractTrieIdOf<Runtime>>> {
-//         todo!()
-//     }
+	fn info(
+		contract_address: &AccountIdOf<Runtime>,
+	) -> Option<
+		PalletContractCodeInfo<AccountIdOf<Runtime>, ContractLabelOf<Runtime>, ContractTrieIdOf<Runtime>>,
+	> {
+		panic!()
+	}
 
-//     fn execute<'a>(
-// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
-// 		entrypoint: ::cosmwasm::types::EntryPoint,
-// 		message: &[u8],
-// 	) -> Result<
-// 		ContractResult<Response<<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
-// 		VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>,
-// 	> {
-//         todo!()
-//     }
+	fn execute<'a>(
+		vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
+		entrypoint: EntryPoint,
+		message: &[u8],
+	) -> Result<
+		ContractResult<Response<<OwnedWasmiVM<CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
+		VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>,
+	> {
+		panic!()
+	}
 
-//     fn run<'a>(
-// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
-// 		entrypoint: ::cosmwasm::types::EntryPoint,
-// 		message: &[u8],
-// 	) -> Result<Vec<u8>, VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>> {
-//         todo!()
-//     }
+	fn query<'a>(
+		vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
+		_message: &[u8],
+	) -> Result<ContractResult<QueryResponse>, VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>> {
+		panic!()
+	}
 
-//     fn query<'a>(
-// 		vm: &mut OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>,
-// 		message: &[u8],
-// 	) -> Result<ContractResult<QueryResponse>, VmErrorOf<OwnedWasmiVM<::cosmwasm::runtimes::vm::CosmwasmVM<'a, Runtime>>>> {
-//         todo!()
-//     }
-// }
+	fn run<'a>(
+		vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
+		_entrypoint: EntryPoint,
+		_message: &[u8],
+	) -> Result<Vec<u8>, VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>> {
+		panic!()
+	}
+}
+
+

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -1,10 +1,10 @@
 use ::cosmwasm::pallet_hook::PalletHook;
 use cosmwasm::{
 	instrument::CostRules,
-	runtimes::vm::CosmwasmVM,
+	runtimes::vm::{CosmwasmVM, CosmwasmVMError},
 	types::{
-		AccountIdOf, CodeInfo, ContractLabelOf, ContractTrieIdOf, EntryPoint,
-		PalletContractCodeInfo, ContractInfo,
+		AccountIdOf, ContractLabelOf, ContractTrieIdOf, EntryPoint,
+		PalletContractCodeInfo,
 	},
 };
 use cosmwasm_vm::{
@@ -177,22 +177,24 @@ impl PalletHook<Runtime> for Precompiles {
 	) -> Result<
 		ContractResult<Response<<OwnedWasmiVM<CosmwasmVM<'a, Runtime>> as VMBase>::MessageCustom>>,
 		VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>,
-	> {
-		panic!()
+	> {		
+	  log::error!("{:?}{:?}{:?}", &vm.0.data().contract_address, &entrypoint, String::from_utf8_lossy(message));
+	  Err(CosmwasmVMError::ContractNotFound)
 	}
 
 	fn run<'a>(
-		vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
+		_vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
 		_entrypoint: EntryPoint,
 		_message: &[u8],
 	) -> Result<Vec<u8>, VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>> {
-		panic!()
+		Err(CosmwasmVMError::ContractNotFound)
 	}
 
 	fn query<'a>(
 		vm: &mut OwnedWasmiVM<CosmwasmVM<'a, Runtime>>,
-		_message: &[u8],
+		message: &[u8],
 	) -> Result<ContractResult<QueryResponse>, VmErrorOf<OwnedWasmiVM<CosmwasmVM<'a, Runtime>>>> {
-		panic!()
+		log::error!("{:?}{:?}", &vm.0.data().contract_address, String::from_utf8_lossy(message));
+		Err(CosmwasmVMError::ContractNotFound)
 	}
 }

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(
 	not(test),
-	warn(
+	deny(
 		clippy::disallowed_methods,
 		clippy::disallowed_types,
 		clippy::indexing_slicing,
@@ -32,6 +32,7 @@ mod migrations;
 mod prelude;
 pub mod version;
 mod weights;
+mod contracts;
 pub mod xcmp;
 pub use common::xcmp::{MaxInstructions, UnitWeightCost};
 pub use fees::{AssetsPaymentHeader, FinalPriceConverter};
@@ -54,7 +55,6 @@ use composable_traits::{
 	assets::Asset,
 	dex::{Amm, PriceAggregate},
 };
-use cosmwasm::instrument::CostRules;
 use pallet_ibc::ics20_fee::FlatFeeConverter;
 use primitives::currency::ForeignAssetId;
 use sp_runtime::traits::Get;
@@ -366,129 +366,6 @@ parameter_types! {
 	pub const ExpectedBlockTime: u64 = SLOT_DURATION;
 }
 
-/// Native <-> Cosmwasm account mapping
-pub struct AccountToAddr;
-
-impl Convert<alloc::string::String, Result<AccountId, ()>> for AccountToAddr {
-	fn convert(a: alloc::string::String) -> Result<AccountId, ()> {
-		let account =
-			ibc_primitives::runtime_interface::ss58_to_account_id_32(&a).map_err(|_| ())?;
-		Ok(account.into())
-	}
-}
-
-impl Convert<AccountId, alloc::string::String> for AccountToAddr {
-	fn convert(a: AccountId) -> alloc::string::String {
-		let account = ibc_primitives::runtime_interface::account_id_to_ss58(a.into(), 49);
-		String::from_utf8_lossy(account.as_slice()).to_string()
-	}
-}
-
-impl Convert<Vec<u8>, Result<AccountId, ()>> for AccountToAddr {
-	fn convert(a: Vec<u8>) -> Result<AccountId, ()> {
-		Ok(<[u8; 32]>::try_from(a).map_err(|_| ())?.into())
-	}
-}
-
-/// Native <-> Cosmwasm asset mapping
-pub struct AssetToDenom;
-
-impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
-	fn convert(currency_id: alloc::string::String) -> Result<CurrencyId, ()> {
-		core::str::FromStr::from_str(&currency_id).map_err(|_| ())
-	}
-}
-
-impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
-	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
-		alloc::format!("{}", currency_id)
-	}
-}
-
-parameter_types! {
-	pub const CosmwasmPalletId: PalletId = PalletId(*b"cosmwasm");
-	pub const ChainId: &'static str = "composable-network-picasso";
-	pub const MaxInstrumentedCodeSize: u32 = 1024 * 1024;
-	pub const MaxContractLabelSize: u32 = 64;
-	pub const MaxContractTrieIdSize: u32 = Hash::len_bytes() as u32;
-	pub const MaxInstantiateSaltSize: u32 = 128;
-	pub const MaxFundsAssets: u32 = 32;
-	pub const CodeTableSizeLimit: u32 = 4096;
-	pub const CodeGlobalVariableLimit: u32 = 256;
-	pub const CodeParameterLimit: u32 = 128;
-	pub const CodeBranchTableSizeLimit: u32 = 256;
-
-	// TODO: benchmark for proper values
-	pub const CodeStorageByteDeposit: u32 = 1_000_000;
-	pub const ContractStorageByteReadPrice: u32 = 1;
-	pub const ContractStorageByteWritePrice: u32 = 1;
-	pub WasmCostRules: CostRules<Runtime> = Default::default();
-}
-
-impl cosmwasm::Config for Runtime {
-	type RuntimeEvent = RuntimeEvent;
-	type AccountIdExtended = AccountId;
-	type PalletId = CosmwasmPalletId;
-	type MaxFrames = ConstU32<64>;
-	type MaxCodeSize = ConstU32<{ 512 * 1024 }>;
-	type MaxInstrumentedCodeSize = MaxInstrumentedCodeSize;
-
-	#[cfg(feature = "testnet")]
-	type MaxMessageSize = ConstU32<{ 128 * 1024 }>;
-
-	#[cfg(not(feature = "testnet"))]
-	type MaxMessageSize = ConstU32<{ 32 * 1024 }>;
-
-	type AccountToAddr = AccountToAddr;
-
-	type AssetToDenom = AssetToDenom;
-
-	type Balance = Balance;
-	type AssetId = CurrencyId;
-	type Assets = AssetsTransactorRouter;
-	type NativeAsset = Balances;
-	type ChainId = ChainId;
-	type MaxContractLabelSize = MaxContractLabelSize;
-	type MaxContractTrieIdSize = MaxContractTrieIdSize;
-	type MaxInstantiateSaltSize = MaxInstantiateSaltSize;
-	type MaxFundsAssets = MaxFundsAssets;
-
-	type CodeTableSizeLimit = CodeTableSizeLimit;
-	type CodeGlobalVariableLimit = CodeGlobalVariableLimit;
-	type CodeStackLimit = ConstU32<{ u32::MAX }>;
-
-	type CodeParameterLimit = CodeParameterLimit;
-	type CodeBranchTableSizeLimit = CodeBranchTableSizeLimit;
-	type CodeStorageByteDeposit = CodeStorageByteDeposit;
-	type ContractStorageByteReadPrice = ContractStorageByteReadPrice;
-	type ContractStorageByteWritePrice = ContractStorageByteWritePrice;
-
-	type WasmCostRules = WasmCostRules;
-	type UnixTime = Timestamp;
-	type WeightInfo = cosmwasm::weights::SubstrateWeight<Runtime>;
-	type IbcRelayerAccount = TreasuryAccount;
-
-	// this was setup in repo in Jan 2023, so need to enable IBC in CW back
-	type IbcRelayer = cosmwasm::NoRelayer<Runtime>;
-
-	type PalletHook = ();
-
-	#[cfg(feature = "testnet")]
-	type UploadWasmOrigin = system::EnsureSigned<Self::AccountId>;
-
-	#[cfg(feature = "testnet")]
-	type ExecuteWasmOrigin = system::EnsureSigned<Self::AccountId>;
-
-	// really need to do EnsureOnOf<Sudo::key, >
-	#[cfg(not(feature = "testnet"))]
-	type UploadWasmOrigin = system::EnsureSignedBy<TechnicalCommitteeMembership, Self::AccountId>;
-
-	#[cfg(not(feature = "testnet"))]
-	type ExecuteWasmOrigin = frame_support::traits::EitherOfDiverse<
-		system::EnsureSignedBy<TechnicalCommitteeMembership, Self::AccountId>,
-		system::EnsureSignedBy<ReleaseMembership, Self::AccountId>,
-	>;
-}
 
 parameter_types! {
 	pub const SpamProtectionDeposit: Balance = 1_000_000_000_000;

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -25,6 +25,7 @@ pub const WASM_BINARY_V2: Option<&[u8]> = None;
 
 extern crate alloc;
 
+mod contracts;
 mod fees;
 pub mod governance;
 pub mod ibc;
@@ -32,7 +33,6 @@ mod migrations;
 mod prelude;
 pub mod version;
 mod weights;
-mod contracts;
 pub mod xcmp;
 pub use common::xcmp::{MaxInstructions, UnitWeightCost};
 pub use fees::{AssetsPaymentHeader, FinalPriceConverter};
@@ -365,7 +365,6 @@ impl oracle::Config for Runtime {
 parameter_types! {
 	pub const ExpectedBlockTime: u64 = SLOT_DURATION;
 }
-
 
 parameter_types! {
 	pub const SpamProtectionDeposit: Balance = 1_000_000_000_000;

--- a/code/parachain/runtime/picasso/src/prelude.rs
+++ b/code/parachain/runtime/picasso/src/prelude.rs
@@ -1,9 +1,8 @@
-pub use alloc::string::{String, ToString,};
+pub use alloc::string::{String, ToString};
 pub use frame_support::{
 	traits::{Contains, PalletInfoAccess},
 	weights::Weight,
-	
 };
 pub use sp_core::{ConstBool, Get};
-pub use sp_std::{prelude::*, str::FromStr,};
+pub use sp_std::{prelude::*, str::FromStr};
 pub use sp_version::RuntimeVersion;

--- a/code/parachain/runtime/picasso/src/prelude.rs
+++ b/code/parachain/runtime/picasso/src/prelude.rs
@@ -1,8 +1,9 @@
-pub use alloc::string::{String, ToString};
+pub use alloc::string::{String, ToString,};
 pub use frame_support::{
 	traits::{Contains, PalletInfoAccess},
 	weights::Weight,
+	
 };
 pub use sp_core::{ConstBool, Get};
-pub use sp_std::{prelude::*, str::FromStr};
+pub use sp_std::{prelude::*, str::FromStr,};
 pub use sp_version::RuntimeVersion;

--- a/code/parachain/runtime/primitives/Cargo.toml
+++ b/code/parachain/runtime/primitives/Cargo.toml
@@ -18,7 +18,7 @@ lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 scale-info = { version = "2.1.1", default-features = false, features = [
   "derive",
 ] }
-serde = { version = '1.0.136', optional = true, features = ['derive'] }
+serde = { workspace = true, default-features = false, features = ['derive'] }
 sp-runtime = { default-features = false, workspace = true }
 sp-std = { default-features = false, workspace = true }
 sp-core = { default-features = false, workspace = true }
@@ -33,7 +33,6 @@ ibc-rs-scale = { workspace = true, default-features = false, features = [
 [features]
 default = ["std"]
 std = [
-  "serde",
   "codec/std",
   "sp-runtime/std",
   "composable-traits/std",

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -50,7 +50,8 @@ pub trait WellKnownCurrency {
 	TypeInfo,
 	CompactAs,
 	Hash,
-	Serialize, Deserialize
+	Serialize,
+	Deserialize,
 )]
 #[repr(transparent)]
 #[serde(transparent)]

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -11,7 +11,6 @@ use sp_runtime::{
 
 use crate::prelude::*;
 
-#[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 
 use xcm::{latest::prelude::*, v3};
@@ -51,10 +50,10 @@ pub trait WellKnownCurrency {
 	TypeInfo,
 	CompactAs,
 	Hash,
+	Serialize, Deserialize
 )]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[repr(transparent)]
-#[cfg_attr(feature = "std", serde(transparent))]
+#[serde(transparent)]
 pub struct CurrencyId(pub u128);
 
 impl FromStr for CurrencyId {

--- a/inputs/centauri/flake-module.nix
+++ b/inputs/centauri/flake-module.nix
@@ -28,7 +28,6 @@
         prometheus_endpoint = "https://127.0.0.1";
       };
 
-
       # so not yet finalizes connection, working on it
       composable-polkadot = {
         type = "composable";


### PR DESCRIPTION
- moves cw to separate mod in runtime so easy to code and read
- adds precompiles for dex (put it into router because osmosis really does router, not dex, so no pools, so need to make router like osmosis i guess)
- makes pablo precompile 
- moved cw crates into workspace deps, more workspace deps

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR