### PR TITLE
multihop review

### DIFF
--- a/code/parachain/frame/composable-traits/src/xcm/assets.rs
+++ b/code/parachain/frame/composable-traits/src/xcm/assets.rs
@@ -92,6 +92,7 @@ pub struct ForeignMetadata<AssetNativeLocation> {
 
 pub trait MultiCurrencyCallback {
 	type AssetId;
+	// please document this
 	fn deposit_asset(
 		asset: &xcm::latest::MultiAsset,
 		location: &xcm::latest::MultiLocation,

--- a/code/parachain/frame/composable-traits/src/xcm/memo.rs
+++ b/code/parachain/frame/composable-traits/src/xcm/memo.rs
@@ -15,13 +15,20 @@ use crate::prelude::*;
 	Debug,
 )]
 pub struct ChainInfo {
-	pub chain_id: u128,
-	pub order: u8,
+	pub chain_id: u128, // please use u32 for chain id, i asked in one of review before
+	pub order: u8, // please document what order means
 	pub channel_id: u64,        //for packet or memo
+	// what is timestamp? what does it means? why chain has timestamp?
 	pub timestamp: Option<u64>, //for packet
+	// instead of code comment, please use stucture to unite peoperites
+	
+	// please use ibc_rs_scale for Timeout Height/Timeout
 	pub height: Option<u64>,    //for memo packet message forwarding
+	// use u8
 	pub retries: Option<u64>,   //for memo packet message forwarding
+	// what is it seconds? please leave comment
 	pub timeout: Option<u64>,   //for memo packet message forwarding
+	// please use Option(Substrate(IBC || XCM),not 2 bools
 	pub is_substrate_ibc: bool,
 	pub is_substrate_xcm: bool,
 	pub para_id: Option<u32>,

--- a/code/parachain/frame/pallet-multihop-xcm-ibc/README.md
+++ b/code/parachain/frame/pallet-multihop-xcm-ibc/README.md
@@ -1,3 +1,5 @@
+PLEASE REMOVE THIS README
+
 # Overview
 
 Allows to map remote assets to local and back(bidirectional). Mapping can be created only by privileged origin.

--- a/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
+++ b/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
@@ -348,6 +348,7 @@ pub mod pallet {
 
 		// i guess moving match to separate method could make this one better
 		// so generally error handling is really bad, may be read something about
+		// i guess better rename this method deposit_asset as it is also much more thing
 		fn deposit_asset(
 			asset: &xcm::latest::MultiAsset,
 			location: &xcm::latest::MultiLocation,
@@ -596,6 +597,7 @@ pub mod pallet {
 					route_id,
 					reason: 8,
 				});
+				// for each case of error and return none use errors and exit via ? form 
 				return None;
 				// return Err(Error::<T>::DoesNotSupportNonFungible);
 			};

--- a/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
+++ b/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
@@ -447,6 +447,7 @@ pub mod pallet {
 				},
 				_ => {
 					//emit event
+					// log error, return error, not event
 					<Pallet<T>>::deposit_event(crate::Event::<T>::FailedMatchLocation {});
 					return None
 				},

--- a/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
+++ b/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
@@ -204,6 +204,7 @@ pub mod pallet {
 		u128: Into<<T as orml_xtokens::Config>::CurrencyId>,
 	{
 		type AccountId = T::AccountId;
+		// is it used anywhere?
 		fn transfer_xcm(
 			from: T::AccountId,
 			to: T::AccountId,

--- a/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
+++ b/code/parachain/frame/pallet-multihop-xcm-ibc/src/lib.rs
@@ -346,6 +346,8 @@ pub mod pallet {
 	{
 		type AssetId = T::AssetId;
 
+		// i guess moving match to separate method could make this one better
+		// so generally error handling is really bad, may be read something about
 		fn deposit_asset(
 			asset: &xcm::latest::MultiAsset,
 			location: &xcm::latest::MultiLocation,
@@ -455,17 +457,19 @@ pub mod pallet {
 
 			let (pallet_id, address_from, route_id, mut addresses) = location_info;
 
+			/// what if PalletInstanceId is const, just asking, can you match on it?
 			if *pallet_id != T::PalletInstanceId::get() {
 				<Pallet<T>>::deposit_event(crate::Event::<T>::FailedCallback {
 					origin_address: address_from,
 					route_id,
-					reason: 1,
+					reason: 1, // what is reason? 
 				});
 				return None
 			}
 
+			// remove
 			// return None;
-
+				
 			//deposit does not executed propertly. nothing todo. assets will stay in the account id
 			// deposit_result.map_err(|_| Error::<T>::XcmDepositFailed)?;
 			deposit_result.ok()?;
@@ -498,7 +502,7 @@ pub mod pallet {
 				});
 				return None;
 			};
-
+			// tbh, sill believe could store betch prefixes instead of addresses, one addesses, many betch prefixes :) 
 			if addresses.len() != route_len {
 				//wrong XCM MultiLocation. route len does not match addresses list in XCM call.
 				// return Err(Error::<T>::IncorrectCountOfAddresses)

--- a/code/parachain/runtime/composable/src/ibc.rs
+++ b/code/parachain/runtime/composable/src/ibc.rs
@@ -223,6 +223,7 @@ impl pallet_ibc::Config for Runtime {
 	type Ics20RateLimiter = ConstantAny;
 	type IsReceiveEnabled = ConstBool<true>;
 	type IsSendEnabled = ConstBool<true>;
+	// why commented?
 	// type SubstrateMultihopXcmHandler = SubstrateMultihopXcmHandlerNone<Runtime>;
 	type SubstrateMultihopXcmHandler = pallet_multihop_xcm_ibc::Pallet<Runtime>;
 	type FeeAccount = FeeAccount;

--- a/code/parachain/runtime/composable/src/xcmp.rs
+++ b/code/parachain/runtime/composable/src/xcmp.rs
@@ -290,7 +290,7 @@ impl<
 			},
 			// unknown asset
 			_ => {
-				// log error
+				// log error (no sure if is old or new code)
 				//TODO? should we try in case if asset is unknown?
 			},
 		}

--- a/code/parachain/runtime/composable/src/xcmp.rs
+++ b/code/parachain/runtime/composable/src/xcmp.rs
@@ -290,6 +290,7 @@ impl<
 			},
 			// unknown asset
 			_ => {
+				// log error
 				//TODO? should we try in case if asset is unknown?
 			},
 		}


### PR DESCRIPTION
- please replace unwraps and ValueQuery possible panics with let/expect and relevant OptionQuery, please ensure that CI checks these lints
- remove garbage comments/text
- please update RFC and/or use type aliases and/or document all extrinsic and/or traits and/or write README for pallets/configs,  peek at least 2 of these so we 100% clear and aligned on implementation
- STORAGE IMPORTANT : Set ChainId to be u32 in storage please
- OPTIONAL many error and default values handling lead to hard to handle production bugs, use logs instead of events, use fold instead of mutable loop (easier to read)
- @kollegian would be awesome (if not yet) you can have time testing our existing XCM flows on DevNet or Rococo (before multihop)
- @RustNinja id do not see https://github.com/open-web3-stack/open-runtime-module-library/blob/master/xcm-support/src/currency_adapter.rs#L105 handling and error handling for usual deposits . did we removed that? i guess if that is correct is is super importatn 🛑

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

