### PR TITLE
Prefer `x.to_string()` over `format!("{}", x)`

### DIFF
--- a/code/parachain/frame/cosmwasm/cli/src/substrate/types.rs
+++ b/code/parachain/frame/cosmwasm/cli/src/substrate/types.rs
@@ -57,7 +57,7 @@ pub mod cosmwasm {
 	impl From<events::Uploaded> for Uploaded {
 		fn from(uploaded: events::Uploaded) -> Self {
 			Self {
-				code_hash: format!("{}", AccountId32::from(uploaded.code_hash)),
+				code_hash: AccountId32::from(uploaded.code_hash).to_string(),
 				code_id: uploaded.code_id,
 			}
 		}

--- a/code/parachain/frame/cosmwasm/rpc/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/rpc/src/lib.rs
@@ -62,7 +62,7 @@ impl<C, M> Cosmwasm<C, M> {
 fn runtime_error_into_rpc_error(e: impl Display) -> RpcError {
 	RpcError::Call(CallError::Custom(ErrorObject::owned(
 		9876, // no real reason for this value
-		format!("{}", e),
+		e.to_string(),
 		None::<()>,
 	)))
 }

--- a/code/parachain/frame/cosmwasm/src/ibc.rs
+++ b/code/parachain/frame/cosmwasm/src/ibc.rs
@@ -298,7 +298,7 @@ impl<T: Config> Router<T> {
 						CosmwasmVMError::<T>::Ibc(format!("failed to execute IBC callback {:?}", x))
 					})?;
 					serde_json::from_slice(&result)
-						.map_err(|x| CosmwasmVMError::<T>::Ibc(format!("{}", x)))
+						.map_err(|x| CosmwasmVMError::<T>::Ibc(x.to_string()))
 				},
 			}
 		})

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -38,6 +38,8 @@
 
 extern crate alloc;
 
+use alloc::string::ToString;
+
 pub use pallet::*;
 pub mod crypto;
 pub mod dispatchable_call;
@@ -564,8 +566,8 @@ pub fn query<T: Config>(
 	query_request: Vec<u8>,
 ) -> Result<QueryResponse, CosmwasmVMError<T>> {
 	let mut shared = Pallet::<T>::do_create_vm_shared(gas, InitialStorageMutability::ReadOnly);
-	let query_request = serde_json::from_slice(&query_request)
-		.map_err(|e| CosmwasmVMError::Rpc(format!("{}", e)))?;
+	let query_request =
+		serde_json::from_slice(&query_request).map_err(|e| CosmwasmVMError::Rpc(e.to_string()))?;
 	Pallet::<T>::sub_level_dispatch(
 		&mut shared,
 		contract.clone(),

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -249,7 +249,7 @@ impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
 
 impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
 	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
-		alloc::format!("{}", currency_id)
+		currency_id.to_string()
 	}
 }
 

