### PR TITLE
xcvm: avoid String allocations when serialising Displayed types

### DIFF
--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -234,8 +234,10 @@ pub fn interpret_call(
 
 		apply_bindings(payload, bindings, &mut formatted_call, |binding| {
 			let data = match binding {
-				BindingValue::Register(Register::Ip) => Cow::Owned(instruction_pointer.to_string().into_bytes()),
-				BindingValue::Register(Register::Relayer) => Cow::Owned(relayer.to_string().into_bytes()),
+				BindingValue::Register(Register::Ip) =>
+					Cow::Owned(instruction_pointer.to_string().into_bytes()),
+				BindingValue::Register(Register::Relayer) =>
+					Cow::Owned(relayer.to_string().into_bytes()),
 				BindingValue::Register(Register::This) =>
 					Cow::Borrowed(env.contract.address.as_bytes()),
 				BindingValue::Register(Register::Result) => Cow::Owned(


### PR DESCRIPTION
Firstly, use Serializer::collect_str to possibly avoid allocating a string in case of serialisers which optimise that call.  In the worst case, collect_str behaves the same way as old code.

Secondly, use Visitor with Visitor::visitor_str method implemented to avoid having to allocate a String when deserialising the value.

Lastly, with all that, add some more documentation and tests for the type.



- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production