### PR TITLE
feat(xcvm): implement sending messagse from escrow to accounts

### DIFF
--- a/code/xcvm/cosmwasm/contracts/escrow/src/deposits.rs
+++ b/code/xcvm/cosmwasm/contracts/escrow/src/deposits.rs
@@ -143,8 +143,7 @@ fn send_deposit(
 		account: deposit.account,
 		deposits,
 	};
-	let send_packet = ibc::make_message(&msg::accounts::Packet::from(packet));
-
+	let send_packet = ibc::make_accounts_message(storage, packet.into())?;
 	let data = to_vec(&msg::DepositAssetsResponse { deposit_id: deposit_id.into() })?;
 	Ok(response.add_message(send_packet).set_data(data))
 }

--- a/code/xcvm/cosmwasm/contracts/escrow/src/error.rs
+++ b/code/xcvm/cosmwasm/contracts/escrow/src/error.rs
@@ -24,6 +24,9 @@ pub enum ContractError {
 	#[error("Invalid packet.")]
 	InvalidPacket,
 
+	#[error("Accounts contract not found")]
+	NoAccountsContract,
+
 	#[error("Internal contract error.")]
 	InternalError,
 }

--- a/code/xcvm/cosmwasm/contracts/escrow/src/ibc.rs
+++ b/code/xcvm/cosmwasm/contracts/escrow/src/ibc.rs
@@ -1,14 +1,37 @@
-use crate::error::{ContractError, Result};
-use cosmwasm_std::{Binary, IbcMsg, IbcTimeout, IbcTimeoutBlock};
+use crate::{
+	error::{ContractError, Result},
+	msg, state,
+};
+use cosmwasm_std::{Binary, CosmosMsg, IbcMsg, IbcTimeout, IbcTimeoutBlock, Storage};
 use parity_scale_codec::{Decode, Encode};
 
-pub(crate) fn make_message(packet: &crate::msg::accounts::Packet) -> IbcMsg {
-	IbcMsg::from(IbcMsg::SendPacket {
-		channel_id: String::from("XXX"),
-		data: cosmwasm_std::Binary::from(packet.encode()),
-		// TODO: should be a parameter or configuration
-		timeout: IbcTimeout::with_block(IbcTimeoutBlock { revision: 0, height: 10000 }),
-	})
+/// Makes a CosmosMsg sending given packet to accounts contract.
+///
+/// Depending whether accounts contract runs on local chain or remotely, the
+/// message is either a local execute message or an IBC send packet message.
+/// Returns and error if no accounts contract is configured.
+pub(crate) fn make_accounts_message(
+	storage: &dyn Storage,
+	packet: msg::accounts::Packet,
+) -> Result<CosmosMsg> {
+	match state::Config::load(storage)?.accounts_contract {
+		state::AccountsContract::Local(addr) => {
+			let msg = msg::accounts::ExecuteMsg::LocalPacket(packet);
+			cosmwasm_std::wasm_execute(addr, &msg, Vec::new())
+				.map(CosmosMsg::from)
+				.map_err(ContractError::from)
+		},
+		state::AccountsContract::Remote(channel) => {
+			let msg = IbcMsg::SendPacket {
+				channel_id: channel,
+				data: cosmwasm_std::Binary::from(packet.encode()),
+				// TODO: should be a parameter or configuration
+				timeout: IbcTimeout::with_block(IbcTimeoutBlock { revision: 0, height: 10000 }),
+			};
+			Ok(IbcMsg::from(msg).into())
+		},
+		state::AccountsContract::None => Err(ContractError::NoAccountsContract),
+	}
 }
 
 pub(crate) fn decode<T: Decode>(data: Binary) -> Result<T> {

--- a/code/xcvm/lib/core/src/escrow.rs
+++ b/code/xcvm/lib/core/src/escrow.rs
@@ -36,8 +36,22 @@ pub struct InstantiateMsg {
 	pub network_id: NetworkId,
 	/// Address of a local XCVM gateway contract.
 	pub gateway_address: String,
+	/// Location of the accounts contract.
+	pub accounts_contract: AccountsContract,
 	/// Admins which are allowed to use the break glass feature.
 	pub admins: Vec<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "snake_case")]
+#[cfg_attr(feature = "std", derive(schemars::JsonSchema))]
+pub enum AccountsContract {
+	/// Address of the accounts contract on the local network.
+	Local(String),
+	/// IBC channel name with accounts contract on the other side.
+	Remote(String),
+	/// No accounts contract configured yet.
+	None,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -59,6 +73,9 @@ pub enum ExecuteMsg {
 	/// `msg` which is JSON-serialised [`ReceiveMsgBody`].
 	#[cfg(feature = "cw20")]
 	Receive(cw20::Cw20ReceiveMsg),
+
+	/// Sets accounts contract address to the one given.
+	SetAccountsContract(AccountsContract),
 
 	Relay(RelayRequest),
 	BreakGlass,


### PR DESCRIPTION
Implement function for sending messages from escrow contract to
accounts contract.  This is done by adding SetAccountsContract request
which configures the escrow contract and specifies location of the
accounts contract.  With that information, the contract now knows
where to send the packets.

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
