### PR TITLE
feat(pallet-assets-registry): simplify asset id generation

### DIFF
--- a/code/parachain/frame/assets-registry/src/lib.rs
+++ b/code/parachain/frame/assets-registry/src/lib.rs
@@ -565,16 +565,11 @@ pub mod pallet {
 		type AssetId = T::LocalAssetId;
 
 		fn generate_asset_id(protocol_id: [u8; 4], nonce: u64) -> Self::AssetId {
-			let bytes = T::NetworkId::get()
-				.to_be_bytes()
-				.into_iter()
-				.chain(protocol_id)
-				.chain(nonce.to_be_bytes())
-				.collect::<Vec<u8>>()
-				.try_into()
-				.expect("[u8; 8] + bytes(u64) = [u8; 16]");
-
-			Self::AssetId::from(u128::from_be_bytes(bytes))
+			let protocol_id = u32::from_be_bytes(protocol_id);
+			let network_id: u32 = T::NetworkId::get();
+			let high = (u64::from(protocol_id) << 32) | u64::from(protocol_id);
+			let asset_id = (u128::from(high) << 64) | u128::from(nonce);
+			Self::AssetId::from(asset_id)
 		}
 	}
 }


### PR DESCRIPTION
No need to allocate a Vec or deal with infallible unwraps.  Just use
plain bit manipulation to generate the asset id.

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
