### PR TITLE
fix(devnet): xc docker image user fix to run devent in docker and codespace

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -273,6 +273,10 @@ jobs:
         uses: "./.github/templates/watch-exec"
         with:
           command: nix -- build .#all-ci-packages --keep-going
+      - name: build-home-configuration
+        uses: "./.github/templates/watch-exec"
+        with:
+          command: nix -- build --no-link ".#homeConfigurations.vscode.activationPackage"
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT" 
 

--- a/.github/workflows/pull-request-comments.yml
+++ b/.github/workflows/pull-request-comments.yml
@@ -40,6 +40,9 @@ jobs:
             ```shell
             # run cross chain devnet with Dotsama and Cosmos nodes 
             nix run "github:ComposableFi/composable/${{ github.ref }}#devnet-xc-fresh" --allow-import-from-derivation --extra-experimental-features "flakes nix-command" --no-sandbox --accept-flake-config --option sandbox relaxed 
+            # or same with docker
+            nix build "github:ComposableFi/composable/${{ github.ref }}#devnet-xc-image" --allow-import-from-derivation --extra-experimental-features "flakes nix-command" --no-sandbox --accept-flake-config --option sandbox relaxed \
+            && docker load --input result && docker run -it --entrypoint bash devnet-xc:latest -c /bin/devnet-xc-fresh 
             ```
             
             [About nix](https://docs.composable.finance/nix.html)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM mcr.microsoft.com/vscode/devcontainers/base:0.202.7-bullseye
+
+ARG NIX_VERSION=2.17.0
+ARG CHANNEL_URL=https://github.com/NixOS/nixpkgs/archive/1db42b7fe3878f3f5f7a4f2dc210772fd080e205.tar.gz
+
 ARG USER=vscode
 ARG UID=1000
 ARG GID=${UID}
-ARG NIX_VERSION=2.14.1
 ARG NIX_INSTALLER=https://releases.nixos.org/nix/nix-${NIX_VERSION}/install
-ARG CHANNEL_URL=https://github.com/NixOS/nixpkgs/archive/aaa1c973c8c189195e1b1a702d3b74dbcde91538.tar.gz
 ARG CACHIX_NAME=composable-community
 
 SHELL [ "/bin/bash", "-o", "pipefail", "-o", "errexit", "-c" ]
@@ -24,9 +26,11 @@ RUN usermod --append --groups sudo ${USER} --shell /bin/bash && \
 
 RUN mkdir --parents /etc/nix/ && \
     echo "sandbox = relaxed" >> /etc/nix/nix.conf && \
-    echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && \
+    echo "experimental-features = nix-command flakes" >> /etc/nix/nix.conf && \    
+    echo "cores = 32" >> /etc/nix/nix.conf && \
+    echo "allow-import-from-derivation = true" >> /etc/nix/nix.conf && \
     echo "narinfo-cache-negative-ttl = 30" >> /etc/nix/nix.conf  && \
-    echo "trusted-users = root vscode" >> /etc/nix/nix.conf  && \
+    echo "trusted-users = root vscode actiions-runner" >> /etc/nix/nix.conf  && \
     echo "substitute = true" >> /etc/nix/nix.conf  && \
     echo "substituters = https://cache.nixos.org/ https://composable-community.cachix.org/ https://devenv.cachix.org/ https://nix-community.cachix.org/" >> /etc/nix/nix.conf  && \
     echo "require-sigs = false" >> /etc/nix/nix.conf  && \

--- a/flake/ci.md
+++ b/flake/ci.md
@@ -29,7 +29,6 @@ cat > /etc/nix/nix.conf << EOF
     max-jobs = 1
     cores = 64
     auto-optimise-store = true
-    # max-substitution-jobs = 32
     allow-import-from-derivation = true
     gc-reserved-space = 18388608
     http-connections = 32

--- a/flake/devnet.nix
+++ b/flake/devnet.nix
@@ -18,8 +18,16 @@
 
         devnet-xc-image = devnetTools.buildDevnetImage {
           name = "devnet-xc";
-          container-tools = devnetTools.withDevNetContainerTools
-            ++ [ pkgs.bash self'.packages.devnet-xc-fresh ];
+          container-tools = devnetTools.withDevNetContainerTools ++ [
+            # just put into path so that can be used for CLI ops and simplified runs
+            pkgs.bash
+            self'.packages.ccw
+            self'.packages.centaurid
+            self'.packages.devnet-xc-cosmos-fresh
+            self'.packages.devnet-xc-fresh
+            self'.packages.osmosisd
+            self'.packages.zombienet-rococo-local-picasso-dev
+          ];
           devNet = self'.packages.devnet-xc-background;
         };
       };

--- a/flake/devnet.nix
+++ b/flake/devnet.nix
@@ -18,7 +18,8 @@
 
         devnet-xc-image = devnetTools.buildDevnetImage {
           name = "devnet-xc";
-          container-tools = devnetTools.withDevNetContainerTools;
+          container-tools = devnetTools.withDevNetContainerTools
+            ++ [ pkgs.bash ];
           devNet = self'.packages.devnet-xc-background;
         };
       };

