### PR TITLE
ci(chore): made ci prs smaller, optimized away some wip runs, stale items cleans

### DIFF
--- a/.github/workflows/maintainance.yaml
+++ b/.github/workflows/maintainance.yaml
@@ -40,7 +40,7 @@ jobs:
         uses: crs-k/stale-branches@v3.0.0
         with:
           days-before-stale: 16
-          days-before-delete: 32
+          days-before-delete: 17
           comment-updates: false
           max-issues: 30
           tag-committer: false

--- a/.github/workflows/maintainance.yaml
+++ b/.github/workflows/maintainance.yaml
@@ -21,7 +21,7 @@ jobs:
           stale-pr-message: 'stale-pr'
           close-issue-message: 'close-issue'
           close-pr-message: 'close-pr'
-          days-before-issue-stale: 16
+          days-before-issue-stale: 32 # if no progress for month, not sure we really doing it
           days-before-pr-stale: 4
           days-before-issue-close: 4
           days-before-pr-close: 4          
@@ -40,7 +40,7 @@ jobs:
         uses: crs-k/stale-branches@v3.0.0
         with:
           days-before-stale: 16
-          days-before-delete: 17
+          days-before-delete: 16 # avoid issue to hang in list too long
           comment-updates: false
           max-issues: 30
           tag-committer: false

--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pr-workflow-check:
-    if: ${{ ( (github.event_name == 'pull_request') && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title && !contains(github.event.pull_request.labels.*.name, 'wip') ) || (github.event_name != 'pull_request') }}
+    if: ${{ ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title) && !contains(github.event.pull_request.labels.*.name, 'wip') ) }} 
     
     uses: ./.github/workflows/pr-workflow.yml
     with:

--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   pr-workflow-check:
+    if: ${{ ( github.event_name == 'pull_request' && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title && !contains(github.event.pull_request.labels.*.name, 'wip') ) || github.event_name != 'pull_request' }}
+    
     uses: ./.github/workflows/pr-workflow.yml
     with:
       github_event_name: ${{ github.event_name }}

--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pr-workflow-check:
-    if: ${{ ( github.event_name == 'pull_request' && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title && !contains(github.event.pull_request.labels.*.name, 'wip') ) || github.event_name != 'pull_request' }}
+    if: ${{ ( (github.event_name == 'pull_request') && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title && !contains(github.event.pull_request.labels.*.name, 'wip') ) || (github.event_name != 'pull_request') }}
     
     uses: ./.github/workflows/pr-workflow.yml
     with:

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -52,10 +52,18 @@ jobs:
     runs-on:
       - ubuntu-latest
     steps:
-      - name: 'Checkout Repository'
+      - name: checkout
         uses: actions/checkout@v3
         if: ${{ inputs.github_event_name != 'merge_group' && inputs.github_event_name != 'push' }}
-      - name: 'Dependency Review'
+      - uses: amannn/action-semantic-pull-request@v5
+        if: ${{ inputs.github_event_name != 'merge_group' && inputs.github_event_name != 'push' }}
+        with:
+          requireScope: false
+          subjectPattern: (.*[a-zA-Z].*){16,}
+          subjectPatternError: |
+            https://regexper.com/#%28.*%5Ba-zA-Z%5D.*%29%7B16%2C%7D
+
+      - name: dependency-review
         if: ${{ inputs.github_event_name != 'merge_group' && inputs.github_event_name != 'push' }}
         uses: actions/dependency-review-action@v3
         with:

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -62,6 +62,8 @@ jobs:
           subjectPattern: (.*[a-zA-Z].*){16,}
           subjectPatternError: |
             https://regexper.com/#%28.*%5Ba-zA-Z%5D.*%29%7B16%2C%7D
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}            
 
       - name: dependency-review
         if: ${{ inputs.github_event_name != 'merge_group' && inputs.github_event_name != 'push' }}

--- a/terraform/github.com/labels.tf
+++ b/terraform/github.com/labels.tf
@@ -2,6 +2,7 @@
 locals {
   labels = {
     "misc"             = "I marked PR by `misc` label if it should not be in release notes"
+    "wip"              = "Work in Progress, #WIP"
     "dependencies"     = "bot"
     "lfs-detected!"    = "bot: Warning Label for use when LFS is detected in the commits of a Pull Request"
     "needs-benchmarks" = "bot: Runs benchmarks on target hardware"


### PR DESCRIPTION
Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

