### PR TITLE
xcvm: remove Network generic argument from xc_core::Instruction

### DIFF
--- a/code/xcvm/cosmwasm/contracts/utils/src/lib.rs
+++ b/code/xcvm/cosmwasm/contracts/utils/src/lib.rs
@@ -1,9 +1,7 @@
 use cosmwasm_std::CanonicalAddr;
 use std::collections::VecDeque;
-use xc_core::{Balance, Funds, NetworkId};
 
-pub type DefaultXCVMInstruction =
-	xc_core::Instruction<NetworkId, Vec<u8>, CanonicalAddr, Funds<Balance>>;
+pub type DefaultXCVMInstruction = xc_core::Instruction<Vec<u8>, CanonicalAddr, xc_core::Funds>;
 pub type DefaultXCVMProgram = xc_core::Program<VecDeque<DefaultXCVMInstruction>>;
 pub type DefaultXCVMPacket = xc_core::Packet<DefaultXCVMProgram>;
 pub type Salt = Vec<u8>;

--- a/code/xcvm/lib/core/src/instruction.rs
+++ b/code/xcvm/lib/core/src/instruction.rs
@@ -52,10 +52,10 @@ pub enum Destination<Account> {
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
 #[derive(Clone, PartialEq, Eq, Debug, Encode, Decode, TypeInfo, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum Instruction<Network, Payload, Account, Assets> {
+pub enum Instruction<Payload, Account, Assets> {
 	/// Transfer some [`Assets`] from the current program to the [`to`] account.
 	Transfer { to: Destination<Account>, assets: Assets },
-	/// Arbitrary payload representing a raw call inside the current [`Network`].
+	/// Arbitrary payload representing a raw call inside the current network.
 	///
 	/// On picasso, this will be a SCALE encoded dispatch call.
 	/// On ethereum, an ethereum ABI encoded call.
@@ -69,7 +69,12 @@ pub enum Instruction<Network, Payload, Account, Assets> {
 	///
 	/// The program will be spawned with the desired [`Assets`].
 	/// The salt is used to track the program when events are dispatched in the network.
-	Spawn { network: Network, salt: Vec<u8>, assets: Assets, program: Program<VecDeque<Self>> },
+	Spawn {
+		network: crate::network::NetworkId,
+		salt: Vec<u8>,
+		assets: Assets,
+		program: Program<VecDeque<Self>>,
+	},
 }
 
 /// Error types for late binding operation

--- a/code/xcvm/lib/core/src/lib.rs
+++ b/code/xcvm/lib/core/src/lib.rs
@@ -23,7 +23,7 @@ use core::marker::PhantomData;
 #[derive(Clone)]
 pub struct ProgramBuilder<CurrentNetwork, Account, Assets> {
 	pub tag: Vec<u8>,
-	pub instructions: VecDeque<Instruction<NetworkId, Vec<u8>, Account, Assets>>,
+	pub instructions: VecDeque<Instruction<Vec<u8>, Account, Assets>>,
 	pub _marker: PhantomData<CurrentNetwork>,
 }
 
@@ -88,7 +88,7 @@ where
 		protocol.serialize().map(|encoded_call| self.call_raw(encoded_call))
 	}
 
-	pub fn build(self) -> Program<VecDeque<Instruction<NetworkId, Vec<u8>, Account, Assets>>> {
+	pub fn build(self) -> Program<VecDeque<Instruction<Vec<u8>, Account, Assets>>> {
 		Program { tag: self.tag, instructions: self.instructions }
 	}
 }

--- a/code/xcvm/lib/proto/src/lib.rs
+++ b/code/xcvm/lib/proto/src/lib.rs
@@ -11,11 +11,11 @@ use xc_core::{Amount, Destination, Displayed, Funds, NetworkId, MAX_PARTS};
 
 include!(concat!(env!("OUT_DIR"), "/interpreter.rs"));
 
-pub type XCVMPacket<TNetwork, TAbiEncoded, TAccount, TAssets> =
-	xc_core::Packet<XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>>;
+pub type XCVMPacket<TAbiEncoded, TAccount, TAssets> =
+	xc_core::Packet<XCVMProgram<TAbiEncoded, TAccount, TAssets>>;
 
-pub type XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets> =
-	xc_core::Program<VecDeque<xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>>>;
+pub type XCVMProgram<TAbiEncoded, TAccount, TAssets> =
+	xc_core::Program<VecDeque<xc_core::Instruction<TAbiEncoded, TAccount, TAssets>>>;
 
 pub trait Encodable {
 	fn encode(self) -> Vec<u8>;
@@ -33,14 +33,13 @@ impl Display for DecodingFailure {
 	}
 }
 
-pub fn decode_packet<TNetwork, TAbiEncoded, TAccount, TAssets>(
+pub fn decode_packet<TAbiEncoded, TAccount, TAssets>(
 	buffer: &[u8],
 ) -> core::result::Result<
-	xc_core::Packet<XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>>,
+	xc_core::Packet<XCVMProgram<TAbiEncoded, TAccount, TAssets>>,
 	DecodingFailure,
 >
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -50,11 +49,10 @@ where
 		.and_then(|x| TryInto::try_into(x).map_err(|_| DecodingFailure::Isomorphism))
 }
 
-pub fn decode<TNetwork, TAbiEncoded, TAccount, TAssets>(
+pub fn decode<TAbiEncoded, TAccount, TAssets>(
 	buffer: &[u8],
-) -> core::result::Result<XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>, DecodingFailure>
+) -> core::result::Result<XCVMProgram<TAbiEncoded, TAccount, TAssets>, DecodingFailure>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -64,10 +62,8 @@ where
 		.and_then(|x| TryInto::try_into(x).map_err(|_| DecodingFailure::Isomorphism))
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> Encodable
-	for XCVMPacket<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> Encodable for XCVMPacket<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -101,15 +97,13 @@ impl From<(xc_core::AssetId, Displayed<u128>)> for PacketAsset {
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets>
-	From<XCVMPacket<TNetwork, TAbiEncoded, TAccount, TAssets>> for Packet
+impl<TAbiEncoded, TAccount, TAssets> From<XCVMPacket<TAbiEncoded, TAccount, TAssets>> for Packet
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
 {
-	fn from(value: XCVMPacket<TNetwork, TAbiEncoded, TAccount, TAssets>) -> Self {
+	fn from(value: XCVMPacket<TAbiEncoded, TAccount, TAssets>) -> Self {
 		Packet {
 			interpreter: Some(Account { account: value.interpreter.into() }),
 			user_origin: Some(value.user_origin.into()),
@@ -120,10 +114,8 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> Encodable
-	for XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> Encodable for XCVMProgram<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -165,10 +157,8 @@ impl TryFrom<PacketAsset> for (xc_core::AssetId, Displayed<u128>) {
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Packet>
-	for XCVMPacket<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Packet> for XCVMPacket<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -192,10 +182,9 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Program>
-	for XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Program>
+	for XCVMProgram<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -210,10 +199,9 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Instructions>
-	for VecDeque<xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Instructions>
+	for VecDeque<xc_core::Instruction<TAbiEncoded, TAccount, TAssets>>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -229,10 +217,9 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Instruction>
-	for xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Instruction>
+	for xc_core::Instruction<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -244,10 +231,9 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<instruction::Instruction>
-	for xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<instruction::Instruction>
+	for xc_core::Instruction<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -263,10 +249,9 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Call>
-	for xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Call>
+	for xc_core::Instruction<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -329,10 +314,9 @@ impl TryFrom<binding_value::Type> for xc_core::BindingValue {
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Spawn>
-	for xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Spawn>
+	for xc_core::Instruction<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -361,14 +345,13 @@ where
 
 impl From<Network> for NetworkId {
 	fn from(network: Network) -> Self {
-		network.network_id.into()
+		Self(network.network_id)
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets> TryFrom<Transfer>
-	for xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>
+impl<TAbiEncoded, TAccount, TAssets> TryFrom<Transfer>
+	for xc_core::Instruction<TAbiEncoded, TAccount, TAssets>
 where
-	TNetwork: From<u32>,
 	TAbiEncoded: TryFrom<Vec<u8>>,
 	TAccount: for<'a> TryFrom<&'a [u8]>,
 	TAssets: From<Vec<(xc_core::AssetId, xc_core::Balance)>>,
@@ -543,7 +526,7 @@ impl From<xc_core::BindingValue> for BindingValue {
 
 impl From<xc_core::NetworkId> for Network {
 	fn from(network_id: xc_core::NetworkId) -> Self {
-		Network { network_id: network_id.0 as u32 }
+		Network { network_id: network_id.0 }
 	}
 }
 
@@ -566,15 +549,14 @@ impl From<(u32, xc_core::BindingValue)> for Binding {
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets>
-	From<xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>> for instruction::Instruction
+impl<TAbiEncoded, TAccount, TAssets> From<xc_core::Instruction<TAbiEncoded, TAccount, TAssets>>
+	for instruction::Instruction
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
 {
-	fn from(instruction: xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>) -> Self {
+	fn from(instruction: xc_core::Instruction<TAbiEncoded, TAccount, TAssets>) -> Self {
 		match instruction {
 			xc_core::Instruction::Transfer { to, assets } =>
 				instruction::Instruction::Transfer(Transfer {
@@ -599,28 +581,25 @@ where
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets>
-	From<xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>> for Instruction
+impl<TAbiEncoded, TAccount, TAssets> From<xc_core::Instruction<TAbiEncoded, TAccount, TAssets>>
+	for Instruction
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
 {
-	fn from(instruction: xc_core::Instruction<TNetwork, TAbiEncoded, TAccount, TAssets>) -> Self {
+	fn from(instruction: xc_core::Instruction<TAbiEncoded, TAccount, TAssets>) -> Self {
 		Instruction { instruction: Some(instruction.into()) }
 	}
 }
 
-impl<TNetwork, TAbiEncoded, TAccount, TAssets>
-	From<XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>> for Program
+impl<TAbiEncoded, TAccount, TAssets> From<XCVMProgram<TAbiEncoded, TAccount, TAssets>> for Program
 where
-	TNetwork: Into<u32>,
 	TAbiEncoded: Into<Vec<u8>>,
 	TAccount: Into<Vec<u8>>,
 	TAssets: Into<Vec<(xc_core::AssetId, xc_core::Balance)>>,
 {
-	fn from(program: XCVMProgram<TNetwork, TAbiEncoded, TAccount, TAssets>) -> Self {
+	fn from(program: XCVMProgram<TAbiEncoded, TAccount, TAssets>) -> Self {
 		Program {
 			tag: program.tag,
 			instructions: Some(Instructions {


### PR DESCRIPTION
It’s rather unlikely that network in an XCVM Instruction type will ever be represented as something other than NetworkId.  Network is part of the interface which needs to be understood by all the chains in the same way and have the same representation.

Remove Network generic argument from xc_core::Instruction to simplify the code slightly.



- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production