### PR TITLE
chore(ci): do not run checks on drafts #check

### DIFF
--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pr-workflow-check:
-    if: ${{ ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title) && !contains(github.event.pull_request.labels.*.name, 'wip') ) }} 
+    if: ${{ ( ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title) && !contains(github.event.pull_request.labels.*.name, 'wip') ) ) && ( github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'check') || contains('#check', github.event.pull_request.title) || contains('#check', github.event.pull_request.title) )  }}
     
     uses: ./.github/workflows/pr-workflow.yml
     with:

--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -7,26 +7,26 @@ on:
   push:
     branches:
       - release-*
-      - main  
-  pull_request:  
+      - main
+  pull_request:
   merge_group:
     types: [checks_requested]
 
 jobs:
   pr-workflow-check:
     if: ${{ ( ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title) && !contains(github.event.pull_request.labels.*.name, 'wip') ) ) && ( github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'check') || contains('#check', github.event.pull_request.title) || contains('#check', github.event.pull_request.title) )  }}
-    
+
     uses: ./.github/workflows/pr-workflow.yml
     with:
       github_event_name: ${{ github.event_name }}
-      github_event_pull_request_head_repo_id : ${{ github.event.pull_request.head.repo.id || 0 }}
+      github_event_pull_request_head_repo_id: ${{ github.event.pull_request.head.repo.id || 0 }}
       github_workflow: ${{ github.workflow }}
       github_event_pull_request_head_sha: ${{ github.event.pull_request.head.sha}}
-      flow: ${{( github.event_name == 'push' && 'push' ) || ( github.event_name == 'merge_group' && 'merge_queue_check' ) || ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.id != 383289760 && 'pr_from_fork' ) || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == 383289760 && 'pr_from_branch' )}}      
+      flow: ${{( github.event_name == 'push' && 'push' ) || ( github.event_name == 'merge_group' && 'merge_queue_check' ) || ( github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.id != 383289760 && 'pr_from_fork' ) || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.id == 383289760 && 'pr_from_branch' )}}
       sha_to_check: ${{ github.event.pull_request.head.sha || github.sha }}
-      
+
     secrets:
-      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}          
+      CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
       DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
       DOCKER_HUB_ACCESS_TOKEN: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
       PABLO_PROJ_JSON: ${{ secrets.PABLO_PROJ_JSON }}

--- a/.github/workflows/pr-workflow-check.yaml
+++ b/.github/workflows/pr-workflow-check.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   pr-workflow-check:
-    if: ${{ ( ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains('#WIP', github.event.pull_request.title) && !contains('#wip', github.event.pull_request.title) && !contains(github.event.pull_request.labels.*.name, 'wip') ) ) && ( github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'check') || contains('#check', github.event.pull_request.title) || contains('#check', github.event.pull_request.title) )  }}
+    if: ${{ ( ( github.event_name != 'pull_request' ) || ( ( github.event_name == 'pull_request' ) && !contains(github.event.pull_request.title, '#WIP') && !contains(github.event.pull_request.title, '#wip') && !contains(github.event.pull_request.labels.*.name, 'wip') ) ) && ( github.event.pull_request.draft != true || contains(github.event.pull_request.labels.*.name, 'check') || contains(github.event.pull_request.title, '#check') || contains(github.event.pull_request.title, '#check') )  }}
 
     uses: ./.github/workflows/pr-workflow.yml
     with:

--- a/terraform/github.com/labels.tf
+++ b/terraform/github.com/labels.tf
@@ -8,7 +8,7 @@ locals {
     "needs-benchmarks" = "bot: Runs benchmarks on target hardware"
     "stale-item"       = "bot: Stale PRs and issues handling"
     "stale-branch"     = "bot: Stale branches handling"
-    "check"            = "Forces CI to run all checks even for draft PRs"
+    "check"            = "run checks for draft PRs"
   }
 }
 

--- a/terraform/github.com/labels.tf
+++ b/terraform/github.com/labels.tf
@@ -8,6 +8,7 @@ locals {
     "needs-benchmarks" = "bot: Runs benchmarks on target hardware"
     "stale-item"       = "bot: Stale PRs and issues handling"
     "stale-branch"     = "bot: Stale branches handling"
+    "check"            = "Forces CI to run all checks even for draft PRs"
   }
 }
 


### PR DESCRIPTION
Do not burn cycles of CI for frequent draft commits, so allow to opt in to do so for a reason (e.g. remote build and cache by nix for devnet testing)

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

