### PR TITLE
chore: reduce build-all-misc-packages noise

### DIFF
--- a/tools/rust.nix
+++ b/tools/rust.nix
@@ -8,7 +8,7 @@
         crane.nightly.cargoBuild (systemCommonRust.common-attrs // {
           cargoArtifacts = self'.packages.common-deps-nightly;
           buildPhase = ''
-            cargo check --no-default-features --target wasm32-unknown-unknown --package ${pname} 
+            cargo check --no-default-features --quiet --target wasm32-unknown-unknown --package ${pname}
             cargo clippy --package ${pname} -- --deny warnings --allow deprecated
           '';
           installPhase = "mkdir --parents $out";


### PR DESCRIPTION
There are *a lot* of duplicate crate dependencies in the repository.
Even though cargo-check isn’t configured to deny them, when run it
outputs all the duplicates that it finds.  This leads to a long log
which makes it more harder to find the actual issue why the CI check
failed.

Add --quiet flag so that only error messages and final check results
are output instead.

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

o
