### PR TITLE
feat(xcvm): define helper proto::define_conversion macro

### DIFF
--- a/code/xcvm/lib/core/src/proto.rs
+++ b/code/xcvm/lib/core/src/proto.rs
@@ -57,3 +57,29 @@ impl core::fmt::Display for DecodeError {
 		}
 	}
 }
+
+/// Defines conversions between protocol buffer message `$pb` and Rust type
+/// `$ty`.
+///
+/// Specifically, implements `TryFrom<$pb> for $ty` and `From<$ty> for $pb`.
+/// That is, conversion from protocol message is fallible while conversion to
+/// protocol message isn’t.  The error for the `TryFrom` conversion is `()`.
+macro_rules! define_conversion {
+	(($pb_name:ident: $pb:ty) -> { $($from_pb:tt)* }
+	 ($ty_name:ident: $ty:ty) -> { $($from_ty:tt)* }) => {
+		impl TryFrom<$pb> for $ty {
+			type Error = ();
+			fn try_from($pb_name: $pb) -> Result<Self, Self::Error> {
+				$($from_pb)*
+			}
+		}
+
+		impl From<$ty> for $pb {
+			fn from($ty_name: $ty) -> $pb {
+				$($from_ty)*
+			}
+		}
+	}
+}
+
+use define_conversion;


### PR DESCRIPTION
To reduce amount of boilerplate when defining conversions between
protocol buffer messages and Rust types, introduce a define_conversion
macro.  It adds a `TryFrom<PB> for TY` and `From<TY> for PB` impls.

A bit of a downside of this is that it’s less obvious than an explicit
implementation of the traits.  However, with many of those traits
needed I think it’s worth it.


Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
