### PR TITLE
pallet-cosmwasm: verify gas checkpoint operations

### DIFF
--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -190,6 +190,7 @@ pub mod pallet {
 		Ibc,
 		FailedToSerialize,
 		OutOfGas,
+		InvalidGasCheckpoint,
 		InvalidSalt,
 		InvalidAccount,
 		Interpreter,
@@ -752,6 +753,7 @@ impl<T: Config> Pallet<T> {
 				log::info!(target: "runtime::contracts", "executing contract error with {}", &error);
 				let error = match error {
 					CosmwasmVMError::Pallet(e) => e,
+					CosmwasmVMError::InvalidGasCheckpoint => Error::<T>::OutOfGas,
 					CosmwasmVMError::OutOfGas => Error::<T>::OutOfGas,
 					CosmwasmVMError::Interpreter(_) => Error::<T>::Interpreter,
 					CosmwasmVMError::VirtualMachine(_) => Error::<T>::VirtualMachine,


### PR DESCRIPTION
Rather than panicking when too many checkpoints are being popped,
return an error which is converted into a VM error.  Similarly,
enforce the max_frame parameter and return an error if too many
checkpoints are being added.



- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
