### PR TITLE
ci(perf): add sscache to release jobs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,0 @@
-changelog:
-  exclude:
-    labels:
-      - misc
-  categories:
-    - title: General changes
-      labels:
-        - "*"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -51,6 +51,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Configure sccache env var
+        run: | 
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+	        echo “SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.2
+
       - name: Login to DockerHub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Assessing if including sccache is a good option for
speeding up CI


Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

