### PR TITLE
xcvm: remove concept of bridge security

### DIFF
--- a/code/xcvm/cosmwasm/contracts/common/src/router.rs
+++ b/code/xcvm/cosmwasm/contracts/common/src/router.rs
@@ -2,7 +2,7 @@ use crate::shared::BridgeMsg;
 use cw_xcvm_utils::DefaultXCVMProgram;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xcvm_core::{BridgeSecurity, CallOrigin, Displayed, Funds, InterpreterOrigin};
+use xcvm_core::{CallOrigin, Displayed, Funds};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -28,14 +28,6 @@ pub enum ExecuteMsg {
 		/// Assets to fund the XCVM interpreter instance
 		/// The interpreter is funded prior to execution
 		assets: Funds<Displayed<u128>>,
-	},
-	/// Set a certain bridge security requirement for a specific interpreter even it hasn't
-	/// instantiated yet
-	SetInterpreterSecurity {
-		/// The interpreter origin we initiate this call for.
-		interpreter_origin: InterpreterOrigin,
-		/// The new bridge security the user is willing to take risk for.
-		bridge_security: BridgeSecurity,
 	},
 	BridgeForward {
 		/// The message we want to forward to the bridge gateway.

--- a/code/xcvm/cosmwasm/contracts/common/src/shared.rs
+++ b/code/xcvm/cosmwasm/contracts/common/src/shared.rs
@@ -2,13 +2,12 @@ use cosmwasm_std::{from_binary, to_binary, Binary, StdResult};
 use cw_xcvm_utils::DefaultXCVMProgram;
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use xcvm_core::{BridgeSecurity, Displayed, Funds, InterpreterOrigin, NetworkId};
+use xcvm_core::{Displayed, Funds, InterpreterOrigin, NetworkId};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct BridgeMsg {
 	pub interpreter_origin: InterpreterOrigin,
 	pub network_id: NetworkId,
-	pub security: BridgeSecurity,
 	pub salt: Vec<u8>,
 	pub program: DefaultXCVMProgram,
 	pub assets: Funds<Displayed<u128>>,

--- a/code/xcvm/cosmwasm/contracts/gateway/src/error.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/error.rs
@@ -18,8 +18,6 @@ pub enum ContractError {
 	UnsupportedNetwork,
 	#[error("Could not serialize to JSON")]
 	FailedToSerialize,
-	#[error("The required BridgeSecurity is not yet supported.")]
-	UnsupportedBridgeSecurity,
 	#[error("The asset is not yet supported.")]
 	UnsupportedAsset,
 	#[error("The contract must be initialized first.")]

--- a/code/xcvm/cosmwasm/contracts/gateway/src/state.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, IbcEndpoint};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xcvm_core::{BridgeId, BridgeSecurity, NetworkId};
+use xcvm_core::{BridgeId, NetworkId};
 
 pub type ChannelId = String;
 
@@ -23,7 +23,6 @@ pub struct Config {
 /// Bridge following the OTP specs.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Bridge {
-	pub security: BridgeSecurity,
 	pub address: Addr,
 }
 

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/error.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/error.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
-use xcvm_core::{BridgeSecurity, LateBindingError};
+use xcvm_core::LateBindingError;
 
 impl From<()> for ContractError {
 	fn from(_: ()) -> Self {
@@ -36,9 +36,6 @@ pub enum ContractError {
 
 	#[error("Bindings are invalid")]
 	InvalidBindings,
-
-	#[error("Expected bridge security to be at least {0:?}, got {1:?}")]
-	InsufficientBridgeSecurity(BridgeSecurity, BridgeSecurity),
 
 	#[error("Caller is not authenticated to take the action")]
 	NotAuthorized,

--- a/code/xcvm/cosmwasm/contracts/pingpong/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/pingpong/src/contract.rs
@@ -16,7 +16,7 @@ use cw_utils::ensure_from_older_version;
 use cw_xcvm_utils::DefaultXCVMProgram;
 use xcvm_core::{
 	cosmwasm::{FlatCosmosMsg, FlatWasmMsg},
-	Balance, BridgeSecurity, Funds, Juno, Network, Picasso, ProgramBuilder, UserId, UserOrigin,
+	Balance, Funds, Juno, Network, Picasso, ProgramBuilder, UserId, UserOrigin,
 };
 
 const CONTRACT_NAME: &str = "composable:xcvm-pingpong";
@@ -45,7 +45,6 @@ fn make_program<T: Network<EncodedCall = Vec<u8>>, U: Network<EncodedCall = Vec<
 		.spawn::<U, (), _, _>(
 			"PONG".as_bytes().to_vec(),
 			vec![0x01, 0x02, 0x03],
-			BridgeSecurity::Deterministic,
 			Funds::<Balance>::empty(),
 			|child| {
 				Ok(child.call_raw(

--- a/code/xcvm/cosmwasm/contracts/router/src/error.rs
+++ b/code/xcvm/cosmwasm/contracts/router/src/error.rs
@@ -1,14 +1,10 @@
 use cosmwasm_std::StdError;
 use thiserror::Error;
-use xcvm_core::BridgeSecurity;
 
 #[derive(Error, Debug)]
 pub enum ContractError {
 	#[error("{0}")]
 	Std(#[from] StdError),
-
-	#[error("Security requirement not meet, expected {0:?}")]
-	ExpectedBridgeSecurity(BridgeSecurity),
 
 	#[error("Caller is not authorized to take this action")]
 	NotAuthorized,

--- a/code/xcvm/cosmwasm/contracts/router/src/state.rs
+++ b/code/xcvm/cosmwasm/contracts/router/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::Addr;
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xcvm_core::{BridgeSecurity, InterpreterOrigin, NetworkId};
+use xcvm_core::{InterpreterOrigin, NetworkId};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
@@ -15,7 +15,6 @@ pub struct Config {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Interpreter {
 	pub address: Option<Addr>,
-	pub security: BridgeSecurity,
 }
 
 pub const INTERPRETERS: Map<InterpreterOrigin, Interpreter> = Map::new("interpreters");

--- a/code/xcvm/cosmwasm/tests/src/tests/suite.rs
+++ b/code/xcvm/cosmwasm/tests/src/tests/suite.rs
@@ -16,8 +16,8 @@ use cw_xcvm_utils::{DefaultXCVMProgram, Salt};
 use proptest::{prelude::any, prop_assume, prop_compose, proptest};
 use std::assert_matches::assert_matches;
 use xcvm_core::{
-	Asset, AssetId, AssetSymbol, Balance, BridgeSecurity, Destination, Funds, Juno, Network,
-	Picasso, ProgramBuilder, ETH, PICA, USDC, USDT,
+	Asset, AssetId, AssetSymbol, Balance, Destination, Funds, Juno, Network, Picasso,
+	ProgramBuilder, ETH, PICA, USDC, USDT,
 };
 
 #[macro_export]
@@ -668,18 +668,10 @@ mod cross_chain {
 		.expect("Must be able to create an XCVM network.");
 		let assets_to_transfer = [(PICA::ID, transfer_amount)];
 		let program = ProgramBuilder::<Picasso, CanonicalAddr, Funds<Balance>>::new([])
-			.spawn::<Juno, (), _, _>(
-				[],
-				[],
-				BridgeSecurity::Deterministic,
-				assets_to_transfer,
-				|juno_program| {
-					Ok(juno_program.transfer(
-						Destination::Account(to_canonical(bob.clone())),
-						assets_to_transfer,
-					))
-				},
-			)
+			.spawn::<Juno, (), _, _>([], [], assets_to_transfer, |juno_program| {
+				Ok(juno_program
+					.transfer(Destination::Account(to_canonical(bob.clone())), assets_to_transfer))
+			})
 			.expect("Must be able to build an XCVM program.")
 			.build();
 		let CrossChainDispatchResult { dispatch_data, relay_data, .. } = network

--- a/code/xcvm/lib/core/src/bridge.rs
+++ b/code/xcvm/lib/core/src/bridge.rs
@@ -1,47 +1,9 @@
 use crate::{NetworkId, UserOrigin};
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
-use core::cmp::Ordering;
 use cosmwasm_std::Addr;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-
-/// Security associated with a bridge.
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-#[repr(u8)]
-pub enum BridgeSecurity {
-	Insecure = 0,
-	Optimistic = 1,
-	Probabilistic = 2,
-	Deterministic = 3,
-}
-
-// Keep the ordering explicit.
-impl PartialOrd for BridgeSecurity {
-	#[inline]
-	fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-		Some(match (self, other) {
-			(BridgeSecurity::Insecure, BridgeSecurity::Insecure) => Ordering::Equal,
-			(BridgeSecurity::Insecure, BridgeSecurity::Deterministic) => Ordering::Less,
-			(BridgeSecurity::Insecure, BridgeSecurity::Probabilistic) => Ordering::Less,
-			(BridgeSecurity::Insecure, BridgeSecurity::Optimistic) => Ordering::Less,
-			(BridgeSecurity::Deterministic, BridgeSecurity::Insecure) => Ordering::Greater,
-			(BridgeSecurity::Deterministic, BridgeSecurity::Deterministic) => Ordering::Equal,
-			(BridgeSecurity::Deterministic, BridgeSecurity::Probabilistic) => Ordering::Greater,
-			(BridgeSecurity::Deterministic, BridgeSecurity::Optimistic) => Ordering::Greater,
-			(BridgeSecurity::Probabilistic, BridgeSecurity::Insecure) => Ordering::Greater,
-			(BridgeSecurity::Probabilistic, BridgeSecurity::Deterministic) => Ordering::Less,
-			(BridgeSecurity::Probabilistic, BridgeSecurity::Probabilistic) => Ordering::Equal,
-			(BridgeSecurity::Probabilistic, BridgeSecurity::Optimistic) => Ordering::Greater,
-			(BridgeSecurity::Optimistic, BridgeSecurity::Insecure) => Ordering::Greater,
-			(BridgeSecurity::Optimistic, BridgeSecurity::Deterministic) => Ordering::Less,
-			(BridgeSecurity::Optimistic, BridgeSecurity::Probabilistic) => Ordering::Less,
-			(BridgeSecurity::Optimistic, BridgeSecurity::Optimistic) => Ordering::Equal,
-		})
-	}
-}
 
 /// Unique identity of a bridge in a given chain, usually a public key.
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
@@ -59,20 +21,7 @@ pub struct BridgeId(Vec<u8>);
 pub enum BridgeProtocol {
 	IBC,
 	XCM,
-	OTP { id: BridgeId, security: BridgeSecurity },
-}
-
-impl BridgeProtocol {
-	/// Ensure that a protocol enforce the minimum requested security.
-	pub fn ensure_security(&self, security: BridgeSecurity) -> Result<(), ()> {
-		match self {
-			BridgeProtocol::IBC => Ok(()),
-			BridgeProtocol::XCM => Ok(()),
-			BridgeProtocol::OTP { security: otp_security, .. } if *otp_security >= security =>
-				Ok(()),
-			_ => Err(()),
-		}
-	}
+	OTP { id: BridgeId },
 }
 
 /// The Origin that executed the XCVM operation.
@@ -99,15 +48,6 @@ impl CallOrigin {
 		match self {
 			CallOrigin::Remote { relayer, .. } => relayer,
 			CallOrigin::Local { user } => user,
-		}
-	}
-
-	/// Ensure that the call origin meet the security requirement.
-	/// If the call is originating from the local chain, it is considered trusted.
-	pub fn ensure_security(&self, security: BridgeSecurity) -> Result<(), ()> {
-		match self {
-			CallOrigin::Remote { protocol, .. } => protocol.ensure_security(security),
-			CallOrigin::Local { .. } => Ok(()),
 		}
 	}
 }

--- a/code/xcvm/lib/core/src/instruction.rs
+++ b/code/xcvm/lib/core/src/instruction.rs
@@ -1,4 +1,4 @@
-use crate::{AssetId, Balance, BridgeSecurity, Program};
+use crate::{AssetId, Balance, Program};
 use alloc::{
 	borrow::Cow,
 	collections::{BTreeMap, VecDeque},
@@ -72,13 +72,7 @@ pub enum Instruction<Network, Payload, Account, Assets> {
 	/// The program will be spawned with the desired [`Assets`].
 	/// The salt is used to track the program when events are dispatched in the network.
 	#[serde(rename_all = "snake_case")]
-	Spawn {
-		network: Network,
-		bridge_security: BridgeSecurity,
-		salt: Vec<u8>,
-		assets: Assets,
-		program: Program<VecDeque<Self>>,
-	},
+	Spawn { network: Network, salt: Vec<u8>, assets: Assets, program: Program<VecDeque<Self>> },
 	/// Query the state of a contract
 	#[serde(rename_all = "snake_case")]
 	Query { network: Network, salt: Vec<u8> },

--- a/code/xcvm/lib/core/src/lib.rs
+++ b/code/xcvm/lib/core/src/lib.rs
@@ -50,7 +50,6 @@ where
 		self,
 		tag: impl Into<Vec<u8>>,
 		salt: impl Into<Vec<u8>>,
-		bridge_security: impl Into<BridgeSecurity>,
 		assets: impl Into<Assets>,
 		f: F,
 	) -> Result<ProgramBuilder<FinalNetwork, Account, Assets>, E>
@@ -67,7 +66,6 @@ where
 		let mut builder =
 			ProgramBuilder { tag: self.tag, instructions: self.instructions, _marker: PhantomData };
 		builder.instructions.push_back(Instruction::Spawn {
-			bridge_security: bridge_security.into(),
 			salt: salt.into(),
 			assets: assets.into(),
 			network: SpawningNetwork::ID,
@@ -156,7 +154,6 @@ mod tests {
 				.spawn::<Ethereum, ProgramBuildError, _, _>(
 					Vec::default(),
 					Vec::default(),
-					BridgeSecurity::Deterministic,
 					Funds::empty(),
 					|child| {
 						Ok(child
@@ -179,7 +176,6 @@ mod tests {
 					// Move to ethereum
 					Instruction::Spawn {
 						network: Ethereum::ID,
-						bridge_security: BridgeSecurity::Deterministic,
 						salt: Vec::new(),
 						assets: Funds::empty(),
 						program: Program {

--- a/code/xcvm/lib/proto/protos/xcvm_program.proto
+++ b/code/xcvm/lib/proto/protos/xcvm_program.proto
@@ -137,16 +137,8 @@ message Network {
   uint32 networkId = 1;
 }
 
-enum BridgeSecurity {
-  insecure = 0;
-  optimistic = 1;
-  probabilistic = 2;
-  deterministic = 3;
-}
-
 message Spawn {
   Network network = 1;
-  BridgeSecurity security = 2;
   Salt salt = 3;
   Program program = 4;
   repeated Asset assets = 5;

--- a/code/xcvm/lib/proto/src/lib.rs
+++ b/code/xcvm/lib/proto/src/lib.rs
@@ -348,13 +348,6 @@ where
 		Ok(xcvm_core::Instruction::Spawn {
 			network,
 			salt,
-			bridge_security: match spawn.security {
-				0 => xcvm_core::BridgeSecurity::Insecure,
-				1 => xcvm_core::BridgeSecurity::Optimistic,
-				2 => xcvm_core::BridgeSecurity::Probabilistic,
-				3 => xcvm_core::BridgeSecurity::Deterministic,
-				_ => return Err(()),
-			},
 			assets: spawn
 				.assets
 				.into_iter()
@@ -599,10 +592,9 @@ where
 						bindings: bindings.into_iter().map(|binding| binding.into()).collect(),
 					}),
 				}),
-			xcvm_core::Instruction::Spawn { network, bridge_security, salt, assets, program } =>
+			xcvm_core::Instruction::Spawn { network, salt, assets, program } =>
 				instruction::Instruction::Spawn(Spawn {
 					network: Some(Network { network_id: network.into() }),
-					security: bridge_security as i32,
 					salt: Some(Salt { salt }),
 					program: Some(program.into()),
 					assets: assets.into().into_iter().map(|asset| asset.into()).collect(),

--- a/code/xcvm/xcvm-typescript-sdk/src/interpreter.proto
+++ b/code/xcvm/xcvm-typescript-sdk/src/interpreter.proto
@@ -59,11 +59,11 @@ message AssetId {
 }
 
 message GlobalId {
-  Uint128 globalId = 1; 
+  Uint128 globalId = 1;
 }
 
 message LocalId {
-  bytes localId = 1; 
+  bytes localId = 1;
 }
 
 message Asset {
@@ -129,16 +129,8 @@ message Network {
   Uint128 networkId = 1;
 }
 
-enum BridgeSecurity {
-  none = 0;
-  deterministic = 1;
-  probabilistic = 2;
-  optimistic = 3;
-}
-
 message Spawn {
   Network network = 1;
-  BridgeSecurity security = 2;
   Salt salt = 3;
   Program program = 4;
   repeated Asset assets = 5;
@@ -153,5 +145,3 @@ message Call {
   bytes payload = 1;
   Bindings bindings = 2;
 }
-
-

--- a/code/xcvm/xcvm-typescript-sdk/src/xcvm.ts
+++ b/code/xcvm/xcvm-typescript-sdk/src/xcvm.ts
@@ -22,7 +22,6 @@ export class XCVM {
   NetworkMessage: Type;
   SpawnMessage: Type;
   CallMessage: Type;
-  BridgeSecurityEnum: Enum;
   BindingValueMessage: Type
   Uint128Message: Type
   SelfMessage: Type
@@ -57,7 +56,6 @@ export class XCVM {
     this.RelayerMessage = this.root.lookupType("interpreter.Relayer");
     this.GlobalIdMessage = this.root.lookupType("interpreter.GlobalId");
     this.LocalIdMessage = this.root.lookupType("interpreter.LocalId");
-    this.BridgeSecurityEnum = this.root.lookupEnum("interpreter.BridgeSecurity");
 
     this.messageTypeLookUp['Program'] = this.ProgramMessage;
     this.messageTypeLookUp['Instruction'] = this.InstructionMessage;
@@ -78,7 +76,6 @@ export class XCVM {
     this.messageTypeLookUp['Salt'] = this.SaltMessage;
     this.messageTypeLookUp['Call'] = this.CallMessage;
     this.messageTypeLookUp['Spawn'] = this.SpawnMessage;
-    this.messageTypeLookUp['BridgeSecurity'] = this.BridgeSecurityEnum;
     this.messageTypeLookUp['Uint128'] = this.Uint128Message;
     this.messageTypeLookUp['Self'] = this.SelfMessage;
     this.messageTypeLookUp['Relayer'] = this.RelayerMessage;
@@ -244,11 +241,7 @@ export class XCVM {
   }
 
 
-  //public createBridgeSecurity(security: Number): Enum {
-  //  return security;
-  //}
-
-  public createSpawn(networkMessage: Message, saltMessage: Message, security: Number, programMessage: Message, assetsMessage: Array<Message>): Message<{}> {
+  public createSpawn(networkMessage: Message, saltMessage: Message, programMessage: Message, assetsMessage: Array<Message>): Message<{}> {
     if (networkMessage.$type.name != "Network") {
       throw this.getTypeError("networkMessage", "network")
     }
@@ -270,9 +263,7 @@ export class XCVM {
 
     return this.SpawnMessage.create({
       network: networkMessage,
-
       salt: saltMessage,
-      security: security,
       program: programMessage,
       assets: assetsMessage
     })


### PR DESCRIPTION
As we’re heading towards IBC-based solution, the bridge security concept is no longer necessary.  Simplify code by removing all handling of it.



- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production