### PR TITLE
xcvm: when testing read contracts from target directory directly

### DIFF
--- a/code/xcvm/cosmwasm/tests/build-contracts.sh
+++ b/code/xcvm/cosmwasm/tests/build-contracts.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+RUSTFLAGS='-C link-arg=-s'
+export RUSTFLAGS
+for pkg in cw-xc-asset-registry cw-xc-gateway cw-xc-interpreter cw-xc-router; do
+	cargo build -p "$pkg" \
+	      --profile cosmwasm-contracts \
+	      --target wasm32-unknown-unknown
+done

--- a/code/xcvm/cosmwasm/tests/build.rs
+++ b/code/xcvm/cosmwasm/tests/build.rs
@@ -17,7 +17,7 @@ fn main() {
 	// When building on CI inside of NIX, don’t download the contract file
 	// since HTTP is blocked.
 	if std::env::var_os("NIX_BUILD").is_some() {
-		return;
+		return
 	}
 
 	// Otherwise, download the file, verify it’s what we expect and store it in


### PR DESCRIPTION
Change the test environment setup such that it reads contract files
from target directory directly rather than requiring environment
variables to be set pointing to the contracts.  This should ‘just
work’ in many situations so long as user builds the contracts.

To further help the user, introduce build-contracts.sh script which
builds contracts necessary by the test environment.

The remaining downside of the approach is that the contracts won’t be
automatically recompiled if user changes them and then executes tests
that use them.


- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
