### PR TITLE
xcvm: add build script to download cw20-base.wasm contract

### DIFF
--- a/code/xcvm/Cargo.lock
+++ b/code/xcvm/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "ahash"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +348,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -789,6 +804,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1273,6 +1298,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -1770,6 +1804,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1830,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
 ]
 
 [[package]]
@@ -1856,6 +1917,16 @@ dependencies = [
  "quote",
  "serde_derive_internals",
  "syn 1.0.107",
+]
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -2030,6 +2101,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2292,6 +2369,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "ureq"
+version = "2.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "url",
+ "webpki",
+ "webpki-roots",
+]
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2422,7 +2521,7 @@ checksum = "e51fb5c61993e71158abf5bb863df2674ca3ec39ed6471c64f07aeaf751d67b4"
 dependencies = [
  "intx",
  "smallvec",
- "spin",
+ "spin 0.9.8",
  "wasmi_arena",
  "wasmi_core",
  "wasmparser-nostd",
@@ -2472,6 +2571,25 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]
@@ -2633,7 +2751,9 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sha2 0.10.6",
  "tokio",
+ "ureq",
  "xc-core",
 ]
 

--- a/code/xcvm/cosmwasm/tests/Cargo.toml
+++ b/code/xcvm/cosmwasm/tests/Cargo.toml
@@ -37,3 +37,7 @@ serde_json = { workspace = true }
 serde = { workspace = true }
 rand = { version = "0.8" }
 proptest = { version = "1" }
+
+[build-dependencies]
+sha2 = "0.10.6"
+ureq = "2.6"

--- a/code/xcvm/cosmwasm/tests/build.rs
+++ b/code/xcvm/cosmwasm/tests/build.rs
@@ -1,0 +1,45 @@
+use sha2::Digest;
+use std::io::Read;
+
+/// Location of the compiled cw20-base contract.
+const CW20_URL: &str =
+	"https://github.com/CosmWasm/cw-plus/releases/download/v1.0.1/cw20_base.wasm";
+
+/// SHA256 of the compiled cw20-base contract.
+const CW20_HASH: &[u8; 32] =
+	b"\x9c\x29\x5a\x93\xd5\x03\x3c\xb7\x40\x2d\x59\xcd\xed\xef\x72\x54\xa6\x9f\x9c\xa5\x0e\xed\x10\x18\x0c\x53\xbb\xb3\x1c\x00\x5e\x92";
+
+/// Downloads `cw20_base.wasm` contract and saves it in `$OUT_DIR`.
+///
+/// Panics if file cannot be downloaded or its SHA256 hash doesn’t match
+/// expected hash.
+fn main() {
+	// When building on CI inside of NIX, don’t download the contract file
+	// since HTTP is blocked.
+	if std::env::var_os("NIX_BUILD").is_some() {
+		return;
+	}
+
+	// Otherwise, download the file, verify it’s what we expect and store it in
+	// out directory.
+	let out_dir = std::env::var_os("OUT_DIR").unwrap();
+	let mut out_file = std::path::PathBuf::from(out_dir);
+	out_file.push("cw20_base.wasm");
+
+	let resp = match ureq::get(CW20_URL).call() {
+		Ok(x) => x,
+		Err(err) => panic!("{CW20_URL}: {err}"),
+	};
+	let mut data = Vec::with_capacity(500_000);
+	if let Err(err) = resp.into_reader().take(500_000).read_to_end(&mut data) {
+		panic!("{CW20_URL}: {err}");
+	}
+
+	if CW20_HASH[..] != sha2::Sha256::digest(data.as_slice())[..] {
+		panic!("{CW20_URL}: content integrity check failed")
+	}
+
+	if let Err(err) = std::fs::write(out_file.as_path(), data.as_slice()) {
+		panic!("{}: {err}", out_file.display());
+	}
+}


### PR DESCRIPTION
This should make it easier to run the tests (at least locally, see
below) since user doesn’t have to worry about getting the compiled
cw20-base contract and setting CW20 environment variable.

One complication is that build scripts cannot download files when
running on CI under NIX so downloading is skipped in that environment.
To run the tests there the CW20 environment variable must be sat (which
is the old test’s behaviour).

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
