### PR TITLE
AR NetworkId

### DIFF
--- a/code/parachain/frame/assets-registry/src/benchmarking.rs
+++ b/code/parachain/frame/assets-registry/src/benchmarking.rs
@@ -31,7 +31,7 @@ benchmarks! {
 
 	register_asset {
 		let location = T::ForeignAssetId::decode(&mut ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here())).encode().as_ref()).unwrap();
-		let protocol_id = *b"benchmar";
+		let protocol_id = *b"benc";
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: Some(BiBoundedAssetName::from_vec(b"Kusama".to_vec()).expect("String is within bounds")),
@@ -44,7 +44,7 @@ benchmarks! {
 
 	update_asset {
 		let location =T::ForeignAssetId::decode(&mut ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here())).encode().as_ref()).unwrap();
-		let protocol_id = *b"benchmar";
+		let protocol_id = *b"benc";
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: Some(BiBoundedAssetName::from_vec(b"Kusama".to_vec()).expect("String is within bounds")),
@@ -84,7 +84,7 @@ benchmarks! {
 
 	update_asset_location {
 		let location =T::ForeignAssetId::decode(&mut ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here())).encode().as_ref()).unwrap();
-		let protocol_id = *b"benchmar";
+		let protocol_id = *b"benc";
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: Some(BiBoundedAssetName::from_vec(b"Kusama".to_vec()).expect("String is within bounds")),

--- a/code/parachain/frame/assets-registry/src/lib.rs
+++ b/code/parachain/frame/assets-registry/src/lib.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 
 		/// Network id, unique per chain
 		#[pallet::constant]
-		type NetworkId: Get<[u8; 4]>;
+		type NetworkId: Get<u32>;
 	}
 
 	#[pallet::pallet]
