### PR TITLE
ci(perf): replace release job with fast cheap box

### DIFF
--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -406,7 +406,7 @@ jobs:
             sandbox = relaxed
             narinfo-cache-negative-ttl = 0      
             system-features = kvm
-      - uses: DeterminateSystems/magic-nix-cache-action@main             
+      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Set up Cachix
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309
         with:

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -190,6 +190,8 @@ jobs:
       group: ${{ inputs.github_workflow }}-build-devnet-xc-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
+      - name: setup-magic-nix-cache
+        uses: DeterminateSystems/magic-nix-cache-action@v2    
       - name: Set up Cachix
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' }}
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -408,7 +408,6 @@ jobs:
             sandbox = relaxed
             narinfo-cache-negative-ttl = 0      
             system-features = kvm
-      - uses: DeterminateSystems/magic-nix-cache-action@main          
       - name: Set up Cachix
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309
         with:

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -406,6 +406,7 @@ jobs:
             sandbox = relaxed
             narinfo-cache-negative-ttl = 0      
             system-features = kvm
+      - uses: DeterminateSystems/magic-nix-cache-action@main             
       - name: Set up Cachix
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309
         with:

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -190,8 +190,6 @@ jobs:
       group: ${{ inputs.github_workflow }}-build-devnet-xc-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-      - name: setup-magic-nix-cache
-        uses: DeterminateSystems/magic-nix-cache-action@main    
       - name: Set up Cachix
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' }}
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309

--- a/.github/workflows/pr-workflow.yml
+++ b/.github/workflows/pr-workflow.yml
@@ -191,7 +191,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: setup-magic-nix-cache
-        uses: DeterminateSystems/magic-nix-cache-action@v2    
+        uses: DeterminateSystems/magic-nix-cache-action@main    
       - name: Set up Cachix
         if: ${{ inputs.flow == 'push' || inputs.flow == 'pr_from_branch' }}
         uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -5,13 +5,6 @@ on:
       - 'release-v[0-9]+\.[0-9]+\.[0-9]+'
 
 env:
-  NIX_VERSION: nix-2.13.2
-  NIXPKGS_CHANNEL: nixos-22.11
-  CACHIX_COMPOSABLE: composable-community
-  CACHIX_COMPRESSION_LEVEL: 16
-  CACHIX_JOBS: 8
-  CACHIX_COMPRESSION_METHOD: zstd
-  CACHIX_NAME: composable-community
   DOCKER_REGISTRY_NAME: composablefi
   DOCKER_USER_OPTION: '$UID:$GID'
 
@@ -19,67 +12,40 @@ jobs:
   release-artifacts:
     name: "release-artifacts"
     runs-on:
-      - self-hosted
-      - x64-monster
+      - x86_64-linux-32C-128GB-2TB
     permissions: 
       pull-requests: write
       contents: write      
     concurrency:
       group: release-artifacts-${{ github.ref }}
       cancel-in-progress: true      
-    steps:
-      - name: Set up Nix
-        uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a # v18
-        with:
-          install_url: https://releases.nixos.org/nix/${{ env.NIX_VERSION }}/install
-          nix_path: nixpkgs=channel:${{ env.NIXPKGS_CHANNEL }}
-          extra_nix_config: |
-            sandbox = relaxed
-            narinfo-cache-negative-ttl = 0      
-            system-features = kvm          
-      - name: Set up Cachix
-        uses: cachix/cachix-action@298387a7aea14d6564aa5d6ead79272878339c8b # v12
+    steps: 
+      - uses: cachix/cachix-action@586bf280495080c5a6d4868237ad28a860e4b309
         with:
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          name: ${{ env.CACHIX_NAME }}
-      - name: Add tools needed for non-nix steps
-        run: |  
-          nix-channel --add https://nixos.org/channels/${{ env.NIXPKGS_CHANNEL }} nixpkgs
-          nix-channel --update
-          nix-env -iA nixpkgs.cachix nixpkgs.git nixpkgs.git-lfs nixpkgs.docker nixpkgs.coreutils    
+          name: composable-community
+          installCommand: "true"
+          skipAddingSubstituter: true  
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
+      - uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
-      - name: Build runtime
-        run: |
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#picasso-runtime
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#composable-runtime
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#picasso-testfast-runtime
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#composable-testfast-runtime
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#composable-node
-          cachix watch-exec --compression-level $CACHIX_COMPRESSION_LEVEL $CACHIX_COMPOSABLE nix -- build .#devnet-image
+      - run: |
           nix run .#generate-release-artifacts --print-build-logs
