### PR TITLE
add bech32 to parse cosmos address into string and insert in ibc memo

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -813,6 +813,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9770,6 +9776,7 @@ dependencies = [
 name = "pallet-xcm-ibc"
 version = "1.0.0"
 dependencies = [
+ "bech32",
  "composable-support",
  "frame-benchmarking",
  "frame-support",

--- a/code/parachain/frame/pallet-xcm-ibc/Cargo.toml
+++ b/code/parachain/frame/pallet-xcm-ibc/Cargo.toml
@@ -8,6 +8,7 @@ version = "1.0.0"
 
 
 [dependencies]
+bech32 = { version = "0.7.3" } 
 log = { version = "0.4.14", default-features = false }
 serde = { version = "1.0.137", default-features = false, features = [
   "derive",

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -440,12 +440,14 @@ parameter_types! {
 	pub const MinCandidates: u32 = 5;
 	pub const PalletXcmIbcInstanceId: u8 = 192; // PalletXcmIbc: pallet_xcm_ibc = 192,
 	pub const MaxMultihopCount: u32 = 10; 
+	pub const ChainNameVecLimit: u32 = 30; 
 }
 
 impl pallet_xcm_ibc::Config for Runtime{
 	type RuntimeEvent = RuntimeEvent;
 	type PalletInstanceId = PalletXcmIbcInstanceId;
 	type MaxMultihopCount = MaxMultihopCount;
+	type ChainNameVecLimit = ChainNameVecLimit;
 }
 
 impl collator_selection::Config for Runtime {


### PR DESCRIPTION
Introduce new dependency to pallet xcm ibc : bech32 to parse [u8;32] into string to compose proper memo for packet message forwarding. 