### PR TITLE
chore(ci): remove duplicate dependencies warning noise

### DIFF
--- a/code/deny.toml
+++ b/code/deny.toml
@@ -148,8 +148,10 @@ registries = [
 # More documentation about the 'bans' section can be found here:
 # https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
 [bans]
-# Lint level for when multiple versions of the same crate are detected
-multiple-versions = "warn"
+# Lint level for when multiple versions of the same crate are detected.  This
+# warning is too noisy to be useful at this point.  As of August 2023 it outputs
+# 8k lines and only pollutes CI.  Because of that, allow multiple versions.
+multiple-versions = "allow"
 # Lint level for when a crate version requirement is `*`
 # * is for git rev too
 wildcards = "allow"
@@ -175,16 +177,13 @@ deny = [
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-  # unfortunately substrate itself depends on several versions, to allow for it 
+  # unfortunately substrate itself depends on several versions, to allow for it
   { name = "wasi", version = "=0.10.0+wasi-snapshot-preview1" },
   { name = "smallvec", version = "=0.6.14" },
   { name = "sha2", version = "=0.9.9" },
-  { name = "semver", version = "=1.0.4" },
   { name = "rustc_version", version = "=0.4.0" },
-  { name = "redox_syscall", version = "=0.2.10" },
   { name = "pbkdf2", version = "=0.8.0" },
   { name = "rand_xorshift", version = "=0.3.0" },
-  { name = "rand_pcg", version = "=0.2.1" },
   { name = "opaque-debug", version = "=0.3.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate

--- a/tools/rust.nix
+++ b/tools/rust.nix
@@ -8,7 +8,7 @@
         crane.nightly.cargoBuild (systemCommonRust.common-attrs // {
           cargoArtifacts = self'.packages.common-deps-nightly;
           buildPhase = ''
-            cargo check --no-default-features --quiet --target wasm32-unknown-unknown --package ${pname}
+            cargo check --no-default-features --target wasm32-unknown-unknown --package ${pname}
             cargo clippy --package ${pname} -- --deny warnings --allow deprecated
           '';
           installPhase = "mkdir --parents $out";


### PR DESCRIPTION
At the moment build-all-misc-packages CI produces *a lot* of warnings
about duplicate dependencies.  Over 8k lines in fact.  Those warnings
aren’t really useful and only make it harder to view through the logs
when the CI step fails.

This should remove those noisy warnings.

So far no one cared about the duplicate crates.  AS such, removing the
warnings shouldn’t have any negative impact.  If will to fix the
situation ever materialises, those warnings should be addressed and
then turned into errors.


Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
