### PR TITLE
chore(ci): added key to manage contract deploys

### DIFF
--- a/terraform/github.com/config.tf
+++ b/terraform/github.com/config.tf
@@ -8,6 +8,11 @@ variable "RELEASE_GITHUB_TOKEN" {
   sensitive = true
 }
 
+variable "CI_COSMOS_MNEMONIC" {
+  type      = string
+  sensitive = true
+}
+
 
 data "github_repository" "self" {
   full_name = "ComposibleFi/composable"
@@ -42,4 +47,10 @@ resource "github_actions_secret" "RELEASE_GITHUB_TOKEN" {
   repository       = "composable"
   secret_name      = "RELEASE_GITHUB_TOKEN"
   plaintext_value  = var.RELEASE_GITHUB_TOKEN
+}
+
+resource "github_actions_secret" "CI_COSMOS_MNEMONIC" {
+  repository       = "composable"
+  secret_name      = "CI_COSMOS_MNEMONIC"  
+  plaintext_value  = var.CI_COSMOS_MNEMONIC
 }


### PR DESCRIPTION
So I will deploy to testnet via CI and nix script. 

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

