### PR TITLE
picasso lp tokens migration

### DIFF
--- a/code/parachain/node/src/chain_spec/composable.rs
+++ b/code/parachain/node/src/chain_spec/composable.rs
@@ -82,7 +82,7 @@ pub fn genesis_config(
 		transaction_payment: Default::default(),
 		ibc: composable_runtime::IbcConfig {
 			assets: vec![pallet_ibc::pallet::AssetConfig {
-				id: primitives::currency::CurrencyId::LAYR,
+				id: primitives::currency::CurrencyId::COMPOSABLE_LAYR,
 				denom: b"1".to_vec(),
 			}],
 		},

--- a/code/parachain/runtime/composable/src/fees.rs
+++ b/code/parachain/runtime/composable/src/fees.rs
@@ -18,7 +18,7 @@ pub struct WellKnownForeignToNativePriceConverter;
 impl ForeignToNativePriceConverter for WellKnownForeignToNativePriceConverter {
 	fn get_ratio(asset_id: CurrencyId) -> Option<Rational64> {
 		match asset_id {
-			CurrencyId::LAYR => Some(rational!(1 / 1)),
+			CurrencyId::COMPOSABLE_LAYR => Some(rational!(1 / 1)),
 			_ => None,
 		}
 	}

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -605,7 +605,7 @@ impl crowdloan_rewards::Config for Runtime {
 
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
-	pub NativeAssetId: CurrencyId = CurrencyId::LAYR;
+	pub NativeAssetId: CurrencyId = CurrencyId(79228162514264337593543950338);
 	pub CreationDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
 	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub RentPerBlock: Balance = CurrencyId::milli::<Balance>();

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -605,7 +605,7 @@ impl crowdloan_rewards::Config for Runtime {
 
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
-	pub NativeAssetId: CurrencyId = CurrencyId(79228162514264337593543950338);
+	pub NativeAssetId: CurrencyId = CurrencyId::COMPOSABLE_LAYR;
 	pub CreationDeposit: Balance = 10 * CurrencyId::unit::<Balance>();
 	pub VaultExistentialDeposit: Balance = 1000 * CurrencyId::unit::<Balance>();
 	pub RentPerBlock: Balance = CurrencyId::milli::<Balance>();

--- a/code/parachain/runtime/composable/src/migrations.rs
+++ b/code/parachain/runtime/composable/src/migrations.rs
@@ -1,7 +1,9 @@
 use crate::*;
+use migrate_asset_ids::MigrateComposableAssetIds;
 
 pub type Migrations = (
 	SchedulerMigrationV1toV4,
+	MigrateComposableAssetIds,
 	preimage::migration::v1::Migration<Runtime>,
 	scheduler::migration::v3::MigrateToV4<Runtime>,
 	democracy::migrations::v1::Migration<Runtime>,
@@ -13,5 +15,218 @@ pub struct SchedulerMigrationV1toV4;
 impl OnRuntimeUpgrade for SchedulerMigrationV1toV4 {
 	fn on_runtime_upgrade() -> frame_support::weights::Weight {
 		Scheduler::migrate_v1_to_v4()
+	}
+}
+
+pub mod migrate_asset_ids {
+	use super::*;
+	use frame_support::traits::{GetStorageVersion, StorageVersion};
+
+	use common::AccountId;
+	use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+
+	pub struct MigrateComposableAssetIds;
+
+	fn get_new_asset_id(old_asset_id: CurrencyId) -> CurrencyId {
+		let zero_array: [u8; 8] = 0_u64.to_be_bytes();
+		let nonce = (u128::from_be_bytes(
+			[0; 8]
+				.into_iter()
+				.chain(zero_array)
+				.collect::<Vec<u8>>()
+				.try_into()
+				.expect("[u8; 8] + bytes(u64) = [u8; 16]"),
+		) ^ old_asset_id.0) as u64;
+
+		CurrencyId(u128::from_be_bytes(
+			[0, 0, 0, 1]
+				.into_iter()
+				.chain([0, 0, 0, 0])
+				.chain(nonce.to_be_bytes())
+				.collect::<Vec<u8>>()
+				.try_into()
+				.expect("[u8; 8] + bytes(u64) = [u8; 16]"),
+		))
+	}
+
+	const ASSETS_REGISTRY_V2: StorageVersion = StorageVersion::new(2);
+	// ids to change
+	const USDT: CurrencyId = CurrencyId(130);
+	const PICA: CurrencyId = CurrencyId(1);
+	const EQD: CurrencyId = CurrencyId(127);
+	const BNC_PLK: CurrencyId = CurrencyId(33);
+	const ASTR: CurrencyId = CurrencyId(2006);
+	const LAYR: CurrencyId = CurrencyId(2);
+	const EQ: CurrencyId = CurrencyId(2011);
+	const DOT: CurrencyId = CurrencyId(6);
+	const KSM: CurrencyId = CurrencyId(4);
+	const V_DOT: CurrencyId = CurrencyId(34);
+
+	/// change asset ids in AR
+	fn migrate_assets_registry(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		for old_asset_id in old_asset_ids.clone() {
+			let new_asset_id = get_new_asset_id(old_asset_id);
+			assets_registry::pallet::AssetRatio::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::ExistentialDeposit::<Runtime>::swap(
+				old_asset_id,
+				new_asset_id,
+			);
+			assets_registry::pallet::AssetName::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetName::<Runtime>::remove(old_asset_id);
+			assets_registry::pallet::AssetSymbol::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetSymbol::<Runtime>::remove(old_asset_id);
+			assets_registry::pallet::AssetDecimals::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetDecimals::<Runtime>::remove(old_asset_id);
+		}
+		Weight::from_ref_time(100_000)
+	}
+
+	fn migrate_orml_tokens(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		// orml_tokens TokenIssuance
+		for old_asset_id in old_asset_ids.clone() {
+			let new_asset_id = get_new_asset_id(old_asset_id);
+			orml_tokens::module::TotalIssuance::<Runtime>::swap(old_asset_id, new_asset_id);
+			orml_tokens::module::TotalIssuance::<Runtime>::remove(old_asset_id);
+		}
+
+		// orml_tokens Accounts storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Accounts::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Accounts::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Accounts::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+
+		// orml_tokens Locks storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Locks::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Locks::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Locks::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+
+		// orml_tokens Reserves storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Reserves::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Reserves::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Reserves::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+		Weight::from_ref_time(100_000)
+	}
+
+	/// change tx payment asset ids
+	fn migrate_tx_payment(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		// orml_tokens Accounts storage
+		let mut account_ids: Vec<(AccountId, CurrencyId)> = vec![];
+		for (account_id, (asset_id, _amount)) in
+			asset_tx_payment::pallet::PaymentAssets::<Runtime>::iter()
+		{
+			if old_asset_ids.contains(&asset_id) {
+				account_ids.push((account_id, asset_id));
+			}
+		}
+		for (account_id, asset_id) in account_ids {
+			asset_tx_payment::pallet::PaymentAssets::<Runtime>::mutate(account_id, |val| {
+				if let Some((asset_id_in, _)) = val {
+					*asset_id_in = get_new_asset_id(asset_id)
+				}
+			});
+		}
+		Weight::from_ref_time(100_000)
+	}
+
+	impl OnRuntimeUpgrade for MigrateComposableAssetIds {
+		fn on_runtime_upgrade() -> Weight {
+			let on_chain_version =
+				<AssetsRegistry as GetStorageVersion>::on_chain_storage_version();
+			if on_chain_version < ASSETS_REGISTRY_V2 {
+				let asset_ids = vec![USDT, PICA, EQD, LAYR, BNC_PLK, ASTR, EQ, DOT, KSM, V_DOT];
+				StorageVersion::new(2).put::<AssetsRegistry>();
+				// 4 pallets are affected, system isnt migrated because only native token id needs
+				// to be changed
+				migrate_orml_tokens(asset_ids.clone()) +
+					migrate_assets_registry(asset_ids.clone()) +
+					migrate_tx_payment(asset_ids.clone())
+			} else {
+				<Runtime as system::Config>::DbWeight::get().reads(1)
+			}
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use frame_support::sp_io;
+
+		use super::*;
+
+		pub fn new_test_ext() -> sp_io::TestExternalities {
+			let storage = frame_system::GenesisConfig::default()
+				.build_storage::<Runtime>()
+				.expect("in memory test");
+			let mut externalities = sp_io::TestExternalities::new(storage);
+			externalities.execute_with(|| System::set_block_number(1));
+			externalities
+		}
+
+		mod migrate_asset {
+
+			use super::*;
+
+			#[test]
+			fn check_ids_correct() {
+				assert_eq!(
+					get_new_asset_id(LAYR),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2
+					]))
+				);
+			}
+
+			#[test]
+			fn run_scenarios() {
+				new_test_ext().execute_with(|| {
+					// todo
+					// create & mint asset 1
+					// create & mint asset 2
+					// create pool
+					// add liquidity
+					// stake some of lp tokens
+					// wait for rewards
+					// execute migration functions and check that old values have new keys and old
+					// keys are removed
+				})
+			}
+		}
 	}
 }

--- a/code/parachain/runtime/composable/src/migrations.rs
+++ b/code/parachain/runtime/composable/src/migrations.rs
@@ -77,7 +77,18 @@ pub mod migrate_asset_ids {
 			assets_registry::pallet::AssetSymbol::<Runtime>::remove(old_asset_id);
 			assets_registry::pallet::AssetDecimals::<Runtime>::swap(old_asset_id, new_asset_id);
 			assets_registry::pallet::AssetDecimals::<Runtime>::remove(old_asset_id);
+
+			assets_registry::pallet::LocalToForeign::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::LocalToForeign::<Runtime>::remove(old_asset_id);
+
+			let location = assets_registry::pallet::LocalToForeign::<Runtime>::get(new_asset_id);
+			if let Some(location_key) = location {
+				assets_registry::pallet::ForeignToLocal::<Runtime>::mutate(location_key, |x| {
+					*x = Some(new_asset_id)
+				});
+			}
 		}
+
 		Weight::from_ref_time(100_000)
 	}
 

--- a/code/parachain/runtime/picasso/src/migrations.rs
+++ b/code/parachain/runtime/picasso/src/migrations.rs
@@ -1,9 +1,11 @@
 use crate::{prelude::*, *};
 use frame_support::traits::{GetStorageVersion, StorageVersion};
+use migrate_asset_ids::MigratePicassoAssetIds;
 
 pub type Migrations = (
 	SchedulerMigrationV1toV4,
 	TechCollectiveRenameMigration,
+	MigratePicassoAssetIds,
 	preimage::migration::v1::Migration<Runtime>,
 	scheduler::migration::v3::MigrateToV4<Runtime>,
 	democracy::migrations::v1::Migration<Runtime>,
@@ -51,6 +53,385 @@ impl OnRuntimeUpgrade for TechCollectiveRenameMigration {
 	fn on_runtime_upgrade() -> Weight {
 		move_runtime_pallet::<"TechnicalCollective", 1, TechnicalCommittee>() +
 			move_runtime_pallet::<"TechnicalMembership", 1, TechnicalCommitteeMembership>()
+	}
+}
+
+pub mod migrate_asset_ids {
+	use super::*;
+
+	use frame_support::traits::{GetStorageVersion, StorageVersion};
+
+	use common::AccountId;
+	use pablo::PoolConfiguration;
+	use sp_std::{collections::btree_set::BTreeSet, vec::Vec};
+
+	pub struct MigratePicassoAssetIds;
+
+	fn get_new_asset_id(old_asset_id: CurrencyId) -> CurrencyId {
+		let zero_array: [u8; 8] = 0_u64.to_be_bytes();
+		let nonce = (u128::from_be_bytes(
+			<Runtime as pablo::Config>::PalletId::get()
+				.0
+				.into_iter()
+				.chain(zero_array)
+				.collect::<Vec<u8>>()
+				.try_into()
+				.expect("[u8; 8] + bytes(u64) = [u8; 16]"),
+		) ^ old_asset_id.0) as u64;
+		let pablo_index = (Pablo::index() as u32).to_be_bytes();
+		CurrencyId(u128::from_be_bytes(
+			[0, 0, 0, 0]
+				.into_iter()
+				.chain(pablo_index)
+				.chain(nonce.to_be_bytes())
+				.collect::<Vec<u8>>()
+				.try_into()
+				.expect("[u8; 8] + bytes(u64) = [u8; 16]"),
+		))
+	}
+
+	const ASSETS_REGISTRY_V2: StorageVersion = StorageVersion::new(2);
+	// ids to change
+	const DOT_PICA_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105538);
+	const DOT_USDT_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105539);
+	const DOT_KSM_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105540);
+	const DOT_OSMO_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105541);
+	const KSM_OSMO_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105542);
+	const USDT_OSMO_LPT: CurrencyId = CurrencyId(149379386384882397174193330044887105543);
+
+	/// migrate orml_tokens storage
+	fn migrate_orml_tokens(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		// orml_tokens TokenIssuance
+		for old_asset_id in old_asset_ids.clone() {
+			let new_asset_id = get_new_asset_id(old_asset_id);
+			orml_tokens::module::TotalIssuance::<Runtime>::swap(old_asset_id, new_asset_id);
+			orml_tokens::module::TotalIssuance::<Runtime>::remove(old_asset_id);
+		}
+
+		// orml_tokens Accounts storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Accounts::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Accounts::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Accounts::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+
+		// orml_tokens Locks storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Locks::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Locks::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Locks::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+
+		// orml_tokens Reserves storage
+		let mut account_ids: BTreeSet<AccountId> = BTreeSet::new();
+		for (account_id, _) in orml_tokens::module::Reserves::<Runtime>::iter_keys() {
+			account_ids.insert(account_id);
+		}
+		for account_id in account_ids {
+			for old_asset_id in old_asset_ids.clone() {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				orml_tokens::module::Reserves::<Runtime>::swap(
+					account_id.clone(),
+					old_asset_id,
+					account_id.clone(),
+					new_asset_id,
+				);
+				orml_tokens::module::Reserves::<Runtime>::remove(account_id.clone(), old_asset_id);
+			}
+		}
+		Weight::from_ref_time(100_000)
+	}
+
+	/// change some of the pools' lp token ids
+	fn migrate_pablo_pools(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		pablo::pallet::Pools::<Runtime>::translate_values(|pool| match pool {
+			PoolConfiguration::DualAssetConstantProduct(mut config) => {
+				if old_asset_ids.contains(&config.lp_token) {
+					config.lp_token = get_new_asset_id(config.lp_token);
+				}
+				Some(PoolConfiguration::DualAssetConstantProduct(config))
+			},
+		});
+		Weight::from_ref_time(100_000)
+	}
+
+	/// change staking storage for staked lp tokens
+	fn migrate_staking(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		// farming pallet RewardSchedules
+		let mut asset_ids: BTreeSet<(CurrencyId, CurrencyId)> = BTreeSet::new();
+		for (asset_id, reward_id) in farming::pallet::RewardSchedules::<Runtime>::iter_keys() {
+			asset_ids.insert((asset_id, reward_id));
+		}
+		for (old_asset_id, reward_id) in asset_ids {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				farming::pallet::RewardSchedules::<Runtime>::swap(
+					old_asset_id.clone(),
+					reward_id.clone(),
+					new_asset_id.clone(),
+					reward_id.clone(),
+				);
+				farming::pallet::RewardSchedules::<Runtime>::remove(
+					old_asset_id.clone(),
+					reward_id.clone(),
+				);
+			}
+		}
+
+		// reward pallet RewardCurrencies
+		let mut asset_ids: BTreeSet<CurrencyId> = BTreeSet::new();
+		for asset_id in
+			reward::pallet::RewardCurrencies::<Runtime, FarmingRewardsInstance>::iter_keys()
+		{
+			asset_ids.insert(asset_id);
+		}
+		for old_asset_id in asset_ids {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				reward::pallet::RewardCurrencies::<Runtime, FarmingRewardsInstance>::swap(
+					old_asset_id.clone(),
+					new_asset_id.clone(),
+				);
+				reward::pallet::RewardCurrencies::<Runtime, FarmingRewardsInstance>::remove(
+					old_asset_id.clone(),
+				);
+			}
+		}
+
+		// reward pallet TotalStake
+		let mut asset_ids: BTreeSet<CurrencyId> = BTreeSet::new();
+		for asset_id in reward::pallet::TotalStake::<Runtime, FarmingRewardsInstance>::iter_keys() {
+			asset_ids.insert(asset_id);
+		}
+		for old_asset_id in asset_ids {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				reward::pallet::TotalStake::<Runtime, FarmingRewardsInstance>::swap(
+					old_asset_id.clone(),
+					new_asset_id.clone(),
+				);
+				reward::pallet::TotalStake::<Runtime, FarmingRewardsInstance>::remove(
+					old_asset_id.clone(),
+				);
+			}
+		}
+
+		// reward pallet Stake
+		let mut asset_ids: BTreeSet<(CurrencyId, AccountId)> = BTreeSet::new();
+		for (asset_id, user_id) in
+			reward::pallet::Stake::<Runtime, FarmingRewardsInstance>::iter_keys()
+		{
+			asset_ids.insert((asset_id, user_id));
+		}
+		for (old_asset_id, user_id) in asset_ids {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id = get_new_asset_id(old_asset_id);
+				reward::pallet::Stake::<Runtime, FarmingRewardsInstance>::swap(
+					(old_asset_id.clone(), user_id.clone()),
+					(new_asset_id.clone(), user_id.clone()),
+				);
+				reward::pallet::Stake::<Runtime, FarmingRewardsInstance>::remove((
+					old_asset_id.clone(),
+					user_id.clone(),
+				));
+			}
+		}
+
+		// reward pallet RewardPerToken
+		let mut keys: BTreeSet<(CurrencyId, CurrencyId)> = BTreeSet::new();
+		for (reward_id, asset_id) in
+			reward::pallet::RewardPerToken::<Runtime, FarmingRewardsInstance>::iter_keys()
+		{
+			keys.insert((reward_id, asset_id));
+		}
+		for (reward_id, old_asset_id) in keys {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id: CurrencyId = get_new_asset_id(old_asset_id);
+				reward::pallet::RewardPerToken::<Runtime, FarmingRewardsInstance>::swap(
+					reward_id.clone(),
+					old_asset_id.clone(),
+					reward_id.clone(),
+					new_asset_id.clone(),
+				);
+				reward::pallet::RewardPerToken::<Runtime, FarmingRewardsInstance>::remove(
+					reward_id.clone(),
+					old_asset_id.clone(),
+				);
+			}
+		}
+
+		// reward pallet RewardTally
+		let mut keys: BTreeSet<(CurrencyId, (CurrencyId, AccountId))> = BTreeSet::new();
+		for (reward_id, (asset_id, account_id)) in
+			reward::pallet::RewardTally::<Runtime, FarmingRewardsInstance>::iter_keys()
+		{
+			keys.insert((reward_id, (asset_id, account_id)));
+		}
+		for (reward_id, (old_asset_id, account_id)) in keys {
+			if old_asset_ids.clone().contains(&old_asset_id) {
+				let new_asset_id: CurrencyId = get_new_asset_id(old_asset_id);
+				reward::pallet::RewardTally::<Runtime, FarmingRewardsInstance>::swap(
+					reward_id.clone(),
+					(old_asset_id.clone(), account_id.clone()),
+					reward_id.clone(),
+					(new_asset_id.clone(), account_id.clone()),
+				);
+				reward::pallet::RewardTally::<Runtime, FarmingRewardsInstance>::remove(
+					reward_id.clone(),
+					(old_asset_id.clone(), account_id.clone()),
+				);
+			}
+		}
+
+		Weight::from_ref_time(100_000)
+	}
+
+	/// change some of the pools' lp token ids
+	fn migrate_assets_registry(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		for old_asset_id in old_asset_ids.clone() {
+			let new_asset_id = get_new_asset_id(old_asset_id);
+			assets_registry::pallet::AssetRatio::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::ExistentialDeposit::<Runtime>::swap(
+				old_asset_id,
+				new_asset_id,
+			);
+			assets_registry::pallet::AssetName::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetName::<Runtime>::remove(old_asset_id);
+			assets_registry::pallet::AssetSymbol::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetSymbol::<Runtime>::remove(old_asset_id);
+			assets_registry::pallet::AssetDecimals::<Runtime>::swap(old_asset_id, new_asset_id);
+			assets_registry::pallet::AssetDecimals::<Runtime>::remove(old_asset_id);
+		}
+		Weight::from_ref_time(100_000)
+	}
+
+	fn migrate_asset_ids(old_asset_ids: Vec<CurrencyId>) -> Weight {
+		let mut total_weight = Weight::from_ref_time(0);
+		total_weight += migrate_orml_tokens(old_asset_ids.clone());
+		total_weight += migrate_pablo_pools(old_asset_ids.clone());
+		total_weight += migrate_staking(old_asset_ids.clone());
+		total_weight += migrate_assets_registry(old_asset_ids.clone());
+		total_weight
+	}
+
+	impl OnRuntimeUpgrade for MigratePicassoAssetIds {
+		fn on_runtime_upgrade() -> Weight {
+			let on_chain_version =
+				<AssetsRegistry as GetStorageVersion>::on_chain_storage_version();
+			if on_chain_version < ASSETS_REGISTRY_V2 {
+				let asset_ids = vec![
+					DOT_PICA_LPT,
+					DOT_USDT_LPT,
+					DOT_KSM_LPT,
+					DOT_OSMO_LPT,
+					KSM_OSMO_LPT,
+					USDT_OSMO_LPT,
+				];
+
+				StorageVersion::new(2).put::<AssetsRegistry>();
+				migrate_asset_ids(asset_ids)
+			} else {
+				<Runtime as system::Config>::DbWeight::get().reads(1)
+			}
+		}
+	}
+
+	#[cfg(test)]
+	mod tests {
+		use frame_support::sp_io;
+
+		use super::*;
+
+		pub fn new_test_ext() -> sp_io::TestExternalities {
+			let storage = frame_system::GenesisConfig::default()
+				.build_storage::<Runtime>()
+				.expect("in memory test");
+			let mut externalities = sp_io::TestExternalities::new(storage);
+			externalities.execute_with(|| System::set_block_number(1));
+			externalities
+		}
+
+		mod migrate_asset {
+
+			use super::*;
+
+			#[test]
+			fn check_ids_correct() {
+				assert_eq!(
+					get_new_asset_id(DOT_PICA_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 2
+					]))
+				);
+				assert_eq!(
+					get_new_asset_id(DOT_USDT_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 3
+					]))
+				);
+				assert_eq!(
+					get_new_asset_id(DOT_KSM_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 4
+					]))
+				);
+				assert_eq!(
+					get_new_asset_id(DOT_OSMO_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 5
+					]))
+				);
+				assert_eq!(
+					get_new_asset_id(KSM_OSMO_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 6
+					]))
+				);
+				assert_eq!(
+					get_new_asset_id(USDT_OSMO_LPT),
+					CurrencyId(u128::from_be_bytes([
+						0, 0, 0, 0, 0, 0, 0, 59, 0, 0, 0, 0, 0, 0, 0, 7
+					]))
+				);
+			}
+
+			#[test]
+			fn run_scenarios() {
+				new_test_ext().execute_with(|| {
+					// todo
+					// create & mint asset 1
+					// create & mint asset 2
+					// create pool
+					// add liquidity
+					// stake some of lp tokens
+					// wait for rewards
+					// execute migration functions and check that old values have new keys and old
+					// keys are removed
+				})
+			}
+		}
 	}
 }
 

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -137,6 +137,8 @@ impl CurrencyId {
 		);
 		///  Native from Composable
 		pub const LAYR: CurrencyId = CurrencyId(2);
