### PR TITLE
ci(perf): fail fast in case of failed builds

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -173,7 +173,7 @@ jobs:
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' }}
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-production-deps --keep-going
+          command: nix -- build .#all-production-deps
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"
 
@@ -208,7 +208,7 @@ jobs:
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' }}
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#devnet-xc-image --keep-going
+          command: nix -- build .#devnet-xc-image
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"        
 
@@ -239,7 +239,7 @@ jobs:
       - name: Build all packages 
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#xcvm-tests --keep-going
+          command: nix -- build .#xcvm-tests
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"  
 
@@ -272,7 +272,7 @@ jobs:
       - name: Build all packages 
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-ci-packages --keep-going
+          command: nix -- build .#all-ci-packages
       - name: build-home-configuration
         uses: "./.github/templates/watch-exec"
         with:
@@ -311,7 +311,7 @@ jobs:
         if: ${{ inputs.flow != 'push' }}
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-benchmarks --keep-going
+          command: nix -- build .#all-benchmarks
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"
 
@@ -346,7 +346,7 @@ jobs:
         if: ${{ inputs.flow == 'pr_from_branch' || inputs.flow == 'pr_from_fork'}}
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-misc --keep-going       
+          command: nix -- build .#all-misc       
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"   
 
@@ -381,7 +381,7 @@ jobs:
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' || inputs.flow == 'pr_from_fork' }}
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-deps --keep-going   
+          command: nix -- build .#all-deps   
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"              
 
@@ -425,7 +425,7 @@ jobs:
       - name: build-all-docs-packages 
         uses: "./.github/templates/watch-exec"
         with:
-          command: nix -- build .#all-docs --keep-going
+          command: nix -- build .#all-docs
       - id: ok
         run: echo "ok=true" >> "$GITHUB_OUTPUT"               
 


### PR DESCRIPTION
so it does not caches what will change on next pr nor makes us wait for CI fail results

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

