### PR TITLE
feat(xcvm): use Displayed consistently for large integers

### DIFF
--- a/code/xcvm/cosmwasm/contracts/gateway/src/contract/ibc/ics20.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/contract/ibc/ics20.rs
@@ -11,7 +11,7 @@ use xc_core::{
 	gateway::{AssetItem, ExecuteMsg, ExecuteProgramMsg, GatewayId},
 	shared::{XcFunds, XcPacket, XcProgram},
 	transport::ibc::{to_cw_message, IbcIcs20Route, XcMessageData},
-	AssetId, CallOrigin, Displayed,
+	AssetId, CallOrigin,
 };
 
 use crate::{
@@ -159,7 +159,7 @@ pub(crate) fn ics20_message_hook(
 				deps,
 				AssetReference::Native { denom: coin.denom },
 			)?;
-			Ok((asset.asset_id, Displayed::<u128>::from(coin.amount.u128())))
+			Ok((asset.asset_id, coin.amount.into()))
 		})
 		.collect();
 	let call_origin = CallOrigin::Remote { user_origin: packet.user_origin };

--- a/code/xcvm/cosmwasm/contracts/gateway/src/state/interpreter.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/state/interpreter.rs
@@ -1,10 +1,10 @@
 use cosmwasm_std::{Deps, StdResult};
 use cw_storage_plus::Item;
-use xc_core::{Displayed, InterpreterOrigin};
+use xc_core::InterpreterOrigin;
 
 use crate::prelude::*;
 
-pub type InterpreterId = Displayed<u128>;
+pub type InterpreterId = xc_core::shared::Displayed<u128>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -20,7 +20,7 @@ use xc_core::{
 	apply_bindings,
 	gateway::{AssetReference, BridgeForwardMsg, ExecuteProgramMsg},
 	shared::{encode_base64, XcProgram},
-	Balance, BindingValue, Destination, Displayed, Funds, Instruction, NetworkId, Register,
+	Balance, BindingValue, Destination, Funds, Instruction, NetworkId, Register,
 };
 
 const CONTRACT_NAME: &str = "composable:xcvm-interpreter";