@@ -566,6 +566,7 @@ pub mod pallet {
 
 		fn generate_asset_id(protocol_id: [u8; 4], nonce: u64) -> Self::AssetId {
 			let bytes = T::NetworkId::get()
+				.to_be_bytes()
 				.into_iter()
 				.chain(protocol_id)
 				.chain(nonce.to_be_bytes())

--- a/code/parachain/frame/assets-registry/src/runtime.rs
+++ b/code/parachain/frame/assets-registry/src/runtime.rs
@@ -69,6 +69,7 @@ ord_parameter_types! {
 
 parameter_types! {
 	pub const NativeED: Balance = 0;
+	pub const PicassoNetworkId: [u8; 4] = [1,0,0,0];
 }
 
 type AssetId = u128;
@@ -88,6 +89,7 @@ impl pallet_assets_registry::Config for Runtime {
 	>;
 	type WeightInfo = SubstrateWeight<Self>;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 // Build genesis storage according to the mock runtime.

--- a/code/parachain/frame/assets-registry/src/runtime.rs
+++ b/code/parachain/frame/assets-registry/src/runtime.rs
@@ -69,7 +69,7 @@ ord_parameter_types! {
 
 parameter_types! {
 	pub const NativeED: Balance = 0;
-	pub const PicassoNetworkId: [u8; 4] = [1,0,0,0];
+	pub const PicassoNetworkId: u32 = 256;
 }
 
 type AssetId = u128;

--- a/code/parachain/frame/assets-registry/src/tests.rs
+++ b/code/parachain/frame/assets-registry/src/tests.rs
@@ -7,7 +7,7 @@ use composable_traits::{
 	storage::UpdateValue,
 	xcm::assets::RemoteAssetRegistryInspect,
 };
-use frame_support::{assert_noop, assert_ok, error::BadOrigin};
+use frame_support::{assert_noop, assert_ok, error::BadOrigin, traits::PalletInfoAccess};
 use frame_system::RawOrigin;
 use primitives::currency::{ForeignAssetId, VersionedMultiLocation};
 use xcm::latest::MultiLocation;
@@ -21,9 +21,76 @@ fn negative_get_metadata() {
 }
 
 #[test]
+fn check_id_structure() {
+	new_test_ext().execute_with(|| {
+		System::set_block_number(1);
+		// asset id 1
+		let protocol_id = [0, 0, 0, 0];
+		let nonce = 1_u64;
+		let asset_info = AssetInfo {
+			name: None,
+			symbol: None,
+			decimals: Some(4),
+			existential_deposit: 0,
+			ratio: Some(rational!(42 / 123)),
+		};
+		assert_ok!(AssetsRegistry::register_asset(
+			RawOrigin::Root.into(),
+			protocol_id,
+			nonce,
+			None,
+			asset_info.clone(),
+		));
+		let asset_id_1 = System::events()
+			.iter()
+			.find_map(|x| match x.event {
+				RuntimeEvent::AssetsRegistry(crate::Event::<Runtime>::AssetRegistered {
+					asset_id,
+					location: _,
+					asset_info: _,
+				}) => Some(asset_id),
+				_ => None,
+			})
+			.expect("Asset registration event emmited");
+
+		// asset id 2
+		assert_eq!(
+			asset_id_1,
+			u128::from_be_bytes([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+		);
+		let protocol_id = [0, 0, 1, 0];
+		let nonce = 256_u64;
+		assert_ok!(AssetsRegistry::register_asset(
+			RawOrigin::Root.into(),
+			protocol_id,
+			nonce,
+			None,
+			asset_info,
+		));
+		let asset_id_2 = System::events()
+			.iter()
+			.find_map(|x| match x.event {
+				RuntimeEvent::AssetsRegistry(crate::Event::<Runtime>::AssetRegistered {
+					asset_id,
+					location: _,
+					asset_info: _,
+				}) if asset_id != asset_id_1 => Some(asset_id),
+				_ => None,
+			})
+			.expect("Asset registration event emmited");
+		println!("{:?}", asset_id_2.to_be_bytes());
+		assert_eq!(
+			asset_id_2,
+			u128::from_be_bytes([1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])
+		);
+	})
+}
+
+#[test]
 fn set_metadata() {
 	new_test_ext().execute_with(|| {
-		let protocol_id = *b"AssTests";
+		// let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: None,
@@ -78,7 +145,7 @@ fn register_asset() {
 				[..],
 		)
 		.expect("Location bytes translate to foreign ID bytes");
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: None,
@@ -122,7 +189,7 @@ fn update_asset() {
 				[..],
 		)
 		.expect("Location bytes translate to foreign ID bytes");
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: None,
@@ -234,7 +301,7 @@ fn update_asset_location() {
 				[..],
 		)
 		.expect("Location bytes translate to foreign ID bytes");
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let asset_info = AssetInfo {
 			name: None,
@@ -321,7 +388,7 @@ fn use_same_location_twice() {
 			&mut &ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here())).encode()[..],
 		)
 		.expect("Location bytes translate to foreign ID bytes");
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce_1 = 1_u64;
 		let nonce_2 = 2_u64;
 		let nonce_3 = 3_u64;
@@ -414,7 +481,7 @@ fn use_same_location_twice() {
 fn get_foreign_assets_list_should_work() {
 	new_test_ext().execute_with(|| {
 		let location = ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here()));
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let name = Some(BiBoundedVec::from_vec(b"asset_name".to_vec()).unwrap());
 		let symbol = Some(BiBoundedVec::from_vec(b"asset_symbol".to_vec()).unwrap());
@@ -460,7 +527,7 @@ fn get_foreign_assets_list_should_work() {
 fn get_all_assets_should_work() {
 	new_test_ext().execute_with(|| {
 		let location = ForeignAssetId::Xcm(VersionedMultiLocation::V3(MultiLocation::here()));
-		let protocol_id = *b"AssTests";
+		let protocol_id = (AssetsRegistry::index() as u32).to_be_bytes();
 		let nonce = 1_u64;
 		let nonce2 = 2_u64;
 		let name = Some(BiBoundedVec::from_vec(b"asset_name".to_vec()).unwrap());
@@ -495,10 +562,9 @@ fn get_all_assets_should_work() {
 			asset_info,
 		));
 
-		let all_assets = AssetsRegistry::get_all_assets();
-
+		let mut all_assets = AssetsRegistry::get_all_assets();
 		assert_eq!(
-			all_assets,
+			all_assets.sort_by_key(|asset| asset.id),
 			vec![
 				Asset {
 					name: name.clone().map(Into::into),
@@ -519,6 +585,7 @@ fn get_all_assets_should_work() {
 					existential_deposit: 0,
 				}
 			]
+			.sort_by_key(|asset| asset.id)
 		);
 	})
 }

--- a/code/parachain/frame/assets-registry/src/tests.rs
+++ b/code/parachain/frame/assets-registry/src/tests.rs
@@ -56,7 +56,7 @@ fn check_id_structure() {
 		// asset id 2
 		assert_eq!(
 			asset_id_1,
-			u128::from_be_bytes([1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+			u128::from_be_bytes([0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
 		);
 		let protocol_id = [0, 0, 1, 0];
 		let nonce = 256_u64;
@@ -81,7 +81,7 @@ fn check_id_structure() {
 		println!("{:?}", asset_id_2.to_be_bytes());
 		assert_eq!(
 			asset_id_2,
-			u128::from_be_bytes([1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])
+			u128::from_be_bytes([0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0])
 		);
 	})
 }

--- a/code/parachain/frame/assets-transactor-router/src/lib.rs
+++ b/code/parachain/frame/assets-transactor-router/src/lib.rs
@@ -458,7 +458,7 @@ pub mod pallet {
 		type Balance = T::Balance;
 
 		fn create_local_asset(
-			protocol_id: [u8; 8],
+			protocol_id: [u8; 4],
 			nonce: u64,
 			asset_info: AssetInfo<T::Balance>,
 		) -> Result<Self::LocalAssetId, DispatchError> {
@@ -470,7 +470,7 @@ pub mod pallet {
 		}
 
 		fn create_foreign_asset(
-			protocol_id: [u8; 8],
+			protocol_id: [u8; 4],
 			nonce: u64,
 			asset_info: AssetInfo<T::Balance>,
 			foreign_asset_id: Self::ForeignAssetId,

--- a/code/parachain/frame/assets-transactor-router/src/mocks.rs
+++ b/code/parachain/frame/assets-transactor-router/src/mocks.rs
@@ -51,6 +51,7 @@ parameter_type_with_key! {
 
 parameter_types! {
 	pub const NativeAssetId: AssetId = 1;
+	pub const NetworkId: [u8; 4] = [0,0,0,0];
 }
 
 impl Config for Test {
@@ -76,6 +77,7 @@ impl assets_registry::Config for Test {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = NetworkId;
 }
 
 parameter_types! {

--- a/code/parachain/frame/assets-transactor-router/src/mocks.rs
+++ b/code/parachain/frame/assets-transactor-router/src/mocks.rs
@@ -51,7 +51,7 @@ parameter_type_with_key! {
 
 parameter_types! {
 	pub const NativeAssetId: AssetId = 1;
-	pub const NetworkId: [u8; 4] = [0,0,0,0];
+	pub const NetworkId: u32 = 0;
 }
 
 impl Config for Test {

--- a/code/parachain/frame/assets-transactor-router/src/tests/extrinsics.rs
+++ b/code/parachain/frame/assets-transactor-router/src/tests/extrinsics.rs
@@ -10,9 +10,10 @@ const TO_ACCOUNT: u128 = 2;
 const INIT_AMOUNT: Balance = 1000;
 const TRANSFER_AMOUNT: Balance = 500;
 
-fn create_asset_id(protocol_id: [u8; 8], nonce: u64) -> u128 {
-	let bytes = protocol_id
+fn create_asset_id(protocol_id: [u8; 4], nonce: u64) -> u128 {
+	let bytes = <Test as assets_registry::Config>::NetworkId::get()
 		.into_iter()
+		.chain(protocol_id)
 		.chain(nonce.to_be_bytes())
 		.collect::<Vec<u8>>()
 		.try_into()
@@ -211,7 +212,7 @@ mod mint_into {
 
 	#[test]
 	fn should_create_local_asset_and_mint() {
-		let protocol_id = *b"unittest";
+		let protocol_id = [0, 0, 0, 1];
 		let nonce = 1;
 		let asset_id = create_asset_id(protocol_id, nonce);
 		let asset_info = AssetInfo {

--- a/code/parachain/frame/assets-transactor-router/src/tests/extrinsics.rs
+++ b/code/parachain/frame/assets-transactor-router/src/tests/extrinsics.rs
@@ -12,6 +12,7 @@ const TRANSFER_AMOUNT: Balance = 500;
 
 fn create_asset_id(protocol_id: [u8; 4], nonce: u64) -> u128 {
 	let bytes = <Test as assets_registry::Config>::NetworkId::get()
+		.to_be_bytes()
 		.into_iter()
 		.chain(protocol_id)
 		.chain(nonce.to_be_bytes())

--- a/code/parachain/frame/assets-transactor-router/src/tests/routing.rs
+++ b/code/parachain/frame/assets-transactor-router/src/tests/routing.rs
@@ -4,11 +4,14 @@ use primitives::currency::{ForeignAssetId, VersionedMultiLocation};
 use xcm::v3::MultiLocation;
 
 use crate::{
-	mocks::{new_test_ext, AccountId, AssetId, RuntimeOrigin, Test},
+	mocks::{new_test_ext, AccountId, AssetId, AssetsRegistry, RuntimeOrigin, Test, Tokens},
 	Config, Pallet,
 };
 use composable_traits::assets::{AssetInfo, BiBoundedAssetName, BiBoundedAssetSymbol, CreateAsset};
-use frame_support::traits::fungibles::{Inspect, InspectHold, MutateHold};
+use frame_support::traits::{
+	fungibles::{Inspect, InspectHold, MutateHold},
+	PalletInfoAccess,
+};
 
 const NATIVE_ASSET_ID: AssetId = 1;
 const ACCOUNT_NATIVE: u128 = 1;
@@ -24,9 +27,9 @@ type ForeignTransactor = <Test as Config>::ForeignTransactor;
 
 // creates for routing 1 local asset and 1 foreign asset(native asset is specified in config)
 fn create_assets() -> (AssetId, AssetId) {
-	let protocol_id_local = *b"testloca";
+	let protocol_id_local = (AssetsRegistry::index() as u32).to_be_bytes();
 	let nonce_local = 0;
-	let protocol_id_foreign = *b"testfore";
+	let protocol_id_foreign = (Tokens::index() as u32).to_be_bytes();
 	let nonce_foreign = 0;
 	let asset_info_local = AssetInfo {
 		name: Some(

--- a/code/parachain/frame/composable-traits/src/assets.rs
+++ b/code/parachain/frame/composable-traits/src/assets.rs
@@ -220,12 +220,13 @@ pub trait CreateAsset {
 	/// If `Ok`, returns the ID of the newly created asset.
 	///
 	/// # Parameters
-	/// * `protocol_id` - The unique ID of the protocol that owns this asset (often a `PalletId`)
+	/// * `protocol_id` - The unique ID of the protocol that owns this asset  (often a
+	///   `(Pallet::<T>::index() as u32).to_be_bytes()` if pallet's index < u32::MAX)
 	/// * `nonce` - A nonce controlled by the owning protocol that uniquely identifies the asset in
 	///   the scope of the protocol
 	/// * `asset_info` - Structure containing relevant information to register the asset
 	fn create_local_asset(
-		protocol_id: [u8; 8],
+		protocol_id: [u8; 4],
 		nonce: u64,
 		asset_info: AssetInfo<Self::Balance>,
 	) -> Result<Self::LocalAssetId, DispatchError>;
@@ -235,13 +236,14 @@ pub trait CreateAsset {
 	/// If `Ok`, returns the ID of the newly created asset.
 	///
 	/// # Parameters
-	/// * `protocol_id` - The unique ID of the protocol that owns this asset (often a `PalletId`)
+	/// * `protocol_id` - The unique ID of the protocol that owns this asset (often a
+	///   `(Pallet::<T>::index() as u32).to_be_bytes()` if pallet's index < u32::MAX)
 	/// * `nonce` - A nonce controlled by the owning protocol that uniquely identifies the asset in
 	///   the scope of the protocol
 	/// * `foreign_asset_id` - Foreign asset ID or relative location
 	/// * `asset_info` - Structure containing relevant information to register the asset
 	fn create_foreign_asset(
-		protocol_id: [u8; 8],
+		protocol_id: [u8; 4],
 		nonce: u64,
 		asset_info: AssetInfo<Self::Balance>,
 		foreign_asset_id: Self::ForeignAssetId,
@@ -251,5 +253,5 @@ pub trait CreateAsset {
 pub trait GenerateAssetId {
 	type AssetId;
 
-	fn generate_asset_id(protocol_id: [u8; 8], nonce: u64) -> Self::AssetId;
+	fn generate_asset_id(protocol_id: [u8; 4], nonce: u64) -> Self::AssetId;
 }

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -183,7 +183,7 @@ impl CurrencyFactory for CurrencyIdGenerator {
 }
 
 parameter_types! {
-	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+	pub const PicassoNetworkId: u32 = 0;
 }
 
 impl pallet_assets_registry::Config for Test {

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -182,6 +182,10 @@ impl CurrencyFactory for CurrencyIdGenerator {
 	}
 }
 
+parameter_types! {
+	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+}
+
 impl pallet_assets_registry::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type LocalAssetId = CurrencyId;
@@ -191,6 +195,7 @@ impl pallet_assets_registry::Config for Test {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 impl pallet_assets_transactor_router::Config for Test {

--- a/code/parachain/frame/dex-router/src/mock.rs
+++ b/code/parachain/frame/dex-router/src/mock.rs
@@ -188,7 +188,7 @@ parameter_types! {
 	pub const MaxStakingDurationPresets: u32 = 10;
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
-	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+	pub const PicassoNetworkId: u32 = 0;
 }
 
 impl pallet_assets_registry::Config for Test {

--- a/code/parachain/frame/dex-router/src/mock.rs
+++ b/code/parachain/frame/dex-router/src/mock.rs
@@ -188,6 +188,7 @@ parameter_types! {
 	pub const MaxStakingDurationPresets: u32 = 10;
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
+	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
 }
 
 impl pallet_assets_registry::Config for Test {
@@ -199,6 +200,7 @@ impl pallet_assets_registry::Config for Test {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 impl pallet_assets_transactor_router::Config for Test {

--- a/code/parachain/frame/liquidations/src/mock/runtime.rs
+++ b/code/parachain/frame/liquidations/src/mock/runtime.rs
@@ -157,6 +157,7 @@ pub static CHARLIE: Public =
 
 ord_parameter_types! {
 	pub const RootAccount: AccountId = ALICE;
+	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
 }
 
 impl pallet_assets_registry::Config for Runtime {
@@ -168,6 +169,7 @@ impl pallet_assets_registry::Config for Runtime {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 impl pallet_assets_transactor_router::Config for Runtime {

--- a/code/parachain/frame/liquidations/src/mock/runtime.rs
+++ b/code/parachain/frame/liquidations/src/mock/runtime.rs
@@ -157,7 +157,7 @@ pub static CHARLIE: Public =
 
 ord_parameter_types! {
 	pub const RootAccount: AccountId = ALICE;
-	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+	pub const PicassoNetworkId: u32 = 0;
 }
 
 impl pallet_assets_registry::Config for Runtime {

--- a/code/parachain/frame/pablo/src/lib.rs
+++ b/code/parachain/frame/pablo/src/lib.rs
@@ -1064,8 +1064,9 @@ pub mod pallet {
 	}
 
 	pub(crate) fn create_lpt_asset<T: Config>(nonce: u64) -> Result<T::AssetId, DispatchError> {
+		let protocol_id = (Pallet::<T>::index() as u32).to_be_bytes();
 		T::LPTokenFactory::create_local_asset(
-			T::PalletId::get().0,
+			protocol_id,
 			nonce,
 			AssetInfo {
 				name: None,

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -192,7 +192,7 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
 	pub const NativeAssetId: AssetId = 1;
-	pub const NetworkId: [u8; 4] = [0,0,0,0];
+	pub const NetworkId: u32 = 0;
 }
 
 impl pallet_assets_registry::Config for Test {

--- a/code/parachain/frame/pablo/src/mock.rs
+++ b/code/parachain/frame/pablo/src/mock.rs
@@ -192,6 +192,7 @@ parameter_types! {
 	pub const MaxRewardConfigsPerPool: u32 = 10;
 	pub const TreasuryAccountId: AccountId = 123_456_789_u128;
 	pub const NativeAssetId: AssetId = 1;
+	pub const NetworkId: [u8; 4] = [0,0,0,0];
 }
 
 impl pallet_assets_registry::Config for Test {
@@ -203,6 +204,7 @@ impl pallet_assets_registry::Config for Test {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = NetworkId;
 }
 
 impl pallet_assets_transactor_router::Config for Test {

--- a/code/parachain/frame/staking-rewards/src/lib.rs
+++ b/code/parachain/frame/staking-rewards/src/lib.rs
@@ -1891,8 +1891,9 @@ pub(crate) fn claim_of_stake<T: Config>(
 impl<T: Config> Pallet<T> {
 	/// Registers a new asset within the namespace of this protocol
 	pub fn register_protocol_asset(nonce: u64) -> Result<T::AssetId, DispatchError> {
+		let protocol_id = (Pallet::<T>::index() as u32).to_be_bytes();
 		T::AssetsTransactor::create_local_asset(
-			T::PalletId::get().0,
+			protocol_id,
 			nonce,
 			AssetInfo {
 				name: None,

--- a/code/parachain/frame/staking-rewards/src/runtime.rs
+++ b/code/parachain/frame/staking-rewards/src/runtime.rs
@@ -186,6 +186,7 @@ impl<CurrencyId>
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
 	pub const NativeAssetId: CurrencyId = PICA::ID;
+	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
 }
 
 impl pallet_assets_registry::Config for Test {
@@ -197,6 +198,7 @@ impl pallet_assets_registry::Config for Test {
 	type WeightInfo = ();
 	type Balance = Balance;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 impl pallet_assets_transactor_router::Config for Test {

--- a/code/parachain/frame/staking-rewards/src/runtime.rs
+++ b/code/parachain/frame/staking-rewards/src/runtime.rs
@@ -186,7 +186,7 @@ impl<CurrencyId>
 parameter_types! {
 	pub const MaxStrategies: usize = 255;
 	pub const NativeAssetId: CurrencyId = PICA::ID;
-	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+	pub const PicassoNetworkId: u32 = 0;
 }
 
 impl pallet_assets_registry::Config for Test {

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -142,6 +142,7 @@ parameter_types! {
 		.build_or_panic();
 
 	pub const SS58Prefix: u8 = 50;
+	pub const ComposableNetworkId: [u8; 4] = [0, 0, 0, 1];
 }
 
 // Configure FRAME pallets to include in runtime.
@@ -208,6 +209,7 @@ impl assets_registry::Config for Runtime {
 	type ParachainOrGovernanceOrigin = EnsureRootOrHalfCouncil;
 	type WeightInfo = weights::assets_registry::WeightInfo<Runtime>;
 	type Convert = sp_runtime::traits::ConvertInto;
+	type NetworkId = ComposableNetworkId;
 }
 
 parameter_types! {

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -142,7 +142,7 @@ parameter_types! {
 		.build_or_panic();
 
 	pub const SS58Prefix: u8 = 50;
-	pub const ComposableNetworkId: [u8; 4] = [0, 0, 0, 1];
+	pub const ComposableNetworkId: u32 = 1;
 }
 
 // Configure FRAME pallets to include in runtime.

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -224,7 +224,7 @@ parameter_types! {
 	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
 	pub AssetIdUSDT: CurrencyId = CurrencyId::USDT;
 	pub FlatFeeUSDTAmount: Balance = 10_000_000; //10 USDT
-	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
+	pub const PicassoNetworkId: u32 = 0;
 }
 
 impl assets_registry::Config for Runtime {

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -224,6 +224,7 @@ parameter_types! {
 	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
 	pub AssetIdUSDT: CurrencyId = CurrencyId::USDT;
 	pub FlatFeeUSDTAmount: Balance = 10_000_000; //10 USDT
+	pub const PicassoNetworkId: [u8; 4] = [0, 0, 0, 0];
 }
 
 impl assets_registry::Config for Runtime {
@@ -235,6 +236,7 @@ impl assets_registry::Config for Runtime {
 	type ParachainOrGovernanceOrigin = EnsureRootOrTwoThirdNativeCouncil;
 	type WeightInfo = weights::assets_registry::WeightInfo<Runtime>;
 	type Convert = ConvertInto;
+	type NetworkId = PicassoNetworkId;
 }
 
 parameter_types! {


### PR DESCRIPTION
- Introduced `NetworkId: u32 into Assets registry Pallet
- changed protocol_id to [u8; 4] from [u8.8]. Now protocol id are expected to be Pallet::index() as u32. Pallet::index() is u64 but we need 4 bytes. which is ok considering pallets' indices are low.
- Asset id for pallets is now concatenated 4 bytes of NetworkId, 4 bytes of protocol_id, 8 bytes of nonce of a pallet
- added test to make sure bytes are concatenated correctly
- changed old tests
- updated LP tokens and old staking pallet tokens asset assignment to use NetworkId and Pallet::index()

- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] I have linked Zenhub/Github or any other reference item if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [ ] I have added at least one reviewer in reviewers list
- [ ] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production