### PR TITLE
feat(xcvm): rework protocol messages [breaking change]

### DIFF
--- a/code/xcvm/cosmwasm/contracts/gateway/src/contract/ibc/xcvm.rs
+++ b/code/xcvm/cosmwasm/contracts/gateway/src/contract/ibc/xcvm.rs
@@ -91,7 +91,7 @@ pub fn ibc_packet_receive(
 ) -> Result<IbcReceiveResponse> {
 	let response = IbcReceiveResponse::default().add_event(make_event("receive"));
 	let msg = (|| -> Result<_> {
-		let packet = XcPacket::try_decode(&msg.packet.data)?;
+		let packet = XcPacket::decode(&msg.packet.data)?;
 		let call_origin = CallOrigin::Remote { user_origin: packet.user_origin };
 		let execute_program = msg::ExecuteProgramMsg {
 			salt: packet.salt,
@@ -119,7 +119,7 @@ pub fn ibc_packet_receive(
 pub fn ibc_packet_ack(_deps: DepsMut, _env: Env, msg: IbcPacketAckMsg) -> Result<IbcBasicResponse> {
 	let ack = XCVMAck::try_from(msg.acknowledgement.data.as_slice())
 		.map_err(|_| ContractError::InvalidAck)?;
-	XcPacket::try_decode(&msg.original_packet.data)?;
+	XcPacket::decode(&msg.original_packet.data)?;
 	Ok(IbcBasicResponse::default().add_event(make_event("ack").add_attribute("ack", ack)))
 }
 
@@ -129,7 +129,7 @@ pub fn ibc_packet_timeout(
 	_env: Env,
 	msg: IbcPacketTimeoutMsg,
 ) -> Result<IbcBasicResponse> {
-	XcPacket::try_decode(&msg.packet.data)?;
+	XcPacket::decode(&msg.packet.data)?;
 	// https://github.com/cosmos/ibc/pull/998
 	Ok(IbcBasicResponse::default())
 }

--- a/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
+++ b/code/xcvm/cosmwasm/contracts/interpreter/src/contract.rs
@@ -147,10 +147,10 @@ pub fn handle_execute_step(
 				interpret_transfer(&mut deps, &env, &tip, to, assets),
 			Instruction::Call { bindings, encoded } =>
 				interpret_call(deps.as_ref(), &env, bindings, encoded, instruction_pointer, &tip),
-			Instruction::Spawn { network, salt, assets, program } =>
-				interpret_spawn(&mut deps, &env, network, salt, assets, program),
-			Instruction::Exchange { give, id, want } =>
-				interpret_exchange(&mut deps, give, want, id, env.contract.address.clone()),
+			Instruction::Spawn { network_id, salt, assets, program } =>
+				interpret_spawn(&mut deps, &env, network_id, salt, assets, program),
+			Instruction::Exchange { exchange_id, give, want } =>
+				interpret_exchange(&mut deps, give, want, exchange_id, env.contract.address.clone()),
 		}?;
 		// Save the intermediate IP so that if the execution fails, we can recover at which
 		// instruction it happened.

--- a/code/xcvm/lib/core/protos/xcvm.proto
+++ b/code/xcvm/lib/core/protos/xcvm.proto
@@ -5,16 +5,16 @@ import "common.proto";
 package cvm.xcvm;
 
 message PacketAsset {
-  AssetId assetId = 1;
+  cvm.common.Uint128 asset_id = 1;
   cvm.common.Uint128 amount = 2;
 
   // next tag: 3
 }
 
 message Packet {
-  Account interpreter = 1;
+  bytes interpreter = 1;
   UserOrigin user_origin = 2;
-  Salt salt = 3;
+  bytes salt = 3;
   Program program = 4;
   repeated PacketAsset assets = 5;
 
@@ -22,23 +22,17 @@ message Packet {
 }
 
 message UserOrigin {
-  Network network = 1;
-  Account account = 2;
+  uint32 network_id = 1;
+  bytes account = 2;
 
   // next tag: 3
 }
 
 message Program {
   bytes tag = 1;
-  Instructions instructions = 2;
+  repeated Instruction instructions = 2;
 
   // next tag: 3
-}
-
-message Instructions {
-  repeated Instruction instructions = 1;
-
-  // next tag: 2
 }
 
 message Instruction {
@@ -83,91 +77,49 @@ message Balance {
   // next tag: 4
 }
 
-message Account {
-  bytes account = 1;
-
-  // next tag: 2
-}
-
-message AssetId {
-  cvm.common.Uint128 id = 1;
-
-  // next tag: 2
-}
-
-message ExchangeId {
-  cvm.common.Uint128 id = 1;
-
-  // next tag: 2
-}
-
 message Asset {
-  AssetId assetId = 1;
+  cvm.common.Uint128 asset_id = 1;
   Balance balance = 2;
 
   // next tag: 3
-}
-
-message Self {
-  uint32 self = 1;
-
-  // next tag: 2
-}
-
-message Tip {
-  uint32 id = 1;
-
-  // next tag: 2
-}
-
-message Result {
-  uint32 result = 1;
-
-  // next tag: 2
 }
 
 message AssetAmount {
-  AssetId assetId = 1;
+  cvm.common.Uint128 asset_id = 1;
   Balance balance = 2;
 
   // next tag: 3
-}
-
-message IpRegister {
-  uint64 ip = 1;
-
-  // next tag: 2
 }
 
 message BindingValue {
   oneof type {
-    Self self = 1;
-    Tip tip = 2;
-    Result result = 3;
-    AssetAmount assetAmount = 4;
-    AssetId assetId = 5;
-    IpRegister ipRegister = 6;
+    Register register = 1;
+    cvm.common.Uint128 asset_id = 2;
+    AssetAmount asset_amount = 3;
   }
 
-  // next tag: 7
+  // next tag: 4
+}
+
+enum Register {
+  IP = 0;
+  TIP = 1;
+  THIS = 2;
+  RESULT = 3;
+
+  // next tag: 4
 }
 
 message Binding {
   uint32 position = 1;
-  BindingValue bindingValue = 2;
+  BindingValue binding_value = 2;
 
   // next tag: 3
 }
 
-message Bindings {
-  repeated Binding bindings = 1;
-
-  // next tag: 2
-}
-
 message Transfer {
   oneof account_type{
-    Account account = 1;
+    bytes account = 1;
     Tip tip = 2;
   }
   repeated Asset assets = 3;
@@ -175,29 +127,21 @@ message Transfer {
   // next tag: 4
 }
 
+message Tip {
+  // next tag: 1
+}
+
 message Exchange {
-  ExchangeId id = 1;
+  cvm.common.Uint128 exchange_id = 1;
   repeated Asset give = 5;
   repeated Asset want = 6;
 
   // next tag: 7
 }
 
-message Salt {
-  bytes salt = 1;
-
-  // next tag: 2
-}
-
-message Network {
-  uint32 networkId = 1;
-
-  // next tag: 2
-}
-
 message Spawn {
-  Network network = 1;
-  Salt salt = 3;
+  uint32 network_id = 1;
+  bytes salt = 3;
   Program program = 4;
   repeated Asset assets = 5;
 
@@ -206,7 +150,7 @@ message Spawn {
 
 message Call {
   bytes payload = 1;
-  Bindings bindings = 2;
+  repeated Binding bindings = 2;
 
   // next tag: 3
 }

--- a/code/xcvm/lib/core/src/gateway/mod.rs
+++ b/code/xcvm/lib/core/src/gateway/mod.rs
@@ -327,7 +327,7 @@ mod tests {
 						  "instructions": [
 							{
 							  "spawn": {
-								"network": 3,
+								"network_id": 3,
 								"salt": "737061776e5f776974685f6173736574",
 								"assets": [
 								  [
@@ -414,7 +414,7 @@ mod tests {
 								"instructions": [
 									{
 										"spawn": {
-											"network": 3,
+											"network_id": 3,
 											"salt": "737061776e5f776974685f6173736574",
 											"assets": [
 												[
@@ -545,7 +545,7 @@ mod tests {
 								"instructions": [
 									{
 										"spawn": {
-											"network": 3,
+											"network_id": 3,
 											"salt": "737061776e5f776974685f6173736574",
 											"assets": [
 												[
@@ -593,7 +593,7 @@ mod tests {
 													},
 													{
 														"spawn": {
-															"network": 2,
+															"network_id": 2,
 															"salt": "737061776e5f776974685f6173736574",
 															"assets": [
 																[
@@ -696,7 +696,7 @@ mod tests {
 								"instructions": [
 									{
 										"spawn": {
-											"network": 2,
+											"network_id": 2,
 											"salt": "737061776e5f776974685f6173736574",
 											"assets": [
 												[

--- a/code/xcvm/lib/core/src/gateway/mod.rs
+++ b/code/xcvm/lib/core/src/gateway/mod.rs
@@ -299,7 +299,7 @@ mod tests {
 				program: XcProgram {
 					tag: b"spawn_with_asset".to_vec(),
 					instructions: [Instruction::Spawn {
-						network: 3.into(),
+						network_id: 3.into(),
 						salt: b"spawn_with_asset".to_vec(),
 						assets: vec![(pica_on_osmosis, 1_000_000_000u128)].into(),
 						program: XcProgram {
@@ -378,7 +378,7 @@ mod tests {
 				program: XcProgram {
 					tag: b"spawn_with_asset".to_vec(),
 					instructions: [Instruction::Spawn {
-						network: 3.into(),
+						network_id: 3.into(),
 						salt: b"spawn_with_asset".to_vec(),
 						assets: vec![(pica_on_osmosis, 1_000_000_000u128)].into(),
 						program: XcProgram {
@@ -488,19 +488,19 @@ mod tests {
 				program: XcProgram {
 					tag: b"spawn_with_asset".to_vec(),
 					instructions: [Instruction::Spawn {
-						network: 3.into(),
+						network_id: 3.into(),
 						salt: b"spawn_with_asset".to_vec(),
 						assets: vec![(pica_on_osmosis, 1_000_000_000u128)].into(),
 						program: XcProgram {
 							tag: b"spawn_with_asset".to_vec(),
 							instructions: [
 								XcInstruction::Exchange {
-									id: pica_osmo_on_osmosis.into(),
+									exchange_id: pica_osmo_on_osmosis.into(),
 									give: XcFundsFilter::one(pica_on_osmosis, 1_000_000_000u128),
 									want: XcFundsFilter::one(osmo_on_osmosis, 1_000u128),
 								},
 								XcInstruction::Spawn {
-									network: 2.into(),
+									network_id: 2.into(),
 									salt: b"spawn_with_asset".to_vec(),
 									assets: XcFundsFilter::one(osmo_on_centauri, (100, 100)),
 									program: XcProgram {
@@ -564,7 +564,7 @@ mod tests {
 												"instructions": [
 													{
 														"exchange": {
-															"id": "237684489387467420151587012609",
+															"exchange_id": "237684489387467420151587012609",
 															"give": [
 																[
 																	"237684487542793012780631851009",
@@ -667,7 +667,7 @@ mod tests {
 				program: XcProgram {
 					tag: b"spawn_with_asset".to_vec(),
 					instructions: [Instruction::Spawn {
-						network: 2.into(),
+						network_id: 2.into(),
 						salt: b"spawn_with_asset".to_vec(),
 						assets: vec![(osmo_on_centauri, 1_000_000_000u128)].into(),
 						program: XcProgram {

--- a/code/xcvm/lib/core/src/instruction.rs
+++ b/code/xcvm/lib/core/src/instruction.rs
@@ -76,7 +76,7 @@ pub enum Instruction<Payload, Account, Assets> {
 	/// The program will be spawned with the desired [`Assets`].
 	/// The salt is used to track the program when events are dispatched in the network.
 	Spawn {
-		network: crate::network::NetworkId,
+		network_id: crate::network::NetworkId,
 		/// If JSON, than hex encoded non prefixed lower case string.
 		#[serde(serialize_with = "hex::serialize", deserialize_with = "hex::deserialize")]
 		#[cfg_attr(feature = "std", schemars(schema_with = "String::json_schema"))]
@@ -85,7 +85,7 @@ pub enum Instruction<Payload, Account, Assets> {
 		program: Program<VecDeque<Self>>,
 	},
 	Exchange {
-		id: ExchangeId,
+		exchange_id: ExchangeId,
 		give: Assets,
 		want: Assets,
 	},

--- a/code/xcvm/lib/core/src/lib.rs
+++ b/code/xcvm/lib/core/src/lib.rs
@@ -83,7 +83,7 @@ where
 		builder.instructions.push_back(Instruction::Spawn {
 			salt: salt.into(),
 			assets: assets.into(),
-			network: SpawningNetwork::ID,
+			network_id: SpawningNetwork::ID,
 			program: f(ProgramBuilder::<SpawningNetwork, Account, Assets>::new(tag.into()))?
 				.build(),
 		});
@@ -190,7 +190,7 @@ mod tests {
 					Instruction::Call { bindings: vec![], encoded: vec![202, 254, 190, 239] },
 					// Move to ethereum
 					Instruction::Spawn {
-						network: Ethereum::ID,
+						network_id: Ethereum::ID,
 						salt: Vec::new(),
 						assets: Funds::default(),
 						program: Program {

--- a/code/xcvm/lib/core/src/proto.rs
+++ b/code/xcvm/lib/core/src/proto.rs
@@ -82,6 +82,8 @@ macro_rules! define_conversion {
 	}
 }
 
+use define_conversion;
+
 /// Maps elements of one sequence and produces the other.
 ///
 /// This is a convenience function for `Vec<T> → Vec<U>` operation (though it
@@ -121,8 +123,6 @@ impl NonEmptyExt for alloc::string::String {
 		}
 	}
 }
-
-use define_conversion;
 
 impl<T> NonEmptyExt for alloc::vec::Vec<T> {
 	type Output = Self;

--- a/code/xcvm/lib/core/src/proto/common.rs
+++ b/code/xcvm/lib/core/src/proto/common.rs
@@ -12,6 +12,18 @@ impl From<u128> for pb::common::Uint128 {
 	}
 }
 
+impl From<pb::common::Uint128> for crate::AssetId {
+	fn from(value: pb::common::Uint128) -> Self {
+		u128::from(value).into()
+	}
+}
+
+impl From<crate::AssetId> for pb::common::Uint128 {
+	fn from(value: crate::AssetId) -> Self {
+		u128::from(value).into()
+	}
+}
+
 #[test]
 fn test_u128_uint128_conversion() {
 	let value = 0xDEAD_0000_0000_0000_BEEF_0000_0000_0000_u128;

--- a/code/xcvm/lib/core/src/proto/result.rs
+++ b/code/xcvm/lib/core/src/proto/result.rs
@@ -1,0 +1,63 @@
+use super::{Isomorphism, NonEmptyExt};
+use prost::Message;
+
+/// A generic definition of a protocol message with an Ok and Err variants.
+#[derive(Clone, PartialEq, Message)]
+pub struct ResultMessage<T: Default + Send + Sync + Message, E: Default + Send + Sync + Message> {
+	#[prost(oneof = "ResultEnum", tags = "1, 2")]
+	pub result: core::option::Option<ResultEnum<T, E>>,
+}
+
+/// Nested enum type in [`ResultMessage`].
+#[derive(Clone, PartialEq, prost::Oneof)]
+pub enum ResultEnum<T: Default + Send + Sync + Message, E: Default + Send + Sync + Message> {
+	#[prost(message, tag = "1")]
+	Ok(T),
+	#[prost(message, tag = "2")]
+	Err(E),
+}
+
+impl<T, E> Isomorphism for Result<T, E>
+where
+	T: Isomorphism,
+	T::Message: Default + Send + Sync + TryInto<T> + From<T>,
+	E: Isomorphism,
+	E::Message: Default + Send + Sync + TryInto<E> + From<E>,
+{
+	type Message = ResultMessage<T::Message, E::Message>;
+}
+
+impl<T: Isomorphism, E: Isomorphism> TryFrom<ResultMessage<T::Message, E::Message>>
+	for Result<T, E>
+{
+	type Error = ();
+	fn try_from(result: ResultMessage<T::Message, E::Message>) -> Result<Self, Self::Error> {
+		match result.result.non_empty()? {
+			ResultEnum::Ok(ok) => Ok(Ok(ok.try_into().map_err(|_| ())?)),
+			ResultEnum::Err(ok) => Ok(Err(ok.try_into().map_err(|_| ())?)),
+		}
+	}
+}
+
+impl<T: Isomorphism, E: Isomorphism> From<Result<T, E>> for ResultMessage<T::Message, E::Message> {
+	fn from(result: Result<T, E>) -> Self {
+		let result = match result {
+			Ok(ok) => ResultEnum::Ok(ok.into()),
+			Err(err) => ResultEnum::Err(err.into()),
+		};
+		Self { result: Some(result) }
+	}
+}
+
+#[test]
+fn test_encoding() {
+	let want = Result::<String, String>::Ok("ok".into());
+	let encoded = want.clone().encode();
+	let got = Result::<String, String>::decode(encoded.as_slice()).unwrap();
+	assert_eq!(want, got);
+
+	let want = Result::<String, String>::Err("err".into());
+	let encoded = want.clone().encode();
+	let got = Result::<String, String>::decode(encoded.as_slice()).unwrap();
+	assert_eq!(want, got);
+}

--- a/code/xcvm/lib/core/src/proto/xcvm.rs
+++ b/code/xcvm/lib/core/src/proto/xcvm.rs
@@ -379,12 +379,10 @@ super::define_conversion! {
 		use pb::xcvm::balance::BalanceType;
 		let (amount, is_unit) = match balance.balance_type.non_empty()? {
 			BalanceType::Ratio(pb::xcvm::Ratio { nominator, denominator }) => {
-				let ratio = Amount::from((nominator, denominator));
-				(ratio.into(), false)
+				(Amount::from((nominator, denominator)), false)
 			},
 			BalanceType::Absolute(pb::xcvm::Absolute { value }) => {
-				let value = value.non_empty()?;
-				(Amount::absolute(value.into()), false)
+				(Amount::absolute(value.non_empty()?.into()), false)
 			},
 			BalanceType::Unit(unit) => {
 				let integer = unit.integer.non_empty()?;

--- a/code/xcvm/lib/core/src/proto/xcvm.rs
+++ b/code/xcvm/lib/core/src/proto/xcvm.rs
@@ -23,9 +23,10 @@ pub type XCVMProgram<TAbiEncoded, TAccount, TAssets> =
 impl<TAbiEncoded, TAccount, TAssets> super::Isomorphism
 	for XCVMPacket<TAbiEncoded, TAccount, TAssets>
 where
-	TAbiEncoded: Into<Vec<u8>>,
-	TAccount: Into<Vec<u8>>,
-	TAssets: Into<Vec<(crate::AssetId, crate::Balance)>>,
+	TAbiEncoded: TryFrom<Vec<u8>> + Into<Vec<u8>>,
+	TAccount: TryFrom<Vec<u8>> + Into<Vec<u8>>,
+	TAssets:
+		From<Vec<(crate::AssetId, crate::Balance)>> + Into<Vec<(crate::AssetId, crate::Balance)>>,
 {
 	type Message = pb::xcvm::Packet;
 }
@@ -33,9 +34,10 @@ where
 impl<TAbiEncoded, TAccount, TAssets> super::Isomorphism
 	for XCVMProgram<TAbiEncoded, TAccount, TAssets>
 where
-	TAbiEncoded: Into<Vec<u8>>,
-	TAccount: Into<Vec<u8>>,
-	TAssets: Into<Vec<(crate::AssetId, crate::Balance)>>,
+	TAbiEncoded: TryFrom<Vec<u8>> + Into<Vec<u8>>,
+	TAccount: TryFrom<Vec<u8>> + Into<Vec<u8>>,
+	TAssets:
+		From<Vec<(crate::AssetId, crate::Balance)>> + Into<Vec<(crate::AssetId, crate::Balance)>>,
 {
 	type Message = pb::xcvm::Program;
 }


### PR DESCRIPTION
Note that this is a breaking change.  Protobuf message definition as
well as serde definition of XCVM program and packets are changed.

1. Simplify protobuf definitions by removing wrapping types.  It’s not
protobuf style to have messages with just one flied (such as AssetId)
where instead the field can be used directly.  Removing those shortens
the protocol buffer and removes some of the conversion code.

2. Replace Self, Tip, Result and IpRegister BindingValues with
a single registry field and a corresponding Registry enum.  This
mirrors the way Rust types are defined and again simplifies conversion
code.

3. Rename `id` to `exchange_id` in instruction::Exchange and `network`
to `network_id` in instruction::Spawn.  This makes it more consistent
with protobuf messages as well as other types which use `foo_id` for
identifier fields.  This change affects serde.

4. Rename handful of fields in protobuf from camelCase to snake_case
as per the protobuf style guide.  This doesn’t change the Rust code.


Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