@@ -268,7 +268,7 @@ pub fn interpret_spawn(
 ) -> Result {
 	let Config { interpreter_origin, gateway_address: gateway, .. } = CONFIG.load(deps.storage)?;
 
-	let mut normalized_funds: Funds<Displayed<u128>> = Funds::default();
+	let mut normalized_funds = Funds::default();
 
 	let mut response = Response::default();
 	for (asset_id, balance) in assets.0 {

--- a/code/xcvm/lib/core/src/accounts.rs
+++ b/code/xcvm/lib/core/src/accounts.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{AssetId, NetworkId};
 
+type Uint128 = crate::shared::Displayed<u128>;
+
 /// Prefix used for all events attached to gateway responses.
 pub const EVENT_PREFIX: &str = "xcvm.accounts";
 
@@ -114,11 +116,11 @@ pub struct AssetBalance {
 	pub asset_id: AssetId,
 	/// Available unlocked balance.  This is the amount user can access at
 	/// the moment.
-	pub unlocked_amount: u128,
+	pub unlocked_amount: Uint128,
 	/// Available locked balance.  This is the amount that is being used
 	/// in processing of a problem and cannot be used until execution of
 	/// the problem terminates.
-	pub locked_amount: u128,
+	pub locked_amount: Uint128,
 }
 
 /// Sends a solution for the virtual wallet to execute.
@@ -151,11 +153,11 @@ pub struct ExecuteSolutionResponse {
 pub struct DepositNotificationPacket {
 	/// Identifier of the deposist assigned by the escrow contract.  It’s
 	/// not globally unique and is used to confirm or deecline a deposit.
-	pub deposit_id: u128,
+	pub deposit_id: Uint128,
 	/// The account whose balances are affected.
 	pub account: String,
 	/// List of credits to balances.
-	pub deposits: Vec<(AssetId, u128)>,
+	pub deposits: Vec<(AssetId, Uint128)>,
 }
 
 /// Message from escrow contract to accounts contract relaying user request.

--- a/code/xcvm/lib/core/src/cosmwasm.rs
+++ b/code/xcvm/lib/core/src/cosmwasm.rs
@@ -66,7 +66,7 @@
 use super::{BindingValue, Bindings};
 use crate::{InterpreterOrigin, NetworkId, OrderedBindings, UserId, UserOrigin};
 use alloc::{fmt::Debug, string::String, vec, vec::Vec};
-use cosmwasm_std::{BankMsg, Coin, CosmosMsg, StdResult};
+use cosmwasm_std::{BankMsg, Coin, CosmosMsg, StdResult, Uint64};
 use cw_storage_plus::{IntKey, Key, KeyDeserialize, Prefixer, PrimaryKey};
 use serde::{Deserialize, Serialize};
 
@@ -226,7 +226,7 @@ where
 	/// `sender` is automatically filled with the current contract's address.
 	Instantiate {
 		admin: Option<String>,
-		code_id: u64,
+		code_id: Uint64,
 		/// msg is the JSON-encoded InstantiateMsg struct (as raw Binary)
 		msg: T,
 		funds: Vec<Coin>,
@@ -243,7 +243,7 @@ where
 	Migrate {
 		contract_addr: String,
 		/// the code_id of the new logic to place in the given contract
-		new_code_id: u64,
+		new_code_id: Uint64,
 		/// msg is the json-encoded MigrateMsg struct that will be passed to the new code
 		msg: T,
 	},
@@ -369,7 +369,7 @@ impl LateCall {
 				Some(StaticBinding::None(data)) => Some(data.clone()),
 				_ => None,
 			},
-			code_id,
+			code_id: code_id.into(),
 			msg: match &msg {
 				IndexedBinding::Some((_, data)) => data.clone(),
 				IndexedBinding::None(data) => data.clone(),
@@ -408,7 +408,7 @@ impl LateCall {
 	) -> Result<Self, ()> {
 		let migrate_msg = FlatWasmMsg::<T>::Migrate {
 			contract_addr,
-			new_code_id,
+			new_code_id: new_code_id.into(),
 			msg: match &msg {
 				IndexedBinding::Some((_, data)) => data.clone(),
 				IndexedBinding::None(data) => data.clone(),
@@ -489,7 +489,7 @@ where
 			FlatCosmosMsg::Wasm(FlatWasmMsg::Instantiate { admin, code_id, msg, funds, label }) =>
 				CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Instantiate {
 					admin,
-					code_id,
+					code_id: code_id.into(),
 					msg: cosmwasm_std::Binary(serde_json_wasm::to_vec(&msg)?),
 					funds,
 					label,
@@ -497,7 +497,7 @@ where
 			FlatCosmosMsg::Wasm(FlatWasmMsg::Migrate { contract_addr, new_code_id, msg }) =>
 				CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Migrate {
 					contract_addr,
-					new_code_id,
+					new_code_id: new_code_id.into(),
 					msg: cosmwasm_std::Binary(serde_json_wasm::to_vec(&msg)?),
 				}),
 			FlatCosmosMsg::Wasm(FlatWasmMsg::UpdateAdmin { contract_addr, admin }) =>
@@ -596,7 +596,7 @@ mod tests {
 			msg.encoded_call,
 			serde_json_wasm::to_vec(&FlatCosmosMsg::Wasm(FlatWasmMsg::Instantiate {
 				admin: Some(Default::default()),
-				code_id: 1,
+				code_id: 1u64.into(),
 				msg: test_msg,
 				funds: Vec::new(),
 				label: "cool label".into()
@@ -622,7 +622,7 @@ mod tests {
 			msg.encoded_call,
 			serde_json_wasm::to_vec(&FlatCosmosMsg::Wasm(FlatWasmMsg::Migrate {
 				contract_addr: "migrate_addr".into(),
-				new_code_id: 2,
+				new_code_id: 2u64.into(),
 				msg: test_msg
 			}))
 			.unwrap()

--- a/code/xcvm/lib/core/src/escrow.rs
+++ b/code/xcvm/lib/core/src/escrow.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::NetworkId;
 
+type Uint128 = crate::shared::Displayed<u128>;
+
 /// Prefix used for all events attached to gateway responses.
 pub const EVENT_PREFIX: &str = "xcvm.escrow";
 
@@ -101,7 +103,7 @@ pub struct DepositAssetsRequest {
 	/// for given amount of the token.  The contract will attempt to transfer
 	/// the funds to its account to get the funds.
 	#[cfg(feature = "cw20")]
-	pub tokens: Vec<(String, u128)>,
+	pub tokens: Vec<(String, Uint128)>,
 }
 
 /// Response to asset deposit request.
@@ -110,7 +112,7 @@ pub struct DepositAssetsRequest {
 #[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
 pub struct DepositAssetsResponse {
 	/// Identifier of the deposit unique on given chain.
-	pub deposit_id: u128,
+	pub deposit_id: Uint128,
 }
 
 /// Relies a problem to the accounts contract on the Centauri chain.

--- a/code/xcvm/lib/core/src/gateway/mod.rs
+++ b/code/xcvm/lib/core/src/gateway/mod.rs
@@ -5,8 +5,7 @@ pub use config::*;
 use crate::prelude::*;
 
 use crate::{
-	transport::ibc::XcMessageData, AssetId, CallOrigin, Displayed, Funds, InterpreterOrigin,
-	NetworkId,
+	transport::ibc::XcMessageData, AssetId, CallOrigin, Funds, InterpreterOrigin, NetworkId,
 };
 
 /// Prefix used for all events attached to gateway responses.
@@ -83,7 +82,7 @@ pub struct ExecuteProgramMsg {
 	pub program: crate::shared::XcProgram,
 	/// Assets to fund the XCVM interpreter instance
 	/// The interpreter is funded prior to execution
-	pub assets: Funds<Displayed<u128>>,
+	pub assets: Funds<crate::shared::Displayed<u128>>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]

--- a/code/xcvm/lib/core/src/packet.rs
+++ b/code/xcvm/lib/core/src/packet.rs
@@ -1,4 +1,4 @@
-use crate::{Displayed, Funds, UserOrigin};
+use crate::{Funds, UserOrigin};
 use alloc::{string::String, vec::Vec};
 use cosmwasm_std::Binary;
 use parity_scale_codec::{Decode, Encode};
@@ -75,5 +75,5 @@ pub struct Packet<Program> {
 	/// The protobuf encoded program.
 	pub program: Program,
 	/// The assets that were attached to the program.
-	pub assets: Funds<Displayed<u128>>,
+	pub assets: Funds<crate::shared::Displayed<u128>>,
 }

--- a/code/xcvm/lib/core/src/service/dex/mod.rs
+++ b/code/xcvm/lib/core/src/service/dex/mod.rs
@@ -1,6 +1,6 @@
-use crate::{prelude::*, Displayed, NetworkId};
+use crate::{prelude::*, NetworkId};
 
-pub type ExchangeId = Displayed<u128>;
+pub type ExchangeId = crate::shared::Displayed<u128>;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "snake_case")]

--- a/code/xcvm/lib/core/src/shared.rs
+++ b/code/xcvm/lib/core/src/shared.rs
@@ -1,4 +1,4 @@
-use crate::{prelude::*, AssetId, Displayed};
+use crate::{prelude::*, AssetId};
 use cosmwasm_std::{from_binary, to_binary, Binary, CanonicalAddr, StdResult};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -14,4 +14,135 @@ pub fn encode_base64<T: Serialize>(x: &T) -> StdResult<String> {
 
 pub fn decode_base64<S: AsRef<str>, T: DeserializeOwned>(encoded: S) -> StdResult<T> {
 	from_binary::<T>(&Binary::from_base64(encoded.as_ref())?)
+}
+
+/// A wrapper around a type which is serde-serialised as a string.
+///
+/// For serde-serialisation to be implemented for the type `T` must implement
+/// `Display` and `FromStr` traits.
+///
+/// ```
+/// # use xc_core::Displayed;
+///
+/// #[derive(serde::Serialize, serde::Deserialize)]
+/// struct Foo {
+///     value: Displayed<u64>
+/// }
+///
+/// let encoded = serde_json_wasm::to_string(&Foo { value: Displayed(42) }).unwrap();
+/// assert_eq!(r#"{"value":"42"}"#, encoded);
+///
+/// let decoded = serde_json_wasm::from_str::<Foo>(r#"{"value":"42"}"#).unwrap();
+/// assert_eq!(Displayed(42), decoded.value);
+/// ```
+#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+#[derive(
+	Copy,
+	Clone,
+	Default,
+	PartialEq,
+	Eq,
+	PartialOrd,
+	Ord,
+	Hash,
+	scale_info::TypeInfo,
+	derive_more::Deref,
+	derive_more::From,
+)]
+#[repr(transparent)]
+pub struct Displayed<T>(pub T);
+
+impl<T> parity_scale_codec::WrapperTypeEncode for Displayed<T> {}
+impl<T> parity_scale_codec::WrapperTypeDecode for Displayed<T> {
+	type Wrapped = T;
+}
+
+impl<T: core::fmt::Display> core::fmt::Display for Displayed<T> {
+	fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		core::fmt::Display::fmt(&self.0, fmtr)
+	}
+}
+
+impl<T: core::fmt::Display> core::fmt::Debug for Displayed<T> {
+	fn fmt(&self, fmtr: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		core::fmt::Display::fmt(&self.0, fmtr)
+	}
+}
+
+impl<T: core::fmt::Display> serde::Serialize for Displayed<T> {
+	fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+		ser.collect_str(&self.0)
+	}
+}
+
+impl<'de, T> serde::Deserialize<'de> for Displayed<T>
+where
+	T: core::str::FromStr,
+	<T as core::str::FromStr>::Err: core::fmt::Display,
+{
+	fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+		de.deserialize_str(DisplayedVisitor::<T>(Default::default()))
+	}
+}
+
+/// Serde Visitor helper for deserialising [`Displayed`] type.
+struct DisplayedVisitor<V>(core::marker::PhantomData<V>);
+
+impl<'de, T> serde::de::Visitor<'de> for DisplayedVisitor<T>
+where
+	T: core::str::FromStr,
+	<T as core::str::FromStr>::Err: core::fmt::Display,
+{
+	type Value = Displayed<T>;
+
+	fn expecting(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+		fmt.write_str("a string")
+	}
+
+	fn visit_str<E: serde::de::Error>(self, s: &str) -> Result<Self::Value, E> {
+		T::from_str(s).map(Displayed).map_err(E::custom)
+	}
+}
+
+macro_rules! impl_conversions {
+	($(Displayed<$inner:ty> => $other:ty),*) => {
+		$(
+		impl From<Displayed<$inner>> for $other {
+			fn from(value: Displayed<$inner>) -> Self {
+				<$other>::from(value.0)
+			}
+		}
+			)*
+	};
+
+	($($other:ty = Displayed<$inner:ty>),*) => {
+		$(
+		impl From<$other> for Displayed<$inner> {
+			fn from(value: $other) -> Self {
+				Self(<$inner>::from(value))
+			}
+		}
+
+		impl From<Displayed<$inner>> for $other {
+			fn from(value: Displayed<$inner>) -> Self {
+				<$other>::from(value.0)
+			}
+		}
+			)*
+	};
+}
+
+// Due to Rust orphan rules it’s not possible to make generic `impl<T>
+// From<Displayed<T>> for T` so we’re defining common conversions explicitly.
+impl_conversions!(Displayed<u128> => u128, Displayed<u64> => u64);
+
+#[cfg(feature = "cosmwasm")]
+impl_conversions!(cosmwasm_std::Uint128 = Displayed<u128>,
+                  cosmwasm_std::Uint64 = Displayed<u64>);
+impl_conversions!(crate::proto::Uint128 = Displayed<u128>);
+
+impl<T: core::cmp::PartialEq> core::cmp::PartialEq<T> for Displayed<T> {
+	fn eq(&self, rhs: &T) -> bool {
+		self.0 == *rhs
+	}
 }


### PR DESCRIPTION
For data structures which are part of public API consistently use
Dispalyed wrapper for u128 and u64 integers.  This is to make sure
that the numbers are encoded as strings when serialising to JSON.

This doesn’t change anything right now but future upgrades of
serde-json-wasm will change how integers are serialised so this is
future-proofing the code.

While at it, since Displayed is a shared wrapper used by various
modules, move it to shared module rather than keeping it in asset.


Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
