### PR TITLE
pallet-cosmwasm: reduce MaxFrames parameter to u16

### DIFF
--- a/code/parachain/frame/cosmwasm/src/lib.rs
+++ b/code/parachain/frame/cosmwasm/src/lib.rs
@@ -230,7 +230,7 @@ pub mod pallet {
 
 		/// Max number of frames a contract is able to push, a.k.a recursive calls.
 		#[pallet::constant]
-		type MaxFrames: Get<u32>;
+		type MaxFrames: Get<u16>;
 
 		/// Max accepted code size in bytes.
 		#[pallet::constant]

--- a/code/parachain/frame/cosmwasm/src/mock.rs
+++ b/code/parachain/frame/cosmwasm/src/mock.rs
@@ -238,7 +238,7 @@ parameter_types! {
 	pub const CosmwasmPalletId: PalletId = PalletId(*b"cosmwasm");
 	pub IbcRelayerAccount: AccountId = PalletId(*b"centauri").into_account_truncating();
 	pub const ChainId: &'static str = "composable-network-dali";
-	pub const MaxFrames: u32 = 64;
+	pub const MaxFrames: u16 = 64;
 	pub const MaxCodeSize: u32 = 512 * 1024;
 	pub const MaxInstrumentedCodeSize: u32 = 1024 * 1024;
 	pub const MaxMessageSize: u32 = 256 * 1024;

--- a/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/abstraction.rs
@@ -96,9 +96,8 @@ pub enum GasOutcome {
 }
 
 impl Gas {
-	pub fn new(max_frames: u32, initial_value: u64) -> Self {
-		let max_frames = usize::try_from(max_frames).unwrap();
-		let mut checkpoints = Vec::with_capacity(max_frames);
+	pub fn new(max_frames: u16, initial_value: u64) -> Self {
+		let mut checkpoints = Vec::with_capacity(max_frames.into());
 		checkpoints.push(initial_value);
 		Gas { checkpoints }
 	}

--- a/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
+++ b/code/parachain/frame/cosmwasm/src/runtimes/vm.rs
@@ -172,7 +172,7 @@ pub struct CosmwasmVMShared {
 	/// A value > 0 mean that the storage is readonly.
 	pub storage_readonly_depth: u32,
 	/// VM depth, i.e. how many contracts has been loaded and are currently running.
-	pub depth: u32,
+	pub depth: u16,
 	/// Shared Gas metering.
 	pub gas: Gas,
 	/// Shared cache.

--- a/code/parachain/runtime/picasso/src/contracts.rs
+++ b/code/parachain/runtime/picasso/src/contracts.rs
@@ -39,7 +39,7 @@ impl cosmwasm::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type AccountIdExtended = AccountId;
 	type PalletId = CosmwasmPalletId;
-	type MaxFrames = ConstU32<64>;
+	type MaxFrames = ConstU16<64>;
 	type MaxCodeSize = ConstU32<{ 512 * 1024 }>;
 	type MaxInstrumentedCodeSize = MaxInstrumentedCodeSize;
 


### PR DESCRIPTION
65k recursive contract calls should be enough for anything so there’s no real need to use MaxFrames parameter of larger type than u16.  With that, we can replace a somewhat noisy usize::try_from call with a more straightforward usize::from.



- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] I have linked Zenhub/Github or any other reference item if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] I waited and did best effort for `pr-workflow-check / draft-release-check` to finish with success(green check mark) with my changes
- [x] I have added at least one reviewer in reviewers list
- [x] I tagged(@) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production