### PR TITLE
xcvm: remove vestigial support for XCM and OTP bridges

### DIFF
--- a/code/xcvm/cosmwasm/contracts/gateway/src/state.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/state.rs
@@ -2,7 +2,7 @@ use cosmwasm_std::{Addr, IbcEndpoint};
 use cw_storage_plus::{Item, Map};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use xc_core::{BridgeId, NetworkId};
+use xc_core::NetworkId;
 
 pub type ChannelId = String;
 
@@ -20,12 +20,6 @@ pub struct Config {
 	pub admin: String,
 }
 
-/// Bridge following the OTP specs.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct Bridge {
-	pub address: Addr,
-}
-
 /// Information associated with an IBC channel.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ChannelInfo {
@@ -39,7 +33,6 @@ pub struct ChannelInfo {
 
 pub const ROUTER: Item<Addr> = Item::new("router");
 pub const CONFIG: Item<Config> = Item::new("config");
-pub const BRIDGES: Map<BridgeId, Bridge> = Map::new("bridges");
 
 pub const IBC_CHANNEL_INFO: Map<ChannelId, ChannelInfo> = Map::new("ibc_channel_info");
 

--- a/code/xcvm/lib/core/src/bridge.rs
+++ b/code/xcvm/lib/core/src/bridge.rs
@@ -1,28 +1,16 @@
 use crate::{NetworkId, UserOrigin};
-use alloc::vec::Vec;
+
 use cosmwasm_std::Addr;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-
-/// Unique identity of a bridge in a given chain, usually a public key.
-#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
-#[derive(
-	Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Encode, Decode, TypeInfo, Serialize, Deserialize,
-)]
-pub struct BridgeId(Vec<u8>);
 
 /// Protocol used to bridge call/funds.
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
 #[derive(
 	Clone, PartialEq, Eq, PartialOrd, Debug, Encode, Decode, TypeInfo, Serialize, Deserialize,
 )]
-#[repr(u8)]
-pub enum BridgeProtocol {
-	IBC,
-	XCM,
-	OTP { id: BridgeId },
-}
+pub enum BridgeProtocol { IBC }
 
 /// The Origin that executed the XCVM operation.
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]


### PR DESCRIPTION
We’re currently only supporting IBC as bridging technology.  The code has vestigial definitions for XCM and OTP bridges but that only serves to confuse the code base.  Since we’re focusing on supporting IBC for now, remove that definitions.



- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production