--- a/code/parachain/frame/vesting/cli/src/main.rs
+++ b/code/parachain/frame/vesting/cli/src/main.rs
@@ -81,17 +81,13 @@ async fn main() -> anyhow::Result<()> {
 				let out = OutputRecord {
 					to: record.account,
 					// in substrate unix time is in milliseconds, while in unix it is in seconds
-					window_start: format!(
-						"{}",
-						OffsetDateTime::from_unix_timestamp(
-							(record.window_moment_start / 1000) as i64
-						)
+					window_start: OffsetDateTime::from_unix_timestamp(
+						(record.window_moment_start / 1000) as i64
+					)
 						.unwrap()
-					),
-					window_period: format!(
-						"{}",
-						Duration::milliseconds(record.window_moment_period as i64)
-					),
+						.to_string(),
+					window_period: Duration::milliseconds(record.window_moment_period as i64)
+						.to_string(),
 					total: record.per_period * record.period_count as u128,
 				};
 				if std::time::SystemTime::UNIX_EPOCH
@@ -403,22 +399,16 @@ async fn main() -> anyhow::Result<()> {
 					};
 					let window_start = match OffsetDateTime::from_unix_timestamp(
 						(window_moment_start / 1000) as i64,
-					)
-					.map(|x| format!("{}", x))
-					.map_err(|_x| "#BAD_START_TME".to_string())
-					{
-						Err(x) => x,
-						Ok(x) => x,
+					) {
+						Ok(x) => x.to_string(),
+						Err(x) => String::from("#BAD_START_TME"),
 					};
 					out.serialize(ListRecord {
 						pubkey: hex::encode(&key.2),
 						account: key.2.to_string(),
 
 						window_start,
-						window_period: format!(
-							"{}",
-							Duration::milliseconds(window_moment_period as i64)
-						),
+						window_period: Duration::milliseconds(window_moment_period as i64).to_string(),
 						total: record.per_period * record.period_count as u128,
 						already_claimed: record.already_claimed,
 						per_period: record.per_period,

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -52,7 +52,7 @@ impl Convert<alloc::string::String, Result<CurrencyId, ()>> for AssetToDenom {
 
 impl Convert<CurrencyId, alloc::string::String> for AssetToDenom {
 	fn convert(CurrencyId(currency_id): CurrencyId) -> alloc::string::String {
-		alloc::format!("{}", currency_id)
+		currency_id.to_string()
 	}
 }
 

--- a/code/utils/price-feed/src/feed/binance.rs
+++ b/code/utils/price-feed/src/feed/binance.rs
@@ -40,7 +40,7 @@ impl BinanceFeed {
 				let asset_pair = AssetPair::new(asset, quote_asset).unwrap_or_else(|| {
 					panic!("asset {:?} should be quotable in {:?}", asset, quote_asset)
 				});
-				format!("{}", ConcatSymbol::new(asset_pair))
+				ConcatSymbol::new(asset_pair).to_string()
 			})
 			.zip(assets.iter().copied())
 			.collect::<HashMap<_, _>>();

--- a/code/utils/price-feed/src/feed/pyth.rs
+++ b/code/utils/price-feed/src/feed/pyth.rs
@@ -195,7 +195,7 @@ impl Pyth {
 		sink: &mpsc::Sender<PythFeedNotification>,
 		asset_pair: &AssetPair,
 	) -> Result<(), PythError> {
-		let asset_pair_symbol = format!("{}", SlashSymbol::new(*asset_pair));
+		let asset_pair_symbol = SlashSymbol::new(*asset_pair).to_string();
 		let product_prices = self
 			.get_product_list()
 			.await?

--- a/code/utils/price-feed/src/frontend.rs
+++ b/code/utils/price-feed/src/frontend.rs
@@ -95,17 +95,14 @@ fn get_price(
 		Ok((normalized_price, elapsed)) => Ok(reply::with_header(
 			reply::with_header(
 				reply::with_status(
-					reply::json(&HashMap::from([(
-						format!("{}", currency_index),
-						normalized_price,
-					)])),
+					reply::json(&HashMap::from([(currency_index.to_string(), normalized_price)])),
 					StatusCode::OK,
 				),
 				"x-composable-cache-elapsed",
-				format!("{}", elapsed),
+				elapsed.to_string(),
 			),
 			"x-composable-cache-duration",
-			format!("{}", cache_duration),
+			cache_duration.to_string(),
 		)),
 		Err(_) => Err(warp::reject::not_found()),
 	}

--- a/code/xcvm/cosmwasm/contracts/asset-registry/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/asset-registry/src/contract.rs
@@ -74,7 +74,7 @@ pub fn handle_register_asset(
 		Ok(Response::new().add_event(
 			Event::new(XCVM_ASSET_REGISTRY_EVENT_PREFIX)
 				.add_attribute("action", "register")
-				.add_attribute("asset_id", format!("{}", asset_id.0 .0 .0))
+				.add_attribute("asset_id", asset_id.0 .0 .0.to_string())
 				.add_attribute("denom", reference.denom()),
 		))
 	} else {
@@ -91,7 +91,7 @@ pub fn handle_unregister_asset(
 		Ok(Response::new().add_event(
 			Event::new(XCVM_ASSET_REGISTRY_EVENT_PREFIX)
 				.add_attribute("action", "unregister")
-				.add_attribute("asset_id", format!("{}", asset_id.0 .0 .0)),
+				.add_attribute("asset_id", asset_id.0 .0 .0.to_string()),
 		))
 	} else {
 		Err(ContractError::NotRegistered)

--- a/code/xcvm/cosmwasm/contracts/gateway/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/contract.rs
@@ -251,7 +251,7 @@ pub fn ibc_packet_receive(
 				Event::new(XCVM_GATEWAY_EVENT_PREFIX)
 					.add_attribute("action", "receive")
 					.add_attribute("result", "failure")
-					.add_attribute("reason", format!("{}", e)),
+					.add_attribute("reason", e.to_string()),
 			)
 			.set_ack(XCVMAck::KO)),
 	}
@@ -289,7 +289,7 @@ pub fn ibc_packet_ack(
 		.add_event(
 			Event::new(XCVM_GATEWAY_EVENT_PREFIX)
 				.add_attribute("action", "ack")
-				.add_attribute("ack", format!("{}", ack.value())),
+				.add_attribute("ack", ack.value().to_string()),
 		)
 		.add_messages(messages))
 }
@@ -328,7 +328,7 @@ pub fn handle_batch_reply(msg: Reply) -> Result<Response, ContractError> {
 				Event::new(XCVM_GATEWAY_EVENT_PREFIX)
 					.add_attribute("action", "receive")
 					.add_attribute("result", "failure")
-					.add_attribute("reason", format!("{}", e)),
+					.add_attribute("reason", e.to_string()),
 			)
 			.set_data(XCVMAck::KO)),
 	}
@@ -459,8 +459,7 @@ pub fn handle_bridge(
 						.map_err(|_| ContractError::FailedToSerialize)?,
 				);
 			if salt.len() >= 3 {
-				event =
-					event.add_attribute("salt", format!("{}", Binary::from(packet.salt.clone())));
+				event = event.add_attribute("salt", Binary::from(packet.salt.clone()).to_string());
 			}
 			Ok(Response::default().add_event(event).add_message(IbcMsg::SendPacket {
 				channel_id,

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -139,7 +139,7 @@ fn add_owners(
 ) -> Result<Response, ContractError> {
 	let mut event = Event::new(XCVM_INTERPRETER_EVENT_PREFIX).add_attribute("action", "owners.add");
 	for owner in owners {
-		event = event.add_attribute("owner", format!("{}", owner));
+		event = event.add_attribute("owner", owner.to_string());
 		OWNERS.save(deps.storage, owner, &())?;
 	}
 	Ok(Response::default().add_event(event))
@@ -151,7 +151,7 @@ fn remove_owners(_: Authenticated, deps: DepsMut, owners: Vec<Addr>) -> Response
 	let mut event =
 		Event::new(XCVM_INTERPRETER_EVENT_PREFIX).add_attribute("action", "owners.remove");
 	for owner in owners {
-		event = event.add_attribute("owner", format!("{}", owner));
+		event = event.add_attribute("owner", owner.to_string());
 		OWNERS.remove(deps.storage, owner);
 	}
 	Response::default().add_event(event)
@@ -249,10 +249,8 @@ pub fn interpret_call(
 
 		apply_bindings(payload, bindings, &mut formatted_call, |binding| {
 			let data = match binding {
-				BindingValue::Register(Register::Ip) =>
-					Cow::Owned(format!("{}", instruction_pointer).into()),
-				BindingValue::Register(Register::Relayer) =>
-					Cow::Owned(format!("{}", relayer.clone()).into()),
+				BindingValue::Register(Register::Ip) => Cow::Owned(instruction_pointer.to_string()),
+				BindingValue::Register(Register::Relayer) => Cow::Owned(relayer.to_string()),
 				BindingValue::Register(Register::This) =>
 					Cow::Borrowed(env.contract.address.as_bytes()),
 				BindingValue::Register(Register::Result) => Cow::Owned(
@@ -267,7 +265,7 @@ pub fn interpret_call(
 					)?;
 					match reference {
 						AssetReference::Virtual { cw20_address } =>
-							Cow::Owned(cw20_address.into_string().into()),
+							Cow::Owned(cw20_address.into_string()),
 						AssetReference::Native { denom } => Cow::Owned(denom.into()),
 					}
 				},
@@ -297,7 +295,7 @@ pub fn interpret_call(
 									.map_err(|_| ContractError::ArithmeticError)
 							},
 					}?;
-					Cow::Owned(format!("{}", amount).into())
+					Cow::Owned(amount.to_string())
 				},
 			};
 			Ok(data)
@@ -407,7 +405,7 @@ pub fn interpret_spawn(
 					serde_json_wasm::to_string(&interpreter_origin.user_origin.user_id)
 						.map_err(|_| ContractError::DataSerializationError)?,
 				)
-				.add_attribute("network_id", format!("{}", network)),
+				.add_attribute("network_id", network.to_string()),
 		))
 }
 
@@ -496,8 +494,11 @@ fn handle_self_call_result(deps: DepsMut, msg: Reply) -> StdResult<Response> {
 			// this way, only the `RESULT_REGISTER` is persisted. All
 			// other state changes are reverted.
 			RESULT_REGISTER.save(deps.storage, &Err(e.clone()))?;
-			let ip_register = IP_REGISTER.load(deps.storage)?;
-			Ok(Response::default().add_event(Event::new(XCVM_INTERPRETER_EVENT_PREFIX).add_attribute("action", "execution.failure").add_attribute("reason", e.to_string())).add_attribute("ip", format!("{}", ip_register)))
+			let ip = IP_REGISTER.load(deps.storage)?.to_string();
+			let event = Event::new(XCVM_INTERPRETER_EVENT_PREFIX)
+				.add_attribute("action", "execution.failure")
+				.add_attribute("reason", e.to_string());
+			Ok(Response::default().add_event(event).add_attribute("ip", ip))
 		}
 	}
 }

--- a/code/xcvm/cosmwasm/contracts/router/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/router/src/contract.rs
@@ -223,16 +223,15 @@ fn handle_set_interpreter_security(
 		),
 	}?;
 