--- a/flake/devnet.nix
+++ b/flake/devnet.nix
@@ -19,7 +19,7 @@
         devnet-xc-image = devnetTools.buildDevnetImage {
           name = "devnet-xc";
           container-tools = devnetTools.withDevNetContainerTools
-            ++ [ pkgs.bash ];
+            ++ [ pkgs.bash self'.packages.devnet-xc-fresh ];
           devNet = self'.packages.devnet-xc-background;
         };
       };

--- a/flake/home-configurations.nix
+++ b/flake/home-configurations.nix
@@ -3,7 +3,7 @@
   flake = {
     homeConfigurations = let user = "vscode";
     in (withSystem "x86_64-linux"
-      ({ config, self', inputs', pkgs, devnetTools, this, subnix, ... }: {
+      ({ config, self', inputs', pkgs, devnetTools, subnix, ... }: {
         default = "${user}";
         "${user}" = let codespace = with pkgs; [ cachix acl direnv ];
         in self.inputs.home-manager.lib.homeManagerConfiguration {
@@ -13,11 +13,21 @@
               username = user;
               sessionVariables = subnix.subattrs;
               homeDirectory = "/home/${user}";
-              stateVersion = "22.11";
+              stateVersion = "23.05";
               packages = with pkgs;
                 with self'.packages;
-                [ clang nodejs python3 yarn sad git git-lfs subwasm zombienet ]
-                ++ (with self'.packages; [ rust-nightly ]) ++ codespace;
+                [
+                  clang
+                  dasel
+                  git
+                  git-lfs
+                  nodejs
+                  python3
+                  sad
+                  subwasm
+                  yarn
+                  zombienet
+                ] ++ (with self'.packages; [ rust-nightly ]) ++ codespace;
             };
             programs = {
               home-manager.enable = true;

--- a/tools/devnet-tools.nix
+++ b/tools/devnet-tools.nix
@@ -39,10 +39,20 @@
           config = {
             Entrypoint =
               [ "${pkgs.lib.getBin devNet}/bin/${pkgs.lib.getName devNet}" ];
+            Env = [ "USER=actions-runner" ];
           };
 
           runAsRoot = ''
-            mkdir --parents /usr/bin /tmp/composable-devnet && chown 777 /tmp
+            #!${pkgs.runtimeShell}
+            ${pkgs.dockerTools.shadowSetup}
+            # so we add 2 potential runners, CI and Codespace just for convenience
+            mkdir --parents /usr/bin /home/actions-runner /tmp/composable-devnet /home/vscode
+            chown 777 /tmp 
+            chown 777 /tmp/composable-devnet
+            chown 777 /home/actions-runner
+            chown 777 /home/vscode
+            groupadd --system actions-runner
+            useradd --system --gid actions-runner --groups root actions-runner
           '';
         };
     };


### PR DESCRIPTION
![image](https://github.com/ComposableFi/composable/assets/757125/1f288499-3285-438b-9499-68847851b52e)


Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists https://github.com/F1bonacc1/process-compose/issues/84
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

