### PR TITLE
chore: remove last reference to lazy-static; use workspace hex-literal

### DIFF
--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -382,6 +382,7 @@ hex = { version = "0.4.3", default-features = false, features = [
   "alloc",
   "serde",
 ] }
+hex-literal = "0.3.4"
 strum = { version = "0.25.0", default-features = false, features = ["derive"] }
 
 cosmwasm-std = { git = "https://github.com/dzmitry-lahoda-forks/cosmwasm", rev = "1277597cbf380a8d04dbe676d9cb344ca31634b6", default-features = false, features = [

--- a/code/integration-tests/local-integration-tests/Cargo.toml
+++ b/code/integration-tests/local-integration-tests/Cargo.toml
@@ -81,7 +81,7 @@ benchmarking = { package = "frame-benchmarking", git = "https://github.com/parit
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false, features = [
   "derive",
 ] }
-hex-literal = { version = "0.3.3", optional = true }
+hex-literal = { workspace = true, optional = true }
 system-benchmarking = { package = "frame-system-benchmarking", git = "https://github.com/paritytech/substrate", default-features = false, optional = true, branch = "polkadot-v0.9.36" }
 
 # Parachain Utilities

--- a/code/parachain/frame/airdrop/Cargo.toml
+++ b/code/parachain/frame/airdrop/Cargo.toml
@@ -16,7 +16,7 @@ version = "3.0.0"
 
 [dev-dependencies]
 composable-tests-helpers = { path = "../composable-tests-helpers" }
-hex-literal = "0.3.3"
+hex-literal.workspace = true
 libsecp256k1 = { version = "0.7.0" }
 pallet-balances = { workspace = true }
 pallet-timestamp = { workspace = true }

--- a/code/parachain/frame/cosmwasm/Cargo.toml
+++ b/code/parachain/frame/cosmwasm/Cargo.toml
@@ -37,7 +37,7 @@ frame-benchmarking = { default-features = false, workspace = true, optional = tr
 frame-support = { default-features = false, workspace = true }
 frame-system = { default-features = false, workspace = true }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
-hex-literal = "0.3.4"
+hex-literal.workspace = true
 vec1 = { version = "*", default-features = false, features = ["smallvec-v1"] }
 
 ibc = { workspace = true, default-features = false }

--- a/code/parachain/frame/crowdloan-rewards/Cargo.toml
+++ b/code/parachain/frame/crowdloan-rewards/Cargo.toml
@@ -19,7 +19,7 @@ version = "3.0.0"
 composable-tests-helpers = { path = "../composable-tests-helpers" }
 ed25519-dalek = "1.0.1"
 frame-benchmarking = { default-features = false, workspace = true }
-hex-literal = "0.3.3"
+hex-literal.workspace = true
 libsecp256k1 = { version = "0.7.0" }
 pallet-balances = { workspace = true }
 pallet-timestamp = { workspace = true }

--- a/code/parachain/frame/dutch-auction/Cargo.toml
+++ b/code/parachain/frame/dutch-auction/Cargo.toml
@@ -47,7 +47,7 @@ xcm = { workspace = true, default-features = false }
 [dev-dependencies]
 composable-tests-helpers = { path = "../composable-tests-helpers" }
 frame-benchmarking = { workspace = true }
-hex-literal = { version = "0.3.3" }
+hex-literal.workspace = true
 orml-tokens = { workspace = true }
 pallet-assets = { path = '../assets' }
 pallet-balances = { workspace = true }

--- a/code/parachain/frame/lending/Cargo.toml
+++ b/code/parachain/frame/lending/Cargo.toml
@@ -54,7 +54,7 @@ frame-benchmarking = { workspace = true }
 frame-executive = { default-features = false, features = [
   "try-runtime",
 ], workspace = true }
-hex-literal = "0.3.3"
+hex-literal.workspace = true
 once_cell = "1.8.0"
 orml-tokens = { workspace = true }
 orml-traits = { workspace = true }

--- a/code/parachain/frame/liquidations/Cargo.toml
+++ b/code/parachain/frame/liquidations/Cargo.toml
@@ -49,7 +49,7 @@ xcm = { workspace = true, default-features = false }
 [dev-dependencies]
 composable-tests-helpers = { path = "../composable-tests-helpers" }
 frame-benchmarking = { default-features = false, workspace = true }
-hex-literal = { version = "0.3.3" }
+hex-literal.workspace = true
 orml-tokens = { workspace = true }
 orml-traits = { workspace = true }
 pallet-assets = { path = "../assets" }

--- a/code/parachain/runtime/composable/Cargo.toml
+++ b/code/parachain/runtime/composable/Cargo.toml
@@ -78,7 +78,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
   "derive",
 ] }
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
-hex-literal = { version = "0.3.4" }
+hex-literal.workspace = true
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
 
 

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -100,7 +100,7 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
   "derive",
 ] }
 frame-benchmarking = { workspace = true, default-features = false, optional = true }
-hex-literal = { version = "0.3.3" }
+hex-literal.workspace = true
 frame-system-benchmarking = { workspace = true, default-features = false, optional = true }
 
 collator-selection = { workspace = true, default-features = false }

--- a/code/parachain/runtime/primitives/Cargo.toml
+++ b/code/parachain/runtime/primitives/Cargo.toml
@@ -14,7 +14,6 @@ codec = { package = "parity-scale-codec", version = "3.0.0", default-features = 
 composable-support = { path = "../../frame/composable-support", default-features = false }
 composable-traits = { path = "../../frame/composable-traits", default-features = false }
 frame-support = { workspace = true, default-features = false }
-lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 scale-info = { workspace = true, default-features = false, features = [
   "derive",
 ] }


### PR DESCRIPTION
Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
