### PR TITLE
Simplify `T::from` spelling

### DIFF
--- a/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
+++ b/code/integration-tests/local-integration-tests/src/common_goods_assets.rs
@@ -487,7 +487,7 @@ fn bob_has_statemine_asset_on_this_and_transfers_it_to_reserve(
 				index: _, // NOTE: finding pay to map pallet/error to index would look better/shorter/faster
 				error: _,
 				message: Some(msg),
-			}) if Into::<&'static str>::into(orml_xtokens::Error::<Runtime>::MinXcmFeeNotDefined) == msg
+			}) if str::from(orml_xtokens::Error::<Runtime>::MinXcmFeeNotDefined) == msg
 		));
 
 		let location = XcmAssetLocation::new(MultiLocation::new(

--- a/code/parachain/frame/airdrop/src/lib.rs
+++ b/code/parachain/frame/airdrop/src/lib.rs
@@ -974,7 +974,7 @@ pub mod pallet {
 			if let Call::claim { airdrop_id, reward_account, proof } = call {
 				// Validity Error if the airdrop does not exist
 				let airdrop_state = Self::get_airdrop_state(*airdrop_id).map_err(|_| {
-					Into::<TransactionValidityError>::into(InvalidTransaction::Custom(
+					TransactionValidityError::from(InvalidTransaction::Custom(
 						ValidityError::NotAnAirdrop as u8,
 					))
 				})?;
@@ -987,7 +987,7 @@ pub mod pallet {
 				// Evaluate proof
 				let identity = Self::get_identity(proof.clone(), reward_account, T::Prefix::get())
 					.map_err(|_| {
-						Into::<TransactionValidityError>::into(InvalidTransaction::Custom(
+						TransactionValidityError::from(InvalidTransaction::Custom(
 							ValidityError::InvalidProof as u8,
 						))
 					})?;

--- a/code/parachain/frame/bonded-finance/src/mock.rs
+++ b/code/parachain/frame/bonded-finance/src/mock.rs
@@ -94,7 +94,7 @@ impl EnsureOrigin<RuntimeOrigin> for EnsureAliceOrBob {
 	type Success = AccountId;
 
 	fn try_origin(o: RuntimeOrigin) -> Result<Self::Success, RuntimeOrigin> {
-		Into::<Result<RawOrigin<AccountId>, RuntimeOrigin>>::into(o).and_then(|o| match o {
+		Result::from(o).and_then(|o| match o {
 			RawOrigin::Signed(ALICE) => Ok(ALICE),
 			RawOrigin::Signed(BOB) => Ok(BOB),
 			r => Err(RuntimeOrigin::from(r)),

--- a/code/parachain/frame/cosmwasm/cli/src/substrate/rpc.rs
+++ b/code/parachain/frame/cosmwasm/cli/src/substrate/rpc.rs
@@ -64,16 +64,16 @@ impl Command {
 				let params = rpc_params!(
 					sender,
 					code_id,
-					Into::<Vec<u8>>::into(salt),
+					Vec::from(salt),
 					admin,
-					Into::<Vec<u8>>::into(label),
+					Vec::from(label),
 					funds
 						.unwrap_or_default()
 						.into_iter()
 						.map(|(asset, amount)| (asset, (amount, true)))
 						.collect::<BTreeMap<u128, (u128, bool)>>(),
 					gas,
-					Into::<Vec<u8>>::into(message)
+					Vec::from(message)
 				);
 				let resp: AccountId32 =
 					rpc_call("cosmwasm_instantiate", &params, chain_endpoint).await?;

--- a/code/parachain/frame/cosmwasm/cli/src/substrate/tx.rs
+++ b/code/parachain/frame/cosmwasm/cli/src/substrate/tx.rs
@@ -204,9 +204,9 @@ where
 		if let Some(event) = event.as_event::<events::Executed>()? {
 			data = event.data;
 		} else if let Some(event) = event.as_event::<E>()? {
-			details = Some(Into::<CE>::into(event));
+			details = Some(CE::from(event));
 		} else if let Some(event) = event.as_event::<events::Emitted>()? {
-			cosmwasm_events.push(Into::<Emitted>::into(event));
+			cosmwasm_events.push(Emitted::from(event));
 		}
 	}
 

--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -911,7 +911,7 @@ impl<T: Config> Pallet<T> {
 			transaction: frame_system::Pallet::<T>::extrinsic_index()
 				.map(|index| TransactionInfo { index }),
 			contract: CosmwasmContractInfo {
-				address: Addr::unchecked(Into::<String>::into(cosmwasm_contract_address)),
+				address: Addr::unchecked(String::from(cosmwasm_contract_address)),
 			},
 		}
 	}
@@ -1046,10 +1046,7 @@ impl<T: Config> Pallet<T> {
 		let env = Self::cosmwasm_env(contract_address.clone());
 		let cosmwasm_message_info = {
 			let cosmwasm_sender_address: CosmwasmAccount<T> = CosmwasmAccount::new(sender);
-			MessageInfo {
-				sender: Addr::unchecked(Into::<String>::into(cosmwasm_sender_address)),
-				funds,
-			}
+			MessageInfo { sender: Addr::unchecked(String::from(cosmwasm_sender_address)), funds }
 		};
 
 		// If the [`contract`] is actually a pallet that is exposed as a cosmwasm contract,

--- a/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
@@ -58,9 +58,9 @@ impl<T: Config> CosmwasmAccount<T> {
 }
 
 #[allow(clippy::from_over_into)]
-impl<T: Config> Into<String> for CosmwasmAccount<T> {
-	fn into(self) -> String {
-		Pallet::<T>::account_to_cosmwasm_addr(self.1)
+impl<T: Config> From<CosmwasmAccount<T>> for String {
+	fn from(account: CosmwasmAccount<T>) -> Self {
+		Pallet::<T>::account_to_cosmwasm_addr(account.1)
 	}
 }
 
@@ -72,9 +72,9 @@ impl<T: Config + VMPallet> TryFrom<String> for CosmwasmAccount<T> {
 }
 
 #[allow(clippy::from_over_into)]
-impl<T: Config> Into<Addr> for CosmwasmAccount<T> {
-	fn into(self) -> Addr {
-		Addr::unchecked(Into::<String>::into(self))
+impl<T: Config> From<CosmwasmAccount<T>> for Addr {
+	fn from(account: CosmwasmAccount<T>) -> Self {
+		Self::unchecked(String::from(account))
 	}
 }
 

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -405,13 +405,13 @@ impl<'a, T: Config + Send + Sync> VMBase for CosmwasmVM<'a, T> {
 	}
 
 	fn balance(&mut self, account: &Self::Address, denom: String) -> Result<Coin, Self::Error> {
-		log::debug!(target: "runtime::contracts", "balance: {} => {:#?}", Into::<String>::into(account.clone()), denom);
+		log::debug!(target: "runtime::contracts", "balance: {} => {:#?}", String::from(account.clone()), denom);
 		let amount = Pallet::<T>::do_balance(account.as_ref(), denom.clone())?;
 		Ok(Coin { denom, amount: amount.into() })
 	}
 
 	fn all_balance(&mut self, account: &Self::Address) -> Result<Vec<Coin>, Self::Error> {
-		log::debug!(target: "runtime::contracts", "all balance: {}", Into::<String>::into(account.clone()));
+		log::debug!(target: "runtime::contracts", "all balance: {}", String::from(account.clone()));
 		//  TODO(hussein-aitlahcen): support iterating over all tokens???
 		Err(CosmwasmVMError::Unsupported)
 	}

--- a/code/parachain/frame/cosmwasm/src/tests/host_functions.rs
+++ b/code/parachain/frame/cosmwasm/src/tests/host_functions.rs
@@ -210,7 +210,7 @@ fn addr_canonicalize_humanize_validate() {
 		// 4. `addr_humanize` gives back the original address.
 		let gas = current_gas(&mut vm);
 		assert_eq!(
-			Into::<String>::into(vm.addr_humanize(&canonical_addr).unwrap().unwrap()),
+			String::from(vm.addr_humanize(&canonical_addr).unwrap().unwrap()),
 			valid_addr.0.to_string()
 		);
 

--- a/code/parachain/frame/crowdloan-rewards/src/lib.rs
+++ b/code/parachain/frame/crowdloan-rewards/src/lib.rs
@@ -720,7 +720,7 @@ pub mod pallet {
 				let remote_account =
 					get_remote_account::<T>(proof.clone(), reward_account, T::Prefix::get())
 						.map_err(|_| {
-							Into::<TransactionValidityError>::into(InvalidTransaction::Custom(
+							TransactionValidityError::from(InvalidTransaction::Custom(
 								ValidityError::InvalidProof as u8,
 							))
 						})?;

--- a/code/parachain/frame/lending/src/helpers/interest.rs
+++ b/code/parachain/frame/lending/src/helpers/interest.rs
@@ -149,9 +149,8 @@ impl<T: Config> Pallet<T> {
 		delta_time: DurationSeconds,
 		total_borrows: T::Balance,
 	) -> Result<AccruedInterest<T>, DispatchError> {
-		let total_borrows: FixedU128 =
-			FixedU128::checked_from_integer(Into::<u128>::into(total_borrows))
-				.ok_or(ArithmeticError::Overflow)?;
+		let total_borrows: FixedU128 = FixedU128::checked_from_integer(total_borrows.into())
+			.ok_or(ArithmeticError::Overflow)?;
 
 		let borrow_rate = interest_rate_model
 			.get_borrow_rate(utilization_ratio)

--- a/code/parachain/frame/lending/src/tests/market.rs
+++ b/code/parachain/frame/lending/src/tests/market.rs
@@ -86,7 +86,7 @@ fn can_create_valid_market() {
                             error: _, // not important in mock runtime
                             message: Some(error)
                         }),
-                    }) if Into::<&'static str>::into(orml_tokens::Error::<Runtime>::BalanceTooLow) == error
+                    }) if <&str>::from(orml_tokens::Error::<Runtime>::BalanceTooLow) == error
                 ),
                 "Creating a market with insufficient funds should fail, with the error message being \"BalanceTooLow\".
                 The other fields are also checked to make sure any changes are tested and accounted for, perhaps one of those fields changed?
@@ -213,7 +213,7 @@ fn can_create_valid_market_with_keep_alive() {
                             error: _, // not important in mock runtime
                             message: Some(error)
                         }),
-                    }) if Into::<&'static str>::into(orml_tokens::Error::<Runtime>::BalanceTooLow) == error
+                    }) if <&str>::from(orml_tokens::Error::<Runtime>::BalanceTooLow) == error
                 ),
                 "Creating a market with insufficient funds should fail, with the error message being \"BalanceTooLow\".
                 The other fields are also checked to make sure any changes are tested and accounted for, perhaps one of those fields changed?

--- a/code/parachain/frame/vesting/src/mock.rs
+++ b/code/parachain/frame/vesting/src/mock.rs
@@ -103,7 +103,7 @@ impl EnsureOrigin<RuntimeOrigin> for EnsureAliceOrBob {
 
 	fn try_origin(o: RuntimeOrigin) -> Result<Self::Success, RuntimeOrigin> {
 		let benchmark_acc = benchmark_vested_transfer_account();
-		Into::<Result<RawOrigin<AccountId>, RuntimeOrigin>>::into(o).and_then(|o| match o {
+		Result::from(o).and_then(|o| match o {
 			RawOrigin::Signed(ALICE) => Ok(ALICE),
 			RawOrigin::Signed(BOB) => Ok(BOB),
 			RawOrigin::Signed(acc) =>

--- a/code/xcvm/lib/proto/src/lib.rs
+++ b/code/xcvm/lib/proto/src/lib.rs
@@ -669,7 +669,7 @@ mod tests {
 		let high_bits = u64::from_be_bytes(real_value.to_be_bytes()[0..8].try_into().unwrap());
 		let low_bits = u64::from_be_bytes(real_value.to_be_bytes()[8..].try_into().unwrap());
 		let uint128 = Uint128 { high_bits, low_bits };
-		assert_eq!(Into::<u128>::into(uint128.clone()), real_value);
-		assert_eq!(Into::<Uint128>::into(real_value), uint128)
+		assert_eq!(u128::from(uint128.clone()), real_value);
+		assert_eq!(Uint128::from(real_value), uint128)
 	}
 }


### PR DESCRIPTION
`Into::<T>::into` is a peculiar way to write `T::from`.  Change the
code to use the latter spelling since it’s shorter and includes one
less level of generics making it easier to read.

To make this work, swap `Into<T> for CosmwasmAccount` implementations
for `From<CosmwasmAccount> for T` implementations.  Offering the
latter is more idiomatic and thanks to standard library automatically
provides a reverse `Into` implementation, a single `impl` effectively
defines two traits.

Some of the places could probable be written as `x.into()` which is
even shorter but that looses the type information which may reduce
clarity of the code so I’ve stuck to `T::from`.

The one exception is in parachain/frame/lending/src/helpers/interest.rs
which now uses `total_borrows.into()`.  The reason is somewhat bafling
definition of DeFiComposableConfig trait whose `Balance` associated
type has `Into<u128>` bound with a comment ‘cannot do From<u128>,
until LiftedFixedBalance integer part is larger than 128 bit’.
I honestly don’t understand it but decided not to look into it further.


- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
