### PR TITLE
chore(price-feed): remove use of lazy-static

### DIFF
--- a/code/utils/price-feed/Cargo.toml
+++ b/code/utils/price-feed/Cargo.toml
@@ -13,7 +13,6 @@ env_logger = "0.9.0"
 futures = "0.3.21"
 jsonrpc-client-transports = "18.0.0"
 jsonrpc-core = "18.0.0"
-lazy_static = "1.4.0"
 log = "0.4.16"
 primitives = { path = "../../parachain/runtime/primitives" }
 scale-codec = { package = "parity-scale-codec", version = "3.0.0", features = [

--- a/code/utils/price-feed/src/asset.rs
+++ b/code/utils/price-feed/src/asset.rs
@@ -1,9 +1,5 @@
 use primitives::currency::CurrencyId;
-use std::{
-	collections::{HashMap, HashSet},
-	convert::TryFrom,
-	fmt::Display,
-};
+use std::{convert::TryFrom, fmt::Display};
 
 custom_derive! {
 	#[derive(EnumFromStr, Copy, Clone, PartialEq, Eq, Hash, Debug)]
@@ -22,27 +18,18 @@ pub const VALID_PRICE_QUOTE_ASSETS: &[Asset] = &[Asset::USDT, Asset::USDC];
 pub struct AssetPair(pub Asset, pub Asset);
 
 // NOTE: sure it is better move it into primitives
-lazy_static! {
-	/*
-	  The map of valid asset we are allowed to ask price for.
-	  We must not swap two indexes.
-	*/
-	pub static ref INDEX_TO_ASSET: HashMap<CurrencyId, Asset> = [
-		(CurrencyId::KSM, Asset::KSM),
-		(CurrencyId::PICA, Asset::PICA),
-		(CurrencyId::USDT, Asset::USDT),
-		(CurrencyId::USDC, Asset::USDC),
-		(CurrencyId::DOT, Asset::DOT),
-	]
-	.into_iter()
-	.collect();
-
-	pub static ref ASSET_TO_INDEX: HashMap<Asset, CurrencyId> =
-		INDEX_TO_ASSET.iter().map(|(&i, &a)| (a, i)).collect();
-
-	pub static ref VALID_ASSETS: HashSet<Asset> =
-		INDEX_TO_ASSET.values().copied().collect();
-}
+//
+// The map of valid asset we are allowed to ask price for.
+// We must not swap two indexes.
+//
+// This is tiny enough that we don’t bother using a Map.
+pub static INDEX_TO_ASSET: [(CurrencyId, Asset); 5] = [
+	(CurrencyId::KSM, Asset::KSM),
+	(CurrencyId::PICA, Asset::PICA),
+	(CurrencyId::USDT, Asset::USDT),
+	(CurrencyId::USDC, Asset::USDC),
+	(CurrencyId::DOT, Asset::DOT),
+];
 
 impl AssetPair {
 	/*
@@ -59,14 +46,17 @@ impl AssetPair {
 impl TryFrom<Asset> for CurrencyId {
 	type Error = ();
 	fn try_from(asset: Asset) -> Result<CurrencyId, Self::Error> {
-		ASSET_TO_INDEX.get(&asset).copied().ok_or(())
+		INDEX_TO_ASSET.iter().find_map(|(id, a)| (asset == *a).then_some(*id)).ok_or(())
 	}
 }
 
 impl TryFrom<CurrencyId> for Asset {
 	type Error = ();
 	fn try_from(currency_index: CurrencyId) -> Result<Asset, Self::Error> {
-		INDEX_TO_ASSET.get(&currency_index).copied().ok_or(())
+		INDEX_TO_ASSET
+			.iter()
+			.find_map(|(id, a)| (currency_index == *id).then_some(*a))
+			.ok_or(())
 	}
 }
 

--- a/code/utils/price-feed/src/feed/pyth.rs
+++ b/code/utils/price-feed/src/feed/pyth.rs
@@ -261,8 +261,8 @@ mod tests {
 		let product_price = PythProductPrice { account, price_exponent: Exponent(0x1337) };
 		let price = Price(0xCAFEBABE);
 		let timestamp = TimeStamp::now();
-		VALID_ASSETS.iter().for_each(|&asset| {
-			[
+		for (_, asset) in INDEX_TO_ASSET {
+			let tests = [
 				(PythSymbolStatus::Halted, None),
 				(PythSymbolStatus::Unknown, None),
 				(
@@ -278,15 +278,14 @@ mod tests {
 						},
 					)),
 				),
-			]
-			.iter()
-			.for_each(|&(status, expected_action)| {
+			];
+			for (status, expected_action) in tests {
 				let notify_price = PythNotifyPrice { status, price };
 				assert_eq!(
 					expected_action,
 					notify_price_action(asset, &product_price, &notify_price, &timestamp)
 				)
-			});
-		});
+			}
+		}
 	}
 }

--- a/code/utils/price-feed/src/main.rs
+++ b/code/utils/price-feed/src/main.rs
@@ -9,8 +9,6 @@ mod opts;
 extern crate custom_derive;
 #[macro_use]
 extern crate enum_derive;
-#[macro_use]
-extern crate lazy_static;
 
 use crate::{
 	asset::Asset,


### PR DESCRIPTION
lazy-static is often no longer necessary now that OnceCell and OnceLock
are a thing.  Furthermore, in case of price-feed the lazy initialisation
isn’t even necessary: there’s so few entries in mapping that it’s enough
to use a static array than build a hash map.

Readjust the code to use said static array and remove dependency on
lazy-static.



Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review `faster:`
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
