### PR TITLE
feat(xcvm): simplify apply_bindings function

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -6632,9 +6632,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-dependencies = [
- "spin 0.5.2",
-]
 
 [[package]]
 name = "lazycell"
@@ -12050,7 +12047,6 @@ dependencies = [
  "cosmwasm-std",
  "frame-support",
  "ibc 0.43.1",
- "lazy_static",
  "parity-scale-codec",
  "scale-info",
  "serde",

--- a/code/xcvm/lib/core/src/instruction.rs
+++ b/code/xcvm/lib/core/src/instruction.rs
@@ -92,6 +92,7 @@ pub enum Instruction<Payload, Account, Assets> {
 }
 
 /// Error types for late binding operation
+#[derive(Clone, Debug, PartialEq)]
 pub enum LateBindingError<E> {
 	/// Provided late-binding is invalid
 	InvalidBinding,
@@ -104,70 +105,114 @@ pub enum LateBindingError<E> {
 /// * `payload`: Payload that is suitable for late-binding operation. Note that this API has no
 ///   assumption on the payload format or structure at all. It will only put the binding values in
 ///   the corresponding indices. If the payload were to be JSON, and `to` key supposed to have
-///   late-binding, the payload would probably look similar to this:
-/// ```{ "from": "address", "to": "" }```
-/// * `bindings`: **SORTED** and **UNIQUE** (in-terms of index) binding index-value pairs.
-/// * `formatted_payload`: Output payload. This should have enough size to contain the final data.
-/// * `binding_data`: Callback function that gives the binding data corresponding to a binding value.
-pub fn apply_bindings<'a, F, E>(
+///   late-binding, the payload would probably look similar to this: `{ "from": "address", "to": ""
+///   }`
+/// * `bindings`: **Sorted** by index binding index-value pairs.
+/// * `binding_data`: Callback function that gives the binding data corresponding to a binding
+///   value.
+pub fn apply_bindings<'a, E>(
 	payload: Vec<u8>,
-	bindings: Bindings,
-	formatted_payload: &mut Vec<u8>,
-	binding_data: F,
-) -> Result<(), LateBindingError<E>>
-where
-	F: Fn(BindingValue) -> Result<Cow<'a, [u8]>, E>,
-{
-	// Current index of the unformatted call
-	let mut original_index: usize = 0;
-	// This stores the amount of shifting we caused because of the data insertion. For example,
-	// inserting a contract address "addr1234" causes 8 chars of shift. Which means index 'X' in
-	// the unformatted call, will be equal to 'X + 8' in the output call.
-	let mut offset: usize = 0;
-	for (binding_index, binding) in bindings {
-		let binding_index = binding_index as usize;
-		// Current index of the output call
-		let shifted_index = original_index + offset;
+	bindings: &[(u32, BindingValue)],
+	binding_data: impl Fn(&BindingValue) -> Result<Cow<'a, [u8]>, E>,
+) -> Result<Vec<u8>, LateBindingError<E>> {
+	if bindings.is_empty() {
+		return Ok(payload)
+	}
 
-		// Check for overflow
-		// * No need to check if `shifted_index` > `binding_index + offset` because `original_index
-		//   > binding_index` already guarantees that
-		// * No need to check if `shifted_index < formatted_call.len()` because initial allocation
-		//   of `formatted_call` guarantees that even the max length can fit in.
-		// * No need to check if `original_index < encoded_call.len()` because `original_index` is
-		//   already less or equals to `binding_index` and we check if `binding_index` is in-bounds.
-		if original_index > binding_index || binding_index + 1 >= payload.len() {
+	// Estimate the maximum length of the payload.  It’s ok if we don’t get this
+	// right.  If our estimate is too large we’re just waste some bytes; if it’s
+	// too small we’ll need to reallocate.  We could go through the bindings an
+	// calculate their lengths but for now we’re assuming this estimate is
+	// enough.
+	let this_len = binding_data(&BindingValue::Register(Register::This))
+		.map_err(LateBindingError::App)?
+		.len();
+	let capacity = bindings.len() * this_len + payload.len();
+	let mut output = Vec::with_capacity(capacity);
+
+	let mut start = 0;
+	for (binding_index, binding) in bindings {
+		let binding_index =
+			usize::try_from(*binding_index).map_err(|_| LateBindingError::InvalidBinding)?;
+
+		#[allow(clippy::comparison-chain)]
+		if binding_index < start {
+			// The bindings weren’t ordered by index.
 			return Err(LateBindingError::InvalidBinding)
+		} else if binding_index > start {
+			// Copy literal part from the template payload.
+			let literal =
+				payload.get(start..binding_index).ok_or(LateBindingError::InvalidBinding)?;
+			output.extend_from_slice(literal);
+			start = binding_index;
 		}
 
-		// Copy everything until the index of where binding happens from original call
-		// to formatted call. Eg.
-		// Formatted call: `{ "hello": "" }`
-		// Output call supposed to be: `{ "hello": "contract_addr" }`
-		// In the first iteration, this will copy `{ "hello": "` to the formatted call.
-		// SAFETY:
-		//     - Two slices are in the same size for sure because `shifted_index` is
-		//		 `original_index + offset` and `binding_index + offset - (shifted_index)`
-		//       equals to `binding_index - original_index`.
-		//     - Index accesses should not fail because we check if all indices are inbounds and
-		//       also if `shifted` and `original` indices are greater than `binding_index`
-		formatted_payload[shifted_index..=binding_index + offset]
-			.copy_from_slice(&payload[original_index..=binding_index]);
-
+		// Resolve the binding and insert it next.
 		let data: Cow<[u8]> = binding_data(binding).map_err(LateBindingError::App)?;
-
-		formatted_payload[binding_index + offset + 1..=binding_index + offset + data.len()]
-			.copy_from_slice(&data);
-		offset += data.len();
-		original_index = binding_index + 1;
+		output.extend_from_slice(&data);
 	}
-	// Copy the rest of the data to the output data
-	if original_index < payload.len() {
-		formatted_payload[original_index + offset..payload.len() + offset]
-			.copy_from_slice(&payload[original_index..]);
-	}
-	// Get rid of the final 0's.
-	formatted_payload.truncate(payload.len() + offset);
 
-	Ok(())
+	// Copy remaining part of the template.
+	let literal = payload.get(start..).ok_or(LateBindingError::InvalidBinding)?;
+	output.extend_from_slice(literal);
+
+	Ok(output)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const FOO: BindingValue = BindingValue::Register(Register::This);
+	const BAR: BindingValue = BindingValue::Register(Register::Tip);
+	const ERR: BindingValue = BindingValue::Register(Register::Ip);
+
+	fn resolver<'a>(binding: &BindingValue) -> Result<Cow<'a, [u8]>, ()> {
+		if binding == &FOO {
+			Ok(Cow::Borrowed("foo".as_bytes()))
+		} else if binding == &BAR {
+			Ok(Cow::Owned("bar".as_bytes().to_vec()))
+		} else {
+			Err(())
+		}
+	}
+
+	fn apply(
+		template: &str,
+		bindings: &[(u32, BindingValue)],
+	) -> Result<String, LateBindingError<()>> {
+		let template = template.as_bytes().to_vec();
+		apply_bindings(template, bindings, resolver)
+			.map(|payload| String::from_utf8(payload).unwrap())
+	}
+
+	#[track_caller]
+	fn check_ok(want: &str, template: &str, bindings: &[(u32, BindingValue)]) {
+		let got = apply(template, bindings);
+		assert_eq!(Ok(want), got.as_deref())
+	}
+
+	#[track_caller]
+	fn check_err(want: LateBindingError<()>, template: &str, bindings: &[(u32, BindingValue)]) {
+		assert_eq!(Err(want), apply(template, bindings))
+	}
+
+	#[test]
+	fn test_apply_bindings_success() {
+		check_ok("", "", &[]);
+		check_ok("foo", "", &[(0, FOO.clone())]);
+		check_ok("<foo>", "<>", &[(1, FOO.clone())]);
+		check_ok("<foobar>", "<>", &[(1, FOO.clone()), (1, BAR.clone())]);
+	}
+
+	#[test]
+	fn test_apply_bindings_failure() {
+		// Index beyond template’s length
+		check_err(LateBindingError::InvalidBinding, "", &[(1, FOO.clone())]);
+		check_err(LateBindingError::InvalidBinding, "", &[(0, FOO.clone()), (1, BAR.clone())]);
+		// Failure in resolution.
+		check_err(LateBindingError::App(()), "", &[(0, ERR.clone())]);
+		// Bindings not in sorted order.
+		check_err(LateBindingError::InvalidBinding, "<>", &[(1, FOO.clone()), (0, BAR.clone())]);
+	}
 }

--- a/code/xcvm/lib/core/src/lib.rs
+++ b/code/xcvm/lib/core/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::comparison_chain)]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(
 	not(test),


### PR DESCRIPTION
Rather than dealing with pre-initialised buffer and having to track
indexes when setting data in the output payload, change the
apply_bindings function to append data into a vector which does index
tracking by itself.  This removes offset tracking from the function
simplifying it.  With that, change the function so it no longer takes
output vector as argument but rather allocates vector internally.

While changing the apply_bindings function in xc_core also change how
it’s used in the interpreter contract refactoring the code
slightly. Part of it is a consequence of changing the signature of the
apply_binding function but partially it’s just refactoring splitting
functions into smaller, more manageable chunks.


Required for merge:
- [x] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf)

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes
- Adding detailed description of changes when it feels appropriate (for example when PR is big)