-          echo "COMPOSABLE_VERSION=$(nix eval --raw .#composable-node.version)" >> $GITHUB_ENV
-
-      - name: Release Docker image
-        run: |
+          COMPOSABLE_VERSION=$(nix eval --raw .#composable-node.version)"
           docker load --input release-artifacts/composable-image
-          docker tag composable:latest "${{ env.DOCKER_REGISTRY_NAME }}/composable:v${{ env.COMPOSABLE_VERSION }}"
+          docker tag composable:latest "${{ env.DOCKER_REGISTRY_NAME }}/composable:v$COMPOSABLE_VERSION"
           docker tag composable:latest "${{ env.DOCKER_REGISTRY_NAME }}/composable:latest-prerelease"
-          docker push "${{ env.DOCKER_REGISTRY_NAME }}/composable:v${{ env.COMPOSABLE_VERSION }}"
+          docker push "${{ env.DOCKER_REGISTRY_NAME }}/composable:v$COMPOSABLE_VERSION"
           docker push "${{ env.DOCKER_REGISTRY_NAME }}/composable:latest-prerelease"
 
           docker load --input release-artifacts/devnet-image
-          docker tag devnet:latest "${{ env.DOCKER_REGISTRY_NAME }}/devnet:v${{ env.COMPOSABLE_VERSION }}"
+          docker tag devnet:latest "${{ env.DOCKER_REGISTRY_NAME }}/devnet:v$COMPOSABLE_VERSION"
           docker tag devnet:latest "${{ env.DOCKER_REGISTRY_NAME }}/devnet:latest-prerelease"
-          docker push "${{ env.DOCKER_REGISTRY_NAME }}/devnet:v${{ env.COMPOSABLE_VERSION }}"
+          docker push "${{ env.DOCKER_REGISTRY_NAME }}/devnet:v$COMPOSABLE_VERSION"
           docker push "${{ env.DOCKER_REGISTRY_NAME }}/devnet:latest-prerelease"                    
 
       - name: Release artifacts

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -2,7 +2,7 @@ name: release-artifacts
 on:
   push:
     tags:
-      - 'test-release-v[0-9]+\.[0-9]+\.[0-9]+'
+      - 'release-v[0-9]+\.[0-9]+\.[0-9]+'
 
 env:
   DOCKER_REGISTRY_NAME: composablefi

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -56,7 +56,7 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           body_path: release-artifacts/release.txt
-          name: test-${{ github.ref_name }}
+          name: ${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           target_commitish: ${{ github.sha }}
           files: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -2,7 +2,7 @@ name: release-artifacts
 on:
   push:
     tags:
-      - 'release-v[0-9]+\.[0-9]+\.[0-9]+'
+      - 'test-release-v[0-9]+\.[0-9]+\.[0-9]+'
 
 env:
   DOCKER_REGISTRY_NAME: composablefi
@@ -56,7 +56,7 @@ jobs:
           fail_on_unmatched_files: true
           generate_release_notes: true
           body_path: release-artifacts/release.txt
-          name: ${{ github.ref_name }}
+          name: test-${{ github.ref_name }}
           tag_name: ${{ github.ref_name }}
           target_commitish: ${{ github.sha }}
           files: |

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       - run: |
           nix run .#generate-release-artifacts --print-build-logs
-          COMPOSABLE_VERSION=$(nix eval --raw .#composable-node.version)"
+          COMPOSABLE_VERSION=$(nix eval --raw .#composable-node.version)
           docker load --input release-artifacts/composable-image
           docker tag composable:latest "${{ env.DOCKER_REGISTRY_NAME }}/composable:v$COMPOSABLE_VERSION"
           docker tag composable:latest "${{ env.DOCKER_REGISTRY_NAME }}/composable:latest-prerelease"

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -12071,6 +12071,7 @@ dependencies = [
  "cosmwasm-std",
  "frame-support",
  "ibc 0.43.1",
+ "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",


### PR DESCRIPTION
https://github.com/ComposableFi/composable/actions/runs/5799514211/job/15719678033
https://github.com/ComposableFi/composable/releases/tag/test-release-v0.0.1

Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