+		///  Native from Composable
+		pub const COMPOSABLE_LAYR: CurrencyId = CurrencyId(79228162514264337593543950338);
 
 		/// Kusama native token
 		pub const KSM: CurrencyId = CurrencyId(
@@ -150,6 +152,7 @@ impl CurrencyId {
 
 		/// DOT from Polkadot
 		pub const DOT: CurrencyId = CurrencyId(6, None);
+		pub const COMPOSABLE_DOT: CurrencyId = CurrencyId(79228162514264337593543950342);
 
 		pub const KSM_USDT_LPT: CurrencyId = CurrencyId(105, None);
 		pub const PICA_USDT_LPT: CurrencyId = CurrencyId(106, None);

--- a/code/parachain/runtime/primitives/src/topology.rs
+++ b/code/parachain/runtime/primitives/src/topology.rs
@@ -253,6 +253,6 @@ impl Composable {
 }
 
 impl WellKnownCurrency for Composable {
-	const NATIVE: CurrencyId = CurrencyId::LAYR;
-	const RELAY_NATIVE: CurrencyId = CurrencyId::DOT;
+	const NATIVE: CurrencyId = CurrencyId::COMPOSABLE_LAYR;
+	const RELAY_NATIVE: CurrencyId = CurrencyId::COMPOSABLE_DOT;
 }


### PR DESCRIPTION
for picasso new asset id structure (https://github.com/ComposableFi/composable/pull/3751), lp tokens need to be migrated DOT_PICA_LPT, DOT_USDT_LPT, DOT_KSM_LPT, DOT_OSMO_LPT, KSM_OSMO_LPT, USDT_OSMO_LPT

- orml_tokens storages swapped for all accounts of now bad structured lp tokens
- pools lp token ids changed to new ones
- farming and reward pallet storages values swapped for new keys
- assets registry swapped old lp tokens for new ones

on composable side asset ids changed for [USDT, PICA, EQD, LAYR, BNC_PLK, ASTR, EQ, DOT, KSM, V_DOT],
LAYR is changed from 2 to 79228162514264337593543950338 (system pallet affect)
assets in assets_tx_payments also migrated,
orml_tokens migrated
assets_registry migrated
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production