### PR TITLE
docs(config): Adding KaTeX config support to docsaurus config

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -4,6 +4,12 @@
 const lightCodeTheme = require('prism-react-renderer/themes/duotoneLight');
 const darkCodeTheme = require('prism-react-renderer/themes/duotoneDark');
 
+// Adding KaTeX config according to https://docusaurus.io/docs/markdown-features/math-equations
+
+const math = require('remark-math');
+const katex = require('rehype-katex');
+
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
 	title: 'Composable Finance',
@@ -39,6 +45,8 @@ const config = {
 					// Please change this to your repo.
 					// Remove this to remove the "edit this page" links.
 					editUrl: 'https://github.com/ComposableFi/composable/tree/main/docs/',
+					remarkPlugins: [math],
+					rehypePlugins: [katex],
 				},
 				blog: false,
 				theme: {
@@ -48,6 +56,16 @@ const config = {
 		],
 	],
 
+    stylesheets: [
+		{
+		  href: 'https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css',
+		  type: 'text/css',
+		  integrity:
+			'sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM',
+		  crossorigin: 'anonymous',
+		},
+	  ],
+	  
 	themeConfig:
 		/** @type {import('@docusaurus/preset-classic').ThemeConfig} */
 		({


### PR DESCRIPTION
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [x] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

