### PR TITLE
Сonfigure composable runtime with pallet ibc xcm

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "pallet-utility",
  "pallet-vault",
  "pallet-xcm",
+ "pallet-xcm-ibc",
  "parachain-info",
  "parity-scale-codec",
  "polkadot-parachain",
@@ -9784,6 +9785,7 @@ dependencies = [
  "sp-io",
  "sp-runtime",
  "sp-std 5.0.0",
+ "xcm",
 ]
 
 [[package]]

--- a/code/parachain/frame/pallet-xcm-ibc/Cargo.toml
+++ b/code/parachain/frame/pallet-xcm-ibc/Cargo.toml
@@ -21,6 +21,7 @@ scale-info = { version = "2.1.1", default-features = false, features = [
 ] }
 
 # Substrate dependencies
+xcm = { workspace = true, default-features = false }
 sp-arithmetic = { default-features = false, workspace = true }
 sp-core = { default-features = false, workspace = true }
 sp-io = { default-features = false, workspace = true }

--- a/code/parachain/frame/pallet-xcm-ibc/src/lib.rs
+++ b/code/parachain/frame/pallet-xcm-ibc/src/lib.rs
@@ -1,38 +1,53 @@
+pub use pallet::*;
+pub use pallet::Error;
+
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use frame_support::{pallet_prelude::*, BoundedBTreeSet};
+    use frame_support::pallet_prelude::*;
 
 	/// ## Configuration
 	/// The pallet's configuration trait.
 	#[pallet::config]
-	pub trait Config<I: 'static = ()>: frame_system::Config {
-		/// The overarching event type.
-		type RuntimeEvent: From<Event<Self, I>>
-			+ IsType<<Self as frame_system::Config>::RuntimeEvent>;
-	}
+	pub trait Config: frame_system::Config {
+		#[allow(missing_docs)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+    }
 
 	// The pallet's events
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(crate) fn deposit_event)]
-	pub enum Event<T: Config<I>, I: 'static = ()> {
+	pub enum Event<T: Config> {
 		
 	}
 
 	#[pallet::error]
-	pub enum Error<T, I = ()> {
-		
+	pub enum Error<T> {
+		Error1,
 	}
 
 	#[pallet::hooks]
-	impl<T: Config<I>, I: 'static> Hooks<T::BlockNumber> for Pallet<T, I> {}
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {}
 
 
 	#[pallet::pallet]
-	#[pallet::without_storage_info]
-	pub struct Pallet<T, I = ()>(_);
+	#[pallet::generate_store(pub (super) trait Store)]
+	pub struct Pallet<T>(_);
 
 	// The pallet's dispatchable functions.
 	#[pallet::call]
-	impl<T: Config<I>, I: 'static> Pallet<T, I> {}
+	impl<T: Config> Pallet<T> {
+    }
+
+    impl<T> MultiCurrencyCallback for Pallet<T> {
+
+    }
+}
+
+
+use xcm::v3::*;
+pub trait MultiCurrencyCallback{
+	fn deposit_asset(asset: &MultiAsset, location: &MultiLocation, context: &XcmContext, deposit_result : Result){
+		//check result, unwrap memo if exists and execute ibc packet
+	}
 }

--- a/code/parachain/runtime/composable/Cargo.toml
+++ b/code/parachain/runtime/composable/Cargo.toml
@@ -75,6 +75,7 @@ system-rpc-runtime-api = { default-features = false, workspace = true }
 transaction-payment-rpc-runtime-api = { package = "pallet-transaction-payment-rpc-runtime-api", path = "../../frame/transaction-payment/rpc/runtime-api", default-features = false }
 assets-runtime-api = { path = '../../frame/assets/runtime-api', default-features = false }
 crowdloan-rewards-runtime-api = { path = '../../frame/crowdloan-rewards/runtime-api', default-features = false }
+pallet-xcm-ibc = { path = "../../frame/pallet-xcm-ibc", default-features = false }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
   "derive",
 ] }
@@ -227,4 +228,5 @@ std = [
   "pallet-xcm/std",
   "composable-traits/std",
   "asset-tx-payment/std",
+  "pallet-xcm-ibc/std"
 ]

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -440,6 +440,10 @@ parameter_types! {
 	pub const MinCandidates: u32 = 5;
 }
 
+impl pallet_xcm_ibc::Config for Runtime{
+	type RuntimeEvent = RuntimeEvent;
+}
+
 impl collator_selection::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
@@ -668,6 +672,8 @@ construct_runtime!(
 
 		Ibc: pallet_ibc = 190,
 		Ics20Fee: pallet_ibc::ics20_fee = 191,
+
+		PalletXcmIbc: pallet_xcm_ibc = 192,
 
 	}
 );

--- a/code/parachain/runtime/composable/src/xcmp.rs
+++ b/code/parachain/runtime/composable/src/xcmp.rs
@@ -6,6 +6,7 @@ use frame_support::{
 	log, parameter_types,
 	traits::{Everything, Nothing, OriginTrait},
 };
+use pallet_xcm_ibc::MultiCurrencyCallback;
 use orml_traits::{
 	location::{AbsoluteReserveProvider, RelativeReserveProvider},
 	parameter_type_with_key,
@@ -187,18 +188,6 @@ PhantomData<(
 	MultiCurrencyCallback
 )>,
 );
-
-pub trait MultiCurrencyCallback{
-	fn deposit_asset(asset: &MultiAsset, location: &MultiLocation, context: &XcmContext, deposit_result : xcm::v3::Result){
-		//check result, unwrap memo if exists and execute ibc packet
-	}
-}
-
-pub struct PalletXcmIbc;
-
-impl MultiCurrencyCallback for PalletXcmIbc{
-	
-}
 
 impl<
 		MultiCurrency: orml_traits::MultiCurrency<AccountId, CurrencyId = CurrencyId>,


### PR DESCRIPTION
This pr introduce pallet ibc xcm to composable runtime and simple deposit call back trait
to register pallet xcm ibc as a callback for multicurrency struct. to execute extra logic on deposit success.
and emit new ibc packet as a part batching tx if memo there is next hop configured with current xcm call.