### PR TITLE
picasso-runtime: make memo field a string for pallet-ibc

### DIFF
--- a/code/parachain/runtime/picasso/src/ibc.rs
+++ b/code/parachain/runtime/picasso/src/ibc.rs
@@ -83,24 +83,7 @@ impl ModuleRouter for Dummy {
 	}
 }
 
-#[derive(
-	Debug, codec::Encode, Clone, codec::Decode, PartialEq, Eq, scale_info::TypeInfo, Default,
-)]
-pub struct MemoMessage;
-extern crate alloc;
-impl alloc::string::ToString for MemoMessage {
-	fn to_string(&self) -> String {
-		Default::default()
-	}
-}
-
-impl core::str::FromStr for MemoMessage {
-	type Err = ();
-
-	fn from_str(_s: &str) -> Result<Self, Self::Err> {
-		Ok(Default::default())
-	}
-}
+pub type MemoMessage = alloc::string::String;
 
 parameter_types! {
 	pub const GRANDPA: pallet_ibc::LightClientProtocol = pallet_ibc::LightClientProtocol::Grandpa;


### PR DESCRIPTION
Memo was an empty field. We need to use it for PFM.
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production