### PR TITLE
xcvm: merge cw-xc-utils crate into cw-xc-common crate

### DIFF
--- a/code/xcvm/Cargo.lock
+++ b/code/xcvm/Cargo.lock
@@ -441,7 +441,6 @@ version = "0.1.0"
 dependencies = [
  "cosmwasm-schema 1.2.5",
  "cosmwasm-std",
- "cw-xc-utils",
  "schemars",
  "serde",
  "xc-core",
@@ -457,7 +456,6 @@ dependencies = [
  "cw-utils",
  "cw-xc-common",
  "cw-xc-interpreter",
- "cw-xc-utils",
  "cw2",
  "cw20",
  "hex",
@@ -479,7 +477,6 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "cw-xc-common",
- "cw-xc-utils",
  "cw2",
  "cw20",
  "hex",
@@ -502,7 +499,6 @@ dependencies = [
  "cw-storage-plus",
  "cw-utils",
  "cw-xc-common",
- "cw-xc-utils",
  "cw2",
  "cw20",
  "hex",
@@ -515,14 +511,6 @@ dependencies = [
  "thiserror-core",
  "xc-core",
  "xc-proto",
-]
-
-[[package]]
-name = "cw-xc-utils"
-version = "0.1.0"
-dependencies = [
- "cosmwasm-std",
- "xc-core",
 ]
 
 [[package]]
@@ -2688,7 +2676,6 @@ dependencies = [
  "cw-xc-common",
  "cw-xc-interpreter",
  "cw-xc-pingpong",
- "cw-xc-utils",
  "cw20",
  "cw20-base",
  "env_logger",

--- a/code/xcvm/cosmwasm/contracts/common/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/common/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 [dependencies]
 cosmwasm-schema = { workspace = true }
 cosmwasm-std = { workspace = true }
-cw-xc-utils = { path = "../utils" }
 schemars = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 xc-core = { path = "../../../lib/core", features = ["std"] }

--- a/code/xcvm/cosmwasm/contracts/common/src/gateway.rs
+++ b/code/xcvm/cosmwasm/contracts/common/src/gateway.rs
@@ -1,6 +1,5 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::Addr;
-use cw_xc_utils::DefaultXCVMProgram;
 use xc_core::{AssetId, CallOrigin, Displayed, Funds, InterpreterOrigin, NetworkId};
 
 /// Prefix used for all events attached to gateway responses.
@@ -67,7 +66,7 @@ pub struct ExecuteProgramMsg {
 	/// The program salt.
 	pub salt: Vec<u8>,
 	/// The program.
-	pub program: DefaultXCVMProgram,
+	pub program: crate::shared::DefaultXCVMProgram,
 	/// Assets to fund the XCVM interpreter instance
 	/// The interpreter is funded prior to execution
 	pub assets: Funds<Displayed<u128>>,

--- a/code/xcvm/cosmwasm/contracts/common/src/shared.rs
+++ b/code/xcvm/cosmwasm/contracts/common/src/shared.rs
@@ -1,11 +1,16 @@
-use cosmwasm_std::{from_binary, to_binary, Binary, StdResult};
+use cosmwasm_std::{from_binary, to_binary, Binary, CanonicalAddr, StdResult};
 use serde::{de::DeserializeOwned, Serialize};
+use std::collections::VecDeque;
+
+pub type DefaultXCVMInstruction = xc_core::Instruction<Vec<u8>, CanonicalAddr, xc_core::Funds>;
+pub type DefaultXCVMProgram = xc_core::Program<VecDeque<DefaultXCVMInstruction>>;
+pub type DefaultXCVMPacket = xc_core::Packet<DefaultXCVMProgram>;
+pub type Salt = Vec<u8>;
 
 pub fn encode_base64<T: Serialize>(x: &T) -> StdResult<String> {
 	Ok(to_binary(x)?.to_base64())
 }
 
 pub fn decode_base64<S: AsRef<str>, T: DeserializeOwned>(encoded: S) -> StdResult<T> {
-	let x = from_binary::<T>(&Binary::from_base64(encoded.as_ref())?)?;
-	Ok(x)
+	from_binary::<T>(&Binary::from_base64(encoded.as_ref())?)
 }

--- a/code/xcvm/cosmwasm/contracts/gateway/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/gateway/Cargo.toml
@@ -18,7 +18,6 @@ cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw-xc-common = { path = "../common" }
 cw-xc-interpreter = { path = "../interpreter", features = ["library"] }
-cw-xc-utils = { path = "../utils" }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 hex = { workspace = true }

--- a/code/xcvm/cosmwasm/contracts/gateway/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/contract.rs
@@ -16,7 +16,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use cw20::Cw20ExecuteMsg;
 use cw_utils::ensure_from_older_version;
-use cw_xc_utils::DefaultXCVMPacket;
+use cw_xc_common::shared::DefaultXCVMPacket;
 use xc_core::{BridgeProtocol, CallOrigin, Displayed, Funds, XCVMAck};
 use xc_proto::{decode_packet, Encodable};
 

--- a/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
@@ -17,7 +17,6 @@ cosmwasm-std = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw-xc-common = { path = "../common" }
-cw-xc-utils = { path = "../utils" }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 hex = { workspace = true, default-features = false, features = [

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -19,16 +19,13 @@ use cw20::{BalanceResponse, Cw20Contract, Cw20ExecuteMsg, Cw20QueryMsg, TokenInf
 use cw_utils::ensure_from_older_version;
 use cw_xc_common::{
 	gateway::{AssetReference, BridgeMsg, ExecuteMsg as GWExecuteMsg, ExecuteProgramMsg},
-	shared::encode_base64,
+	shared::{encode_base64, DefaultXCVMProgram},
 };
-use cw_xc_utils::DefaultXCVMProgram;
 use num::Zero;
 use xc_core::{
 	apply_bindings, AssetId, Balance, BindingValue, Destination, Displayed, Funds, Instruction,
 	NetworkId, Register,
 };
-
-type XCVMProgram = DefaultXCVMProgram;
 
 const CONTRACT_NAME: &str = "composable:xcvm-interpreter";
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -165,7 +162,7 @@ fn remove_owners(_: Authenticated, deps: DepsMut, owners: Vec<Addr>) -> Response
 	Response::default().add_event(event)
 }
 
-/// Execute a [`XCVMProgram`].
+/// Execute an XCVM program.
 /// The function will execute the program instructions one by one.
 /// If the program contains a [`XCVMInstruction::Call`], the execution is suspended and resumed
 /// after having executed the call.
@@ -318,7 +315,7 @@ pub fn interpret_spawn(
 	network: NetworkId,
 	salt: Vec<u8>,
 	assets: Funds<Balance>,
-	program: XCVMProgram,
+	program: DefaultXCVMProgram,
 ) -> Result<Response, ContractError> {
 	let Config { interpreter_origin, gateway_address, .. } = CONFIG.load(deps.storage)?;
 

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/msg.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/msg.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use alloc::{string::String, vec::Vec};
 use cosmwasm_std::Addr;
-use cw_xc_utils::DefaultXCVMProgram;
+use cw_xc_common::shared::DefaultXCVMProgram;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use xc_core::{InterpreterOrigin, Register};

--- a/code/xcvm/cosmwasm/contracts/pingpong/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/pingpong/Cargo.toml
@@ -18,7 +18,6 @@ cosmwasm-std = { workspace = true }
 cw-storage-plus = { workspace = true }
 cw-utils = { workspace = true }
 cw-xc-common = { path = "../common" }
-cw-xc-utils = { path = "../utils" }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
 hex = { workspace = true, default-features = false, features = [

--- a/code/xcvm/cosmwasm/contracts/pingpong/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/pingpong/src/contract.rs
@@ -13,7 +13,6 @@ use cosmwasm_std::{
 };
 use cw2::set_contract_version;
 use cw_utils::ensure_from_older_version;
-use cw_xc_utils::DefaultXCVMProgram;
 use xc_core::{
 	cosmwasm::{FlatCosmosMsg, FlatWasmMsg},
 	Balance, Funds, Juno, Network, Picasso, ProgramBuilder, UserId, UserOrigin,
@@ -40,7 +39,7 @@ pub fn instantiate(
 fn make_program<T: Network<EncodedCall = Vec<u8>>, U: Network<EncodedCall = Vec<u8>>>(
 	remote_address: UserId,
 	msg: ExecuteMsg,
-) -> Result<DefaultXCVMProgram, ContractError> {
+) -> Result<cw_xc_common::shared::DefaultXCVMProgram, ContractError> {
 	Ok(ProgramBuilder::<T, CanonicalAddr, Funds<Balance>>::new("PING".as_bytes().to_vec())
 		.spawn::<U, (), _, _>(
 			"PONG".as_bytes().to_vec(),

--- a/code/xcvm/cosmwasm/contracts/utils/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/utils/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-authors = ["Composable Developers"]
-edition = "2021"
-name = "cw-xc-utils"
-version = "0.1.0"
-
-[dependencies]
-cosmwasm-std = { workspace = true }
-xc-core = { path = "../../../lib/core", features = [] }

--- a/code/xcvm/cosmwasm/contracts/utils/src/lib.rs
+++ b/code/xcvm/cosmwasm/contracts/utils/src/lib.rs
@@ -1,7 +1,0 @@
-use cosmwasm_std::CanonicalAddr;
-use std::collections::VecDeque;
-
-pub type DefaultXCVMInstruction = xc_core::Instruction<Vec<u8>, CanonicalAddr, xc_core::Funds>;
-pub type DefaultXCVMProgram = xc_core::Program<VecDeque<DefaultXCVMInstruction>>;
-pub type DefaultXCVMPacket = xc_core::Packet<DefaultXCVMProgram>;
-pub type Salt = Vec<u8>;

--- a/code/xcvm/cosmwasm/tests/Cargo.toml
+++ b/code/xcvm/cosmwasm/tests/Cargo.toml
@@ -21,7 +21,6 @@ cosmwasm-orchestrate = { workspace = true }
 cw-xc-interpreter = { path = "../contracts/interpreter" }
 cw-xc-pingpong = { path = "../contracts/pingpong" }
 cw-xc-common = { path = "../contracts/common" }
-cw-xc-utils = { path = "../contracts/utils" }
 xc-core = { path = "../../lib/core" }
 
 log = { version = "0.4" }

--- a/code/xcvm/cosmwasm/tests/src/tests/framework.rs
+++ b/code/xcvm/cosmwasm/tests/src/tests/framework.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 };
 use cosmwasm_vm::system::CosmwasmCodeId;
 use cw20::{Cw20Coin, Expiration, MinterResponse};
-use cw_xc_utils::{DefaultXCVMProgram, Salt};
+use cw_xc_common::shared::{DefaultXCVMProgram, Salt};
 use std::{collections::HashMap, hash::Hash};
 use xc_core::{Asset, AssetId, AssetSymbol, Funds, Network, NetworkId};
 

--- a/code/xcvm/cosmwasm/tests/src/tests/suite.rs
+++ b/code/xcvm/cosmwasm/tests/src/tests/suite.rs
@@ -9,9 +9,11 @@ use cosmwasm_std::{
 use cosmwasm_vm::system::CUSTOM_CONTRACT_EVENT_PREFIX;
 use cw20::{Cw20Coin, Expiration, MinterResponse};
 
-use cw_xc_common::gateway::EVENT_PREFIX as XCVM_GATEWAY_EVENT_PREFIX;
+use cw_xc_common::{
+	gateway::EVENT_PREFIX as XCVM_GATEWAY_EVENT_PREFIX,
+	shared::{DefaultXCVMProgram, Salt},
+};
 use cw_xc_interpreter::contract::XCVM_INTERPRETER_EVENT_PREFIX;
-use cw_xc_utils::{DefaultXCVMProgram, Salt};
 use proptest::{prelude::any, prop_assume, prop_compose, proptest};
 use std::assert_matches::assert_matches;
 use xc_core::{


### PR DESCRIPTION
The two crates serve very similar function (by providing common type declarations an code used by XCVM-related contracts) and both are rather small.  Merge both of them to simplify code dependencies.



- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production