### PR TITLE
chore: fix cargo warnings

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -17822,7 +17822,6 @@ version = "0.1.0"
 dependencies = [
  "composable-runtime",
  "derive_more 0.99.17",
- "frame-system",
  "pallet-transaction-payment 4.0.0-dev",
  "picasso-runtime",
  "sp-core",

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -151,12 +151,10 @@ frame-benchmarking-cli = { git = "https://github.com/ComposableFi/substrate", re
 frame-election-provider-support = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-executive = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-support = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
-support = { package = "frame-support", git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-support-procedural = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-support-procedural-tools = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-support-procedural-tools-derive = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-system = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
-system = { package = "frame-system", git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-system-benchmarking = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 frame-system-rpc-runtime-api = { git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }
 system-rpc-runtime-api = { package = "frame-system-rpc-runtime-api", git = "https://github.com/ComposableFi/substrate", rev = "c74d73bfe1e4f725b3f7d81c997ba9c940bf6005", default-features = false }

--- a/code/parachain/frame/call-filter/Cargo.toml
+++ b/code/parachain/frame/call-filter/Cargo.toml
@@ -16,8 +16,8 @@ sp-io = { default-features = false, workspace = true }
 sp-runtime = { default-features = false, workspace = true }
 sp-std = { default-features = false, workspace = true }
 sp-core = { default-features = false, workspace = true }
-support = { package = "frame-support", default-features = false, workspace = true }
-system = { package = "frame-system", default-features = false, workspace = true }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
 
 [dev-dependencies]
 pallet-balances = { workspace = true }
@@ -29,13 +29,12 @@ sp-io = { workspace = true }
 default = ["std"]
 std = [
   "codec/std",
+  "frame-support/std",
+  "frame-system/std",
   "scale-info/std",
   "serde",
   "sp-core/std",
   "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
-  "support/std",
-  "support/std",
-  "system/std",
 ]

--- a/code/parachain/frame/call-filter/src/lib.rs
+++ b/code/parachain/frame/call-filter/src/lib.rs
@@ -15,21 +15,21 @@
 
 mod prelude;
 mod types;
-pub use pallet::*;
-use support::{
+use frame_support::{
 	dispatch::{CallMetadata, GetCallMetadata},
 	pallet_prelude::*,
 	traits::{Contains, PalletInfoAccess},
 	transactional,
 };
-use system::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
 pub use types::*;
 use weights::WeightInfo;
 mod mock;
 mod tests;
 mod weights;
 
-#[support::pallet]
+#[frame_support::pallet]
 pub mod pallet {
 	use super::*;
 	use prelude::*;
@@ -37,9 +37,9 @@ pub mod pallet {
 	type CallFilterEntryOf<T> = CallFilterEntry<<T as Config>::MaxStringSize>;
 
 	#[pallet::config]
-	pub trait Config: system::Config {
+	pub trait Config: frame_system::Config {
 		/// Overarching event type
-		type RuntimeEvent: From<Event<Self>> + IsType<<Self as system::Config>::RuntimeEvent>;
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
 		/// Origin which can disable extrinsic for being executed.
 		/// Consider be same or more allowed than EnableOrigin.
@@ -176,7 +176,7 @@ pub mod pallet {
 
 	impl<T: Config> Contains<T::RuntimeCall> for Pallet<T>
 	where
-		<T as system::Config>::RuntimeCall: GetCallMetadata,
+		<T as frame_system::Config>::RuntimeCall: GetCallMetadata,
 	{
 		fn contains(call: &T::RuntimeCall) -> bool {
 			let CallMetadata { function_name, pallet_name } = call.get_call_metadata();

--- a/code/parachain/frame/call-filter/src/mock.rs
+++ b/code/parachain/frame/call-filter/src/mock.rs
@@ -1,10 +1,10 @@
 #![cfg(test)]
 
 use super::*;
+use frame_support::{construct_runtime, ord_parameter_types, parameter_types, traits::Everything};
+use frame_system::EnsureSignedBy;
 use sp_core::H256;
 use sp_runtime::{testing::Header, traits::IdentityLookup};
-use support::{construct_runtime, ord_parameter_types, parameter_types, traits::Everything};
-use system::EnsureSignedBy;
 
 pub type AccountId = u128;
 pub type Balance = u128;
@@ -18,7 +18,7 @@ parameter_types! {
 	pub const BlockHashCount: u64 = 250;
 }
 
-impl system::Config for Runtime {
+impl frame_system::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
 	type Index = u64;
 	type BlockNumber = u64;
@@ -83,8 +83,8 @@ impl Config for Runtime {
 	type MaxStringSize = MaxStringSize;
 }
 
-type UncheckedExtrinsic = system::mocking::MockUncheckedExtrinsic<Runtime>;
-type Block = system::mocking::MockBlock<Runtime>;
+type UncheckedExtrinsic = frame_system::mocking::MockUncheckedExtrinsic<Runtime>;
+type Block = frame_system::mocking::MockBlock<Runtime>;
 
 construct_runtime!(
 	pub enum Runtime where
@@ -92,7 +92,7 @@ construct_runtime!(
 		NodeBlock = Block,
 		UncheckedExtrinsic = UncheckedExtrinsic
 	{
-		System: system::{Pallet, Call, Config, Storage, Event<T>},
+		System: frame_system::{Pallet, Call, Config, Storage, Event<T>},
 		Filter: call_filter::{Pallet, Storage, Call, Event<T>},
 		Balances: pallet_balances::{Pallet, Storage, Call, Event<T>},
 	}
@@ -108,7 +108,7 @@ impl Default for ExtBuilder {
 
 impl ExtBuilder {
 	pub fn build(self) -> sp_io::TestExternalities {
-		let t = system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
+		let t = frame_system::GenesisConfig::default().build_storage::<Runtime>().unwrap();
 		t.into()
 	}
 }

--- a/code/parachain/frame/call-filter/src/prelude.rs
+++ b/code/parachain/frame/call-filter/src/prelude.rs
@@ -1,3 +1,3 @@
+pub use frame_support::{dispatch::DispatchResult, pallet_prelude::*, BoundedVec};
 pub use sp_core::Get;
 pub use sp_std::prelude::*;
-pub use support::{dispatch::DispatchResult, pallet_prelude::*, BoundedVec};

--- a/code/parachain/frame/call-filter/src/tests.rs
+++ b/code/parachain/frame/call-filter/src/tests.rs
@@ -1,11 +1,11 @@
 #![cfg(test)]
 
 use super::*;
+use frame_support::{assert_noop, assert_ok};
 use mock::{RuntimeEvent, *};
 use sp_runtime::traits::BadOrigin;
-use support::{assert_noop, assert_ok};
 
-const BALANCE_TRANSFER: &<Runtime as system::Config>::RuntimeCall =
+const BALANCE_TRANSFER: &<Runtime as frame_system::Config>::RuntimeCall =
 	&mock::RuntimeCall::Balances(pallet_balances::Call::transfer { dest: ALICE, value: 10 });
 #[test]
 fn pause_transaction_work() {

--- a/code/parachain/frame/call-filter/src/weights.rs
+++ b/code/parachain/frame/call-filter/src/weights.rs
@@ -3,7 +3,7 @@
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
 
-use support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
+use frame_support::{traits::Get, weights::{Weight, constants::RocksDbWeight}};
 use sp_std::marker::PhantomData;
 
 pub trait WeightInfo {

--- a/code/utils/common/Cargo.toml
+++ b/code/utils/common/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 [dependencies]
 sp-core = { workspace = true }
 sp-runtime = { workspace = true }
-system = { workspace = true }
 composable-runtime = { path = "../../parachain/runtime/composable" }
 derive_more = "0.99.17"
 picasso-runtime = { path = "../../parachain/runtime/picasso" }


### PR DESCRIPTION
This addresses the following two warnings:

    warning: .../code/parachain/frame/call-filter/Cargo.toml: unused manifest key: dependencies.support.package
    warning: .../code/parachain/frame/call-filter/Cargo.toml: unused manifest key: dependencies.system.package

Funnily enough, removing the package keys *did* affect the compilation
and broke stuff.  However, the obvious solution was to just use full
names of the packages (which we already had in workspace Cargo.toml)
rather than renaming them.


Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
