### PR TITLE
xcvm: use hex to encode binary data in JSON messages

### DIFF
--- a/code/xcvm/Cargo.lock
+++ b/code/xcvm/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -458,7 +458,6 @@ dependencies = [
  "cw-xc-interpreter",
  "cw2",
  "cw20",
- "hex",
  "prost",
  "schemars",
  "serde",
@@ -479,7 +478,6 @@ dependencies = [
  "cw-xc-common",
  "cw2",
  "cw20",
- "hex",
  "num",
  "prost",
  "schemars",
@@ -501,7 +499,6 @@ dependencies = [
  "cw-xc-common",
  "cw2",
  "cw20",
- "hex",
  "num",
  "prost",
  "schemars",
@@ -2645,6 +2642,7 @@ dependencies = [
  "cosmwasm-std",
  "cw-storage-plus",
  "fixed",
+ "hex",
  "num",
  "parity-scale-codec",
  "prost",
@@ -2679,7 +2677,6 @@ dependencies = [
  "cw20",
  "cw20-base",
  "env_logger",
- "hex",
  "log",
  "proptest",
  "rand",

--- a/code/xcvm/Cargo.toml
+++ b/code/xcvm/Cargo.toml
@@ -18,7 +18,6 @@ panic = "abort"
 rpath = false
 
 [workspace.dependencies]
-
 cosmwasm-schema = { git = "https://github.com/dzmitry-lahoda-forks/cosmwasm", rev = "1277597cbf380a8d04dbe676d9cb344ca31634b6", default-features = false }
 serde-json-wasm = { git = "https://github.com/dzmitry-lahoda-forks/serde-json-wasm", rev = "8a7e522c0e4de36a6dfb535766f26a9941017d81", default-features = false }
 cosmwasm-std = { git = "https://github.com/dzmitry-lahoda-forks/cosmwasm", rev = "1277597cbf380a8d04dbe676d9cb344ca31634b6", default-features = false, features = [
@@ -36,6 +35,7 @@ cosmwasm-orchestrate = { git = "https://github.com/ComposableFi/cosmwasm-vm", re
 
 
 fixed = { version = "1.15", default-features = false }
+hex = { version = "0.4.3" }
 parity-scale-codec = { version = "3.5.0", default-features = false }
 num = { version = "0.4", default-features = false }
 prost = { version = "0.11.9", default-features = false, features = [
@@ -64,10 +64,6 @@ cw2 = { git = "https://github.com/dzmitry-lahoda-forks/cw-plus", rev = "458e2eb0
 thiserror = { version = "1.0.38", package = "thiserror-core", default-features = false }
 
 serde-cw-value = { version = "0.7.0", default-features = false }
-hex = { version = "0.4", default-features = false, features = [
-  "alloc",
-  "serde",
-] }
 
 
 [patch.crates-io]

--- a/code/xcvm/cosmwasm/contracts/gateway/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/gateway/Cargo.toml
@@ -20,7 +20,6 @@ cw-xc-common = { path = "../common" }
 cw-xc-interpreter = { path = "../interpreter", features = ["library"] }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-hex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, default-features = false, features = ["derive"] }
 serde-json-wasm = { workspace = true }

--- a/code/xcvm/cosmwasm/contracts/gateway/src/exec.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/exec.rs
@@ -120,12 +120,7 @@ pub(crate) fn handle_execute_program_privilleged(
 				interpreter_origin: interpreter_origin.clone(),
 			})?,
 			funds: vec![],
-			label: format!(
-				"xcvm-interpreter-{}-{}-{}",
-				u32::from(interpreter_origin.user_origin.network_id),
-				hex::encode::<Vec<u8>>(interpreter_origin.user_origin.user_id.into()),
-				hex::encode(&interpreter_origin.salt)
-			),
+			label: format!("xcvm-interpreter-{interpreter_origin}"),
 		}
 		.into();
 

--- a/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/interpreter/Cargo.toml
@@ -19,10 +19,6 @@ cw-utils = { workspace = true }
 cw-xc-common = { path = "../common" }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-hex = { workspace = true, default-features = false, features = [
-  "alloc",
-  "serde",
-] }
 num = { workspace = true }
 prost = { workspace = true, default-features = false, features = [
   "prost-derive",

--- a/code/xcvm/cosmwasm/contracts/pingpong/Cargo.toml
+++ b/code/xcvm/cosmwasm/contracts/pingpong/Cargo.toml
@@ -20,10 +20,6 @@ cw-utils = { workspace = true }
 cw-xc-common = { path = "../common" }
 cw2 = { workspace = true }
 cw20 = { workspace = true }
-hex = { workspace = true, default-features = false, features = [
-  "alloc",
-  "serde",
-] }
 num = { workspace = true }
 prost = { workspace = true, default-features = false, features = [
   "prost-derive",

--- a/code/xcvm/cosmwasm/tests/Cargo.toml
+++ b/code/xcvm/cosmwasm/tests/Cargo.toml
@@ -33,7 +33,6 @@ env_logger = { version = "0.10" }
 tokio = { version = "1.22", features = ["rt", "macros"] }
 cw20 = { workspace = true }
 cw20-base = { workspace = true, features = ["library"] }
-hex = { version = "0.4" }
 serde_json = { workspace = true }
 serde = { workspace = true }
 rand = { version = "0.8" }

--- a/code/xcvm/lib/core/Cargo.toml
+++ b/code/xcvm/lib/core/Cargo.toml
@@ -10,6 +10,7 @@ cosmwasm-std = { workspace = true }
 cw-storage-plus = { workspace = true, optional = true }
 
 fixed = { workspace = true, default-features = false }
+hex = { workspace = true, features = ["serde"] }
 parity-scale-codec = { workspace = true, default-features = false }
 num = { workspace = true, default-features = false }
 prost = { workspace = true, default-features = false, features = [

--- a/code/xcvm/lib/core/src/packet.rs
+++ b/code/xcvm/lib/core/src/packet.rs
@@ -48,10 +48,14 @@ impl TryFrom<&[u8]> for XCVMAck {
 #[serde(rename_all = "snake_case")]
 pub struct Packet<Program> {
 	/// The interpreter that was the origin of this packet.
+	#[serde(with = "hex")]
+	#[schemars(with = "String")]
 	pub interpreter: Vec<u8>,
 	/// The user that originated the first XCVM call.
 	pub user_origin: UserOrigin,
 	/// The salt associated with the program.
+	#[serde(with = "hex")]
+	#[schemars(with = "String")]
 	pub salt: Vec<u8>,
 	/// The protobuf encoded program.
 	pub program: Program,


### PR DESCRIPTION
hex is more compact JSON representation than an array of bytes.
Prefer it for UserId and program origin salt.

We’re not using cosmwasm_std::HexBinary because it doesn’t play nice
with scale.  It’s most strightforward to just use serde(with) option.

- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
