### PR TITLE
xcvm: change XCVMAck into an enum; and swap values

### DIFF
--- a/code/xcvm/cosmwasm/contracts/gateway/src/contract/mod.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/contract/mod.rs
@@ -70,8 +70,8 @@ pub fn reply(deps: DepsMut, _env: Env, msg: Reply) -> Result<Response> {
 fn handle_exec_reply(msg: Reply) -> Result {
 	let (data, event) = match msg.result {
 		SubMsgResult::Ok(_) =>
-			(XCVMAck::OK, make_event("receive").add_attribute("result", "success")),
-		SubMsgResult::Err(err) => (XCVMAck::KO, make_ibc_failure_event(err.to_string())),
+			(XCVMAck::Ok, make_event("receive").add_attribute("result", "success")),
+		SubMsgResult::Err(err) => (XCVMAck::Fail, make_ibc_failure_event(err.to_string())),
 	};
 	Ok(Response::default().add_event(event).set_data(data))
 }

--- a/code/xcvm/cosmwasm/tests/src/tests/suite.rs
+++ b/code/xcvm/cosmwasm/tests/src/tests/suite.rs
@@ -769,7 +769,7 @@ mod cross_chain {
 
 		// The relayer must obtain a successful ack on the destination, and nothing on the source
 		// after relaying the ack itself.
-		assert_eq!(relay_data, vec![Some(XCVMAck::OK.into()), None]);
+		assert_eq!(relay_data, vec![Some(XCVMAck::Ok.into()), None]);
 
 		// We don't dispatch any information in the data field.
 		assert_eq!(dispatch_data, None);


### PR DESCRIPTION
XCVMAck can hold limited set of values (success or failure) so rather
than writing it as a newtype around u8 change it into an enum.  This
simplifies any code that needs to match on an XCVMAck value since it
doesn’t need to check values greater than 1.

Furthermore, rename the variants to Ok and Fail to better fit Rust
naming and be more distinguishable; and swap the value so that Ok is
zero and Fail is one.


Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
