### PR TITLE
xcvm: fix to build script incorrectly detecting running inside of CI

### DIFF
--- a/code/xcvm/cosmwasm/tests/build.rs
+++ b/code/xcvm/cosmwasm/tests/build.rs
@@ -14,9 +14,9 @@ const CW20_HASH: &[u8; 32] =
 /// Panics if file cannot be downloaded or its SHA256 hash doesn’t match
 /// expected hash.
 fn main() {
-	// When building on CI inside of NIX, don’t download the contract file
-	// since HTTP is blocked.
-	if std::env::var_os("NIX_BUILD").is_some() {
+	// When building on CI, don’t download the contract file since networking is
+	// blocked in our Nix environment.
+	if std::env::var_os("CI").is_some() {
 		return;
 	}
 


### PR DESCRIPTION
NIX_BUILD environment variable is not the one to check if code is running under CI.  CI variable is.



- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production