### PR TITLE
feat(ibc): Only allow `forward` and `wasm` middlewares to be used in IBC memo

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -8613,7 +8613,6 @@ source = "git+https://github.com/ComposableFi/substrate?rev=c74d73bfe1e4f725b3f7
 dependencies = [
  "frame-support",
  "frame-system",
- "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "beefy-light-client-primitives",
  "ckb-merkle-mountain-range 0.3.2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "ckb-merkle-mountain-range 0.3.2",
  "derive_more 0.99.17",
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-verifier"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "anyhow",
  "finality-grandpa",
@@ -5543,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.15.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "derive_more 0.99.17",
  "flex-error",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-crate 1.3.1",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "base58",
  "blake2",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.18.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.4.0",
@@ -5680,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "ibc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "frame-system",
  "hex-literal",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "ibc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "ibc-primitives",
  "pallet-ibc",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "ics07-tendermint"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "bytes 1.4.0",
  "flex-error",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "ics08-wasm"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "hex",
  "ibc 0.15.0",
@@ -5753,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "ics10-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "ics11-beefy"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "anyhow",
  "beefy-light-client",
@@ -7228,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "light-client-common"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "beefy-light-client-primitives",
  "cumulus-primitives-core",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc-ping"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15111,7 +15111,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 [[package]]
 name = "simple-iavl"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
 dependencies = [
  "bytes 1.4.0",
  "ics23 0.10.0",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "composable"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "color-eyre",
  "composable-node",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "composable-node"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "assets-rpc",
  "assets-runtime-api",
@@ -1914,7 +1914,7 @@ dependencies = [
 
 [[package]]
 name = "composable-runtime"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "assets-runtime-api",
  "common",
@@ -2003,7 +2003,7 @@ dependencies = [
 
 [[package]]
 name = "composable-runtime-wasm"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "composable-runtime",
 ]
@@ -10513,7 +10513,7 @@ dependencies = [
 
 [[package]]
 name = "picasso-runtime"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "assets-runtime-api",
  "common",
@@ -10618,7 +10618,7 @@ dependencies = [
 
 [[package]]
 name = "picasso-runtime-wasm"
-version = "9.10038.2"
+version = "9.10039.0"
 dependencies = [
  "picasso-runtime",
 ]

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -17420,7 +17420,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.9.0",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",
@@ -17622,7 +17622,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.6.5",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "beefy-light-client-primitives",
  "ckb-merkle-mountain-range 0.3.2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "ckb-merkle-mountain-range 0.3.2",
  "derive_more 0.99.17",
@@ -1774,6 +1774,7 @@ dependencies = [
  "pallet-balances",
  "pallet-collator-selection",
  "pallet-collective",
+ "pallet-ibc",
  "pallet-sudo",
  "pallet-treasury",
  "parity-scale-codec",
@@ -5082,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5104,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-verifier"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "anyhow",
  "finality-grandpa",
@@ -5542,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.15.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "derive_more 0.99.17",
  "flex-error",
@@ -5602,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-crate 1.3.1",
@@ -5626,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "base58",
  "blake2",
@@ -5650,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.18.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.4.0",
@@ -5679,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "ibc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "frame-system",
  "hex-literal",
@@ -5706,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "ibc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "ibc-primitives",
  "pallet-ibc",
@@ -5718,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "ics07-tendermint"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "bytes 1.4.0",
  "flex-error",
@@ -5740,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "ics08-wasm"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "hex",
  "ibc 0.15.0",
@@ -5752,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "ics10-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5778,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "ics11-beefy"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "anyhow",
  "beefy-light-client",
@@ -7227,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "light-client-common"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8612,6 +8613,7 @@ source = "git+https://github.com/ComposableFi/substrate?rev=c74d73bfe1e4f725b3f7
 dependencies = [
  "frame-support",
  "frame-system",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -9201,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "beefy-light-client-primitives",
  "cumulus-primitives-core",
@@ -9254,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc-ping"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15109,7 +15111,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 [[package]]
 name = "simple-iavl"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/centauri?rev=629eb0da075350ae514bacfde70e15a1c93debd7#629eb0da075350ae514bacfde70e15a1c93debd7"
+source = "git+https://github.com/ComposableFi/centauri?rev=5a738a74d1680a2504984a24d179edd6237b1daa#5a738a74d1680a2504984a24d179edd6237b1daa"
 dependencies = [
  "bytes 1.4.0",
  "ics23 0.10.0",
@@ -17418,7 +17420,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.9.0",
+ "parking_lot 0.11.2",
  "regex",
  "serde",
  "serde_json",
@@ -17620,7 +17622,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.6.5",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -8988,6 +8988,7 @@ dependencies = [
 name = "pallet-custom-origins"
 version = "1.0.0"
 dependencies = [
+ "frame-benchmarking",
  "frame-support",
  "frame-system",
  "parity-scale-codec",

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -8613,6 +8613,7 @@ source = "git+https://github.com/ComposableFi/substrate?rev=c74d73bfe1e4f725b3f7
 dependencies = [
  "frame-support",
  "frame-system",
+ "log 0.4.19",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -17419,7 +17420,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.9.0",
  "regex",
  "serde",
  "serde_json",
@@ -17621,7 +17622,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -895,7 +895,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "beefy-light-client-primitives",
  "ckb-merkle-mountain-range 0.3.2",
@@ -918,7 +918,7 @@ dependencies = [
 [[package]]
 name = "beefy-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "ckb-merkle-mountain-range 0.3.2",
  "derive_more 0.99.17",
@@ -5083,7 +5083,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5105,7 +5105,7 @@ dependencies = [
 [[package]]
 name = "grandpa-light-client-verifier"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "anyhow",
  "finality-grandpa",
@@ -5543,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "ibc"
 version = "0.15.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "derive_more 0.99.17",
  "flex-error",
@@ -5603,7 +5603,7 @@ dependencies = [
 [[package]]
 name = "ibc-derive"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro-crate 1.3.1",
@@ -5627,7 +5627,7 @@ dependencies = [
 [[package]]
 name = "ibc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "base58",
  "blake2",
@@ -5651,7 +5651,7 @@ dependencies = [
 [[package]]
 name = "ibc-proto"
 version = "0.18.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "base64 0.13.1",
  "bytes 1.4.0",
@@ -5680,7 +5680,7 @@ dependencies = [
 [[package]]
 name = "ibc-rpc"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "frame-system",
  "hex-literal",
@@ -5707,7 +5707,7 @@ dependencies = [
 [[package]]
 name = "ibc-runtime-api"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "ibc-primitives",
  "pallet-ibc",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "ics07-tendermint"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "bytes 1.4.0",
  "flex-error",
@@ -5741,7 +5741,7 @@ dependencies = [
 [[package]]
 name = "ics08-wasm"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "hex",
  "ibc 0.15.0",
@@ -5753,7 +5753,7 @@ dependencies = [
 [[package]]
 name = "ics10-grandpa"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "anyhow",
  "derive_more 0.99.17",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "ics11-beefy"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "anyhow",
  "beefy-light-client",
@@ -7228,7 +7228,7 @@ dependencies = [
 [[package]]
 name = "light-client-common"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9203,7 +9203,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "beefy-light-client-primitives",
  "cumulus-primitives-core",
@@ -9256,7 +9256,7 @@ dependencies = [
 [[package]]
 name = "pallet-ibc-ping"
 version = "0.0.1"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -15111,7 +15111,7 @@ checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
 [[package]]
 name = "simple-iavl"
 version = "0.1.0"
-source = "git+https://github.com/ComposableFi/composable-ibc?rev=c761976863f2e73824b3eaac2a1759c7d797721a#c761976863f2e73824b3eaac2a1759c7d797721a"
+source = "git+https://github.com/ComposableFi/composable-ibc?rev=1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a#1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a"
 dependencies = [
  "bytes 1.4.0",
  "ics23 0.10.0",
@@ -17420,7 +17420,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.9.0",
  "regex",
  "serde",
  "serde_json",
@@ -17622,7 +17622,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand 0.6.5",
  "static_assertions",
 ]
 

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -124,11 +124,11 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 
-ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
-ibc-rpc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
-ibc-primitives = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
-ibc-runtime-api = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
-pallet-ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
+ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a", default-features = false }
+ibc-rpc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a", default-features = false }
+ibc-primitives = { git = "https://github.com/ComposableFi/composable-ibc", rev = "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a", default-features = false }
+ibc-runtime-api = { git = "https://github.com/ComposableFi/composable-ibc", rev = "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a", default-features = false }
+pallet-ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a", default-features = false }
 
 xcm-builder = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -124,11 +124,11 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 
-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "629eb0da075350ae514bacfde70e15a1c93debd7", default-features = false }
-ibc-rpc = { git = "https://github.com/ComposableFi/centauri", rev = "629eb0da075350ae514bacfde70e15a1c93debd7", default-features = false }
-ibc-primitives = { git = "https://github.com/ComposableFi/centauri", rev = "629eb0da075350ae514bacfde70e15a1c93debd7", default-features = false }
-ibc-runtime-api = { git = "https://github.com/ComposableFi/centauri", rev = "629eb0da075350ae514bacfde70e15a1c93debd7", default-features = false }
-pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "629eb0da075350ae514bacfde70e15a1c93debd7", default-features = false }
+ibc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
+ibc-rpc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
+ibc-primitives = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
+ibc-runtime-api = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
+pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
 
 xcm-builder = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -124,11 +124,11 @@ orml-xcm-support = { git = "https://github.com/open-web3-stack/open-runtime-modu
 orml-xtokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 orml-tokens = { git = "https://github.com/open-web3-stack/open-runtime-module-library", rev = "a0751540591c88ccc2d4029464de887933727183", default-features = false }
 
-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
-ibc-rpc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
-ibc-primitives = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
-ibc-runtime-api = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
-pallet-ibc = { git = "https://github.com/ComposableFi/centauri", rev = "5a738a74d1680a2504984a24d179edd6237b1daa", default-features = false }
+ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
+ibc-rpc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
+ibc-primitives = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
+ibc-runtime-api = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
+pallet-ibc = { git = "https://github.com/ComposableFi/composable-ibc", rev = "c761976863f2e73824b3eaac2a1759c7d797721a", default-features = false }
 
 xcm-builder = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }
 polkadot-primitives = { git = "https://github.com/paritytech/polkadot", rev = "c22e1c4173bf6966f5d1980f4299f7abe836f0c1", default-features = false }

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -6,7 +6,7 @@ name = "composable"
 version = { workspace = true }
 
 [workspace.package]
-version = "9.10038.2"
+version = "9.10039.0"
 
 [[bin]]
 name = "composable"

--- a/code/parachain/frame/origins/Cargo.toml
+++ b/code/parachain/frame/origins/Cargo.toml
@@ -18,6 +18,7 @@ version = "3.0.0"
 [dependencies]
 frame-support = { default-features = false, workspace = true }
 frame-system = { default-features = false, workspace = true }
+frame-benchmarking = { default-features = false, optional = true, workspace = true }
 
 scale-info = { version = "2.1.1", default-features = false, features = [
   "derive",
@@ -30,6 +31,11 @@ sp-std = { default-features = false, workspace = true }
 
 [features]
 default = ["std"]
+runtime-benchmarks = [
+  "frame-benchmarking",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+]
 std = [
   "frame-support/std",
   "frame-system/std",

--- a/code/parachain/frame/origins/Cargo.toml
+++ b/code/parachain/frame/origins/Cargo.toml
@@ -39,7 +39,7 @@ runtime-benchmarks = [
 std = [
   "frame-support/std",
   "frame-system/std",
-  frame-benchmarking/std,
+  "frame-benchmarking/std",
   "sp-runtime/std",
   "sp-io/std",
   "sp-core/std",

--- a/code/parachain/frame/origins/Cargo.toml
+++ b/code/parachain/frame/origins/Cargo.toml
@@ -39,6 +39,7 @@ runtime-benchmarks = [
 std = [
   "frame-support/std",
   "frame-system/std",
+  frame-benchmarking/std,
   "sp-runtime/std",
   "sp-io/std",
   "sp-core/std",

--- a/code/parachain/runtime/common/Cargo.toml
+++ b/code/parachain/runtime/common/Cargo.toml
@@ -49,6 +49,7 @@ ibc-rs-scale = { workspace = true, default-features = false, features = [
   "parity-scale-codec",
   "serde",
 ] }
+pallet-ibc = { workspace = true, default-features = false }
 
 cosmwasm-std = { workspace = true, default-features = false, features = [
   "ibc3",
@@ -86,6 +87,7 @@ std = [
   "ibc-rs-scale/std",
   "orml-tokens/std",
   "orml-traits/std",
+  "pallet-ibc/std",
   "polkadot-primitives/std",
   "primitives/std",
   "scale-info/std",

--- a/code/parachain/runtime/common/src/ibc.rs
+++ b/code/parachain/runtime/common/src/ibc.rs
@@ -1,11 +1,13 @@
 use codec::{Decode, Encode};
 use composable_traits::{prelude::Deserialize, xcm::assets::RemoteAssetRegistryInspect};
-use core::fmt::{Display, Formatter};
+use core::{
+	convert::Infallible,
+	fmt::{Display, Formatter},
+};
 use pallet_ibc::ics20::{MemoData, ValidateMemo};
 use primitives::currency::{ForeignAssetId, PrefixedDenom};
 use scale_info::TypeInfo;
 use sp_core::ConstU64;
-use std::convert::Infallible;
 
 use crate::prelude::*;
 

--- a/code/parachain/runtime/common/src/ibc.rs
+++ b/code/parachain/runtime/common/src/ibc.rs
@@ -1,6 +1,11 @@
-use composable_traits::xcm::assets::RemoteAssetRegistryInspect;
+use codec::{Decode, Encode};
+use composable_traits::{prelude::Deserialize, xcm::assets::RemoteAssetRegistryInspect};
+use core::fmt::{Display, Formatter};
+use pallet_ibc::ics20::{MemoData, ValidateMemo};
 use primitives::currency::{ForeignAssetId, PrefixedDenom};
+use scale_info::TypeInfo;
 use sp_core::ConstU64;
+use std::convert::Infallible;
 
 use crate::prelude::*;
 
@@ -31,3 +36,124 @@ where
 }
 
 pub type MinimumConnectionDelaySeconds = ConstU64<10>;
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "snake_case")]
+pub enum MemoMiddlewareNamespaceChain {
+	Forward { next: Option<Box<Self>> },
+	Wasm { next: Option<Box<Self>> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Default, Encode, Decode, TypeInfo)]
+pub struct RawMemo(pub String);
+
+impl FromStr for RawMemo {
+	type Err = Infallible;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(Self(s.to_string()))
+	}
+}
+
+impl TryFrom<MemoData> for RawMemo {
+	type Error = <String as TryFrom<MemoData>>::Error;
+
+	fn try_from(value: MemoData) -> Result<Self, Self::Error> {
+		Ok(Self(value.try_into()?))
+	}
+}
+
+impl TryFrom<RawMemo> for MemoData {
+	type Error = <MemoData as TryFrom<String>>::Error;
+
+	fn try_from(value: RawMemo) -> Result<Self, Self::Error> {
+		Ok(value.0.try_into()?)
+	}
+}
+
+impl Display for RawMemo {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.0)
+	}
+}
+
+impl ValidateMemo for RawMemo {
+	fn validate(&self) -> Result<(), String> {
+		// the MiddlewareNamespaceChain type contains all the supported middlewares
+		serde_json_wasm::from_str::<MemoMiddlewareNamespaceChain>(&self.0)
+			.map(|| ())
+			.map_err(ToString::to_string)
+	}
+}
+
+#[test]
+fn test_memo_validation() {
+	let memo = r#"{
+	   "forward":{
+		  "receiver":"osmo1uj22h9ksaykwvr33psnq5dhk9f48zsvnyuxr68ryuhlu3jucrqctyh2vq0",
+		  "port":"transfer",
+		  "channel":"channel-0",
+		  "next":{
+			 "wasm":{
+				"contract":"osmo1usnq5dhk9f48zsvnyuxqctyh2vq0r68ryuhluj22h9ksaykwvr33p3jucr",
+				"msg":{
+				   "execute_swap_operations":{
+					  "minimum_receive":"60325",
+					  "routes":[
+						 {
+							"offer_amount":"5812128242124",
+							"operations":[
+							   {
+								  "t_f_m_swap":{
+									 "pool_id":351,
+									 "offer_asset_info":{
+										"native_token":{
+										   "denom":"ibc/F3AE996E091BD322EDD14C27CF37E05AEE4C1E66D7C03B8F6A3E0AC59725107A"
+										}
+									 },
+									 "ask_asset_info":{
+										"native_token":{
+										   "denom":"uosmo"
+										}
+									 }
+								  }
+							   },
+							   {
+								  "t_f_m_swap":{
+									 "pool_id":1,
+									 "offer_asset_info":{
+										"native_token":{
+										   "denom":"uosmo"
+										}
+									 },
+									 "ask_asset_info":{
+										"native_token":{
+										   "denom":"ibc/4C1F92EEB2527374F36EF416001CEADA9CA97CCD56123CE5EB2A62294FB092D2"
+										}
+									 }
+								  }
+							   }
+							]
+						 }
+					  ],
+					  "to":"osmo1z0yde9mnpvreulck3ue0umfxfr7pst9h5yffaf"
+				   }
+				}
+			 }
+		  }
+	   }
+	}"#;
+	assert_eq!(RawMemo(memo.to_string()).validate(), Ok(()));
+
+	let memo = r#"{
+	   "forward":{
+		  "receiver":"osmo1uj22h9ksaykwvr33psnq5dhk9f48zsvnyuxr68ryuhlu3jucrqctyh2vq0",
+		  "port":"transfer",
+		  "channel":"channel-0",
+		  "next":{
+			 "unknown":{}
+		  }
+	   }
+	}"#;
+	assert_eq!(RawMemo(memo.to_string()).validate(), Err(()));
+}

--- a/code/parachain/runtime/common/src/ibc.rs
+++ b/code/parachain/runtime/common/src/ibc.rs
@@ -81,8 +81,8 @@ impl ValidateMemo for RawMemo {
 	fn validate(&self) -> Result<(), String> {
 		// the MiddlewareNamespaceChain type contains all the supported middlewares
 		serde_json_wasm::from_str::<MemoMiddlewareNamespaceChain>(&self.0)
-			.map(|| ())
-			.map_err(ToString::to_string)
+			.map(|_| ())
+			.map_err(|x| x.to_string())
 	}
 }
 
@@ -155,5 +155,8 @@ fn test_memo_validation() {
 		  }
 	   }
 	}"#;
-	assert_eq!(RawMemo(memo.to_string()).validate(), Err(()));
+	assert_eq!(
+		RawMemo(memo.to_string()).validate(),
+		Err("unknown variant `unknown`, expected `forward` or `wasm`".to_string())
+	);
 }

--- a/code/parachain/runtime/composable/Cargo.toml
+++ b/code/parachain/runtime/composable/Cargo.toml
@@ -156,6 +156,10 @@ runtime-benchmarks = [
   "pallet-ibc/runtime-benchmarks",
   "pallet-proxy/runtime-benchmarks",
   "asset-tx-payment/runtime-benchmarks",
+  "pallet-referenda/runtime-benchmarks",
+  "pallet-conviction-voting/runtime-benchmarks",
+  "pallet-whitelist/runtime-benchmarks",
+  "pallet-custom-origins/runtime-benchmarks",
 ]
 std = [
   "asset-tx-payment/std",

--- a/code/parachain/runtime/composable/Cargo.toml
+++ b/code/parachain/runtime/composable/Cargo.toml
@@ -156,10 +156,6 @@ runtime-benchmarks = [
   "pallet-ibc/runtime-benchmarks",
   "pallet-proxy/runtime-benchmarks",
   "asset-tx-payment/runtime-benchmarks",
-  "pallet-referenda/runtime-benchmarks",
-  "pallet-conviction-voting/runtime-benchmarks",
-  "pallet-whitelist/runtime-benchmarks",
-  "pallet-custom-origins/runtime-benchmarks",
 ]
 std = [
   "asset-tx-payment/std",

--- a/code/parachain/runtime/composable/Cargo.toml
+++ b/code/parachain/runtime/composable/Cargo.toml
@@ -159,6 +159,7 @@ runtime-benchmarks = [
   "pallet-referenda/runtime-benchmarks",
   "pallet-conviction-voting/runtime-benchmarks",
   "pallet-whitelist/runtime-benchmarks",
+  "pallet-custom-origins/runtime-benchmarks",
 ]
 std = [
   "asset-tx-payment/std",

--- a/code/parachain/runtime/composable/src/ibc.rs
+++ b/code/parachain/runtime/composable/src/ibc.rs
@@ -28,7 +28,7 @@ impl Default for Runtime {
 	}
 }
 
-use common::ibc::ForeignIbcIcs20Assets;
+use common::ibc::{ForeignIbcIcs20Assets, RawMemo};
 pub struct IbcDenomToAssetIdConversion;
 
 impl DenomToAssetId<Runtime> for IbcDenomToAssetIdConversion {
@@ -173,7 +173,7 @@ impl pallet_ibc::Config for Runtime {
 	#[cfg(not(feature = "testnet"))]
 	type RelayerOrigin = system::EnsureSignedBy<TechnicalCommitteeMembership, Self::IbcAccountId>;
 	type HandleMemo = IbcMemoHandler<(), Runtime>;
-	type MemoMessage = alloc::string::String;
+	type MemoMessage = RawMemo;
 	type IsReceiveEnabled = ConstBool<true>;
 	type IsSendEnabled = ConstBool<true>;
 	type SubstrateMultihopXcmHandler = pallet_multihop_xcm_ibc::Pallet<Runtime>;

--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -773,9 +773,6 @@ mod benches {
 		[assets_registry, AssetsRegistry]
 		[multisig, Multisig]
 		[pallet_ibc, Ibc]
-		[whitelist, Whitelist]
-		[conviction_voting, ConvictionVoting]
-		[referenda, Referenda]
 	);
 }
 

--- a/code/parachain/runtime/composable/src/tracks.rs
+++ b/code/parachain/runtime/composable/src/tracks.rs
@@ -67,7 +67,6 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 2]
 			min_support: Curve::make_linear(30, 30, percent(0), percent(50)),
 			#[cfg(not(feature = "fastnet"))]
 			min_support: Curve::make_linear(28, 28, percent(0), percent(50)),
-			
 		},
 	),
 	(
@@ -93,13 +92,7 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 2]
 			#[cfg(not(feature = "fastnet"))]
 			min_enactment_period: 10 * MINUTES,
 			#[cfg(feature = "fastnet")]
-			min_approval: Curve::make_reciprocal(
-				1,
-				30,
-				percent(96),
-				percent(50),
-				percent(100),
-			),
+			min_approval: Curve::make_reciprocal(1, 30, percent(96), percent(50), percent(100)),
 			#[cfg(not(feature = "fastnet"))]
 			min_approval: Curve::make_reciprocal(
 				16,

--- a/code/parachain/runtime/composable/src/version.rs
+++ b/code/parachain/runtime/composable/src/version.rs
@@ -13,8 +13,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10038,
-	impl_version: 2,
+	spec_version: 10039,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 	state_version: 0,

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -197,6 +197,7 @@ runtime-benchmarks = [
   "utility/runtime-benchmarks",
   "vesting/runtime-benchmarks",
   "xcm-builder/runtime-benchmarks",
+  "pallet-custom-origins/runtime-benchmarks",
 ]
 
 std = [

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -184,6 +184,9 @@ runtime-benchmarks = [
   "oracle/runtime-benchmarks",
   "pablo/runtime-benchmarks",
   "pallet-ibc/runtime-benchmarks",
+  "pallet-referenda/runtime-benchmarks",
+  "pallet-conviction-voting/runtime-benchmarks",
+  "pallet-whitelist/runtime-benchmarks",
   "pallet-xcm/runtime-benchmarks",
   "proxy/runtime-benchmarks",
   "scheduler/runtime-benchmarks",
@@ -194,6 +197,7 @@ runtime-benchmarks = [
   "utility/runtime-benchmarks",
   "vesting/runtime-benchmarks",
   "xcm-builder/runtime-benchmarks",
+  "pallet-custom-origins/runtime-benchmarks",
 ]
 
 std = [

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -184,9 +184,6 @@ runtime-benchmarks = [
   "oracle/runtime-benchmarks",
   "pablo/runtime-benchmarks",
   "pallet-ibc/runtime-benchmarks",
-  "pallet-referenda/runtime-benchmarks",
-  "pallet-conviction-voting/runtime-benchmarks",
-  "pallet-whitelist/runtime-benchmarks",
   "pallet-xcm/runtime-benchmarks",
   "proxy/runtime-benchmarks",
   "scheduler/runtime-benchmarks",
@@ -197,7 +194,6 @@ runtime-benchmarks = [
   "utility/runtime-benchmarks",
   "vesting/runtime-benchmarks",
   "xcm-builder/runtime-benchmarks",
-  "pallet-custom-origins/runtime-benchmarks",
 ]
 
 std = [

--- a/code/parachain/runtime/picasso/src/ibc.rs
+++ b/code/parachain/runtime/picasso/src/ibc.rs
@@ -72,6 +72,7 @@ parameter_types! {
 	pub const IbcPalletId: PalletId = PalletId(*b"cntr_ibc");
 }
 
+use common::ibc::RawMemo;
 use pallet_ibc::{ics20::IbcMemoHandler, ics20_fee::NonFlatFeeConverter};
 
 type CosmwasmRouter = cosmwasm::ibc::Router<Runtime>;
@@ -132,7 +133,7 @@ impl pallet_ibc::Config for Runtime {
 	type SpamProtectionDeposit = SpamProtectionDeposit;
 	type IbcAccountId = Self::AccountId;
 	type HandleMemo = IbcMemoHandler<xcvm_memo_processing::XcvmMemoHandler<(), Runtime>, Runtime>;
-	type MemoMessage = alloc::string::String;
+	type MemoMessage = RawMemo;
 	type SubstrateMultihopXcmHandler = pallet_multihop_xcm_ibc::Pallet<Runtime>;
 	type IsReceiveEnabled = ConstBool<true>;
 	type IsSendEnabled = ConstBool<true>;

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -950,9 +950,6 @@ mod benches {
 		[democracy, Democracy]
 		[oracle, Oracle]
 		[pallet_ibc, Ibc]
-		[whitelist, Whitelist]
-		[conviction_voting, ConvictionVoting]
-		[referenda, Referenda]
 	);
 }
 

--- a/code/parachain/runtime/picasso/src/tracks.rs
+++ b/code/parachain/runtime/picasso/src/tracks.rs
@@ -99,13 +99,7 @@ const TRACKS_DATA: [(u16, pallet_referenda::TrackInfo<Balance, BlockNumber>); 2]
 			#[cfg(not(feature = "fastnet"))]
 			min_enactment_period: 10 * MINUTES,
 			#[cfg(feature = "fastnet")]
-			min_approval: Curve::make_reciprocal(
-				1,
-				30,
-				percent(96),
-				percent(50),
-				percent(100),
-			),
+			min_approval: Curve::make_reciprocal(1, 30, percent(96), percent(50), percent(100)),
 			#[cfg(not(feature = "fastnet"))]
 			min_approval: Curve::make_reciprocal(
 				16,

--- a/code/parachain/runtime/picasso/src/version.rs
+++ b/code/parachain/runtime/picasso/src/version.rs
@@ -16,8 +16,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10038,
-	impl_version: 2,
+	spec_version: 10039,
+	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
 	state_version: 0,

--- a/flake.lock
+++ b/flake.lock
@@ -121,17 +121,17 @@
     "centauri-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1692289034,
-        "narHash": "sha256-FHAVtfe3uLTNzPbe8HqPONj6B56gb9vz7vXM0kle0ks=",
+        "lastModified": 1695265294,
+        "narHash": "sha256-Sfsrj+GvKqu/OP3dI2NvuZcHNQMZ1oVxbSb4sLfNWeE=",
         "owner": "ComposableFi",
-        "repo": "centauri",
-        "rev": "629eb0da075350ae514bacfde70e15a1c93debd7",
+        "repo": "composable-ibc",
+        "rev": "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a",
         "type": "github"
       },
       "original": {
         "owner": "ComposableFi",
-        "repo": "centauri",
-        "rev": "629eb0da075350ae514bacfde70e15a1c93debd7",
+        "repo": "composable-ibc",
+        "rev": "1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
     centauri-src = {
       flake = false;
       url =
-        "github:ComposableFi/centauri/629eb0da075350ae514bacfde70e15a1c93debd7";
+        "github:ComposableFi/composable-ibc/1b1a2ff37b2dbdd9546da62c8a0b24d0a638ce0a";
     };
   };
 


### PR DESCRIPTION
Added `MemoMiddlewareNamespaceChain` enum that specifies all the acceptable IBC packet middleware namespace. The validation is done by deserializing the memo data into the enum: if deserialization fails, then the memo is invalid or contains an unsupported middleware.

Updated composable-ibc deps to reveision: _TODO_

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [x] I marked PR by `misc` label if it should not be in release notes
- [x] Linked Zenhub/Github/Slack/etc reference if one exists
- [x] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [x] Added reviewer into `Reviewers`
- [x] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ x I have proved that PR has no general regressions of relevant features and processes required to release into production
- [x] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