-	Ok(Response::default().add_event(
-		Event::new(XCVM_ROUTER_EVENT_PREFIX)
-			.add_attribute("action", "interpreter.setSecurity")
-			.add_attribute(
-				"network_id",
-				format!("{}", u32::from(interpreter_origin.user_origin.network_id)),
-			)
-			.add_attribute("user_id", hex::encode(&interpreter_origin.user_origin.user_id))
-			.add_attribute("security", format!("{}", security as u8)),
-	))
+	let event = Event::new(XCVM_ROUTER_EVENT_PREFIX)
+		.add_attribute("action", "interpreter.setSecurity")
+		.add_attribute(
+			"network_id",
+			u32::from(interpreter_origin.user_origin.network_id).to_string(),
+		)
+		.add_attribute("user_id", hex::encode(&interpreter_origin.user_origin.user_id))
+		.add_attribute("security", (security as u8).to_string());
+	Ok(Response::default().add_event(event))
 }
 
 /// Handle a request to execute a [`XCVMProgram`].
@@ -263,7 +262,6 @@ fn handle_execute_program(
 				send_funds_to_interpreter(deps.as_ref(), interpreter_address.clone(), assets)?;
 			let wasm_msg = wasm_execute(
 				interpreter_address.clone(),
-				
 				&cw_xcvm_interpreter::msg::ExecuteMsg::Execute {
 					relayer: call_origin.relayer().clone(),
 					program,

--- a/code/xcvm/cosmwasm/tests/src/tests/suite.rs
+++ b/code/xcvm/cosmwasm/tests/src/tests/suite.rs
@@ -412,7 +412,7 @@ fn xcvm_deploy_asset<A: Asset + AssetSymbol, T>(
 		events.registry_events.iter(),
 		XCVM_ASSET_REGISTRY_EVENT_PREFIX,
 		"asset_id",
-		&format!("{}", A::ID.0 .0),
+		&A::ID.0 .0.to_string(),
 	);
 	xcvm_assert_prefixed_event(
 		events.registry_events.iter(),


### PR DESCRIPTION
Rust is currently unable to optimise `format!("{}", x)` invocations which are noticeably slower than calls to `to_string` method.  Prefer the latter.

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production