### PR TITLE
xcvm: remove Query instruction

### DIFF
--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -184,8 +184,6 @@ pub fn handle_execute_step(
 			),
 			Instruction::Spawn { network, salt, assets, program } =>
 				interpret_spawn(&mut deps, &env, network, salt, assets, program),
-			// TODO(hussein-aitlahcen)
-			Instruction::Query { .. } => Ok(Response::default()),
 		}?;
 		// Save the intermediate IP so that if the execution fails, we can recover at which
 		// instruction it happened.

--- a/code/xcvm/lib/core/src/instruction.rs
+++ b/code/xcvm/lib/core/src/instruction.rs
@@ -54,7 +54,6 @@ pub enum Destination<Account> {
 #[serde(rename_all = "snake_case")]
 pub enum Instruction<Network, Payload, Account, Assets> {
 	/// Transfer some [`Assets`] from the current program to the [`to`] account.
-	#[serde(rename_all = "snake_case")]
 	Transfer { to: Destination<Account>, assets: Assets },
 	/// Arbitrary payload representing a raw call inside the current [`Network`].
 	///
@@ -65,17 +64,12 @@ pub enum Instruction<Network, Payload, Account, Assets> {
 	/// Depending on the network, the payload might be more structured than the base call.
 	/// For most of the network in fact, we need to provide the target address along the payload,
 	/// which can be encoded inside this single payload.
-	#[serde(rename_all = "snake_case")]
 	Call { bindings: Bindings, encoded: Payload },
 	/// Spawn a sub-program on the target `network`.
 	///
 	/// The program will be spawned with the desired [`Assets`].
 	/// The salt is used to track the program when events are dispatched in the network.
-	#[serde(rename_all = "snake_case")]
 	Spawn { network: Network, salt: Vec<u8>, assets: Assets, program: Program<VecDeque<Self>> },
-	/// Query the state of a contract
-	#[serde(rename_all = "snake_case")]
-	Query { network: Network, salt: Vec<u8> },
 }
 
 /// Error types for late binding operation

--- a/code/xcvm/lib/proto/protos/xcvm_program.proto
+++ b/code/xcvm/lib/proto/protos/xcvm_program.proto
@@ -39,7 +39,6 @@ message Instruction {
     Transfer transfer = 1;
     Spawn spawn = 2;
     Call call = 3;
-    Query query = 4;
   }
 }
 
@@ -142,11 +141,6 @@ message Spawn {
   Salt salt = 3;
   Program program = 4;
   repeated Asset assets = 5;
-}
-
-message Query {
-  Network network = 1;
-  Salt salt = 2;
 }
 
 message Call {

--- a/code/xcvm/lib/proto/src/lib.rs
+++ b/code/xcvm/lib/proto/src/lib.rs
@@ -259,9 +259,6 @@ where
 			instruction::Instruction::Transfer(t) => t.try_into(),
 			instruction::Instruction::Spawn(s) => s.try_into(),
 			instruction::Instruction::Call(c) => c.try_into(),
-			// TODO(aeryz): Query needs to be implemented
-			// instruction::Instruction::Query(q) => q.try_into(),
-			_ => Err(()),
 		}
 	}
 }
@@ -598,11 +595,6 @@ where
 					salt: Some(Salt { salt }),
 					program: Some(program.into()),
 					assets: assets.into().into_iter().map(|asset| asset.into()).collect(),
-				}),
-			xcvm_core::Instruction::Query { network, salt } =>
-				instruction::Instruction::Query(Query {
-					network: Some(Network { network_id: network.into() }),
-					salt: Some(Salt { salt }),
 				}),
 		}
 	}

--- a/code/xcvm/xcvm-typescript-sdk/src/interpreter.proto
+++ b/code/xcvm/xcvm-typescript-sdk/src/interpreter.proto
@@ -21,7 +21,6 @@ message Instruction {
     Transfer transfer = 1;
     Spawn spawn = 2;
     Call call = 3;
-    Query query = 4;
   }
 }
 
@@ -134,11 +133,6 @@ message Spawn {
   Salt salt = 3;
   Program program = 4;
   repeated Asset assets = 5;
-}
-
-message Query {
-  Network network = 1;
-  Salt salt = 2;
 }
 
 message Call {

--- a/code/xcvm/xcvm-typescript-sdk/src/xcvm.ts
+++ b/code/xcvm/xcvm-typescript-sdk/src/xcvm.ts
@@ -190,13 +190,6 @@ export class XCVM {
 
   public createInstruction(typedInstruction: Message): Message<{}> {
     const typeName = typedInstruction.$type.name;
-    if (typeName != "Transfer"
-      && typeName != "Spawn"
-      && typeName != "Call"
-      && typeName != "Query"
-    ) {
-      throw this.getTypeError("typedInstruction", "Transfer, Spawn, Call or Quey");
-    }
     if (typeName == "Transfer") {
       return this.InstructionMessage.create({transfer: typedInstruction})
     } else if (typeName == "Spawn") {
@@ -204,7 +197,7 @@ export class XCVM {
     } else if (typeName == "Call") {
       return this.InstructionMessage.create({call: typedInstruction})
     } else {
-      return this.InstructionMessage.create({query: typedInstruction})
+      throw this.getTypeError("typedInstruction", "Transfer, Spawn or Call");
     }
   }
 


### PR DESCRIPTION
The instruction is not implemented and current design doesn’t include it.  We can add it later when we need it.  For now it only clutters the code.



- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production