### PR TITLE
introduce xcm composable barrier to allow AllowKnownQueryResponses when querier is None.

### DIFF
--- a/code/parachain/runtime/composable/src/xcmp.rs
+++ b/code/parachain/runtime/composable/src/xcmp.rs
@@ -29,7 +29,7 @@ use xcm_builder::{
 	TakeWeightCredit,
 };
 use xcm_executor::{
-	traits::{ConvertOrigin, DropAssets, MatchesFungible},
+	traits::{ConvertOrigin, DropAssets, MatchesFungible, ShouldExecute},
 	Assets, XcmExecutor,
 };
 
@@ -72,25 +72,49 @@ impl orml_unknown_tokens::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 }
 
-pub struct AllowAll;
-impl xcm_executor::traits::ShouldExecute for AllowAll {
+pub struct AllowKnownQueryResponsesSubstituteQuerierIfNone<ResponseHandler>(
+	PhantomData<ResponseHandler>,
+);
+impl<ResponseHandler: OnResponse> ShouldExecute
+	for AllowKnownQueryResponsesSubstituteQuerierIfNone<ResponseHandler>
+{
 	fn should_execute<RuntimeCall>(
 		origin: &MultiLocation,
 		instructions: &mut [Instruction<RuntimeCall>],
 		max_weight: Weight,
 		weight_credit: &mut Weight,
 	) -> Result<(), ProcessMessageError> {
+		for i in &mut *instructions {
+			match i {
+				QueryResponse { mut querier, .. } => {
+					if querier.is_none() {
+						//need this line because querier is None
+						//and here is where it failed in pallet-xcm
+						//https://github.com/paritytech/polkadot/blob/release-v0.9.43/xcm/pallet-xcm/src/lib.rs#L2001-L2010
+						//so need to substitute it with expected querier
+						querier = Some(MultiLocation { parents: 0, interior: Here });
+					}
+				},
+				_ => {},
+			};
+		}
+
+		AllowKnownQueryResponses::<ResponseHandler>::should_execute(
+			origin,
+			instructions,
+			max_weight,
+			weight_credit,
+		)?;
 		Ok(())
 	}
 }
 
-// pub type Barrier = (
-// 	AllowAll
-// 	// TakeWeightCredit,
-// 	// AllowKnownQueryResponses<PolkadotXcm>,
-// 	// AllowSubscriptionsFrom<ParentOrSiblings>,
-// 	// AllowTopLevelPaidExecutionFrom<Everything>,
-// );
+pub type Barrier = (
+	TakeWeightCredit,
+	AllowKnownQueryResponsesSubstituteQuerierIfNone<PolkadotXcm>,
+	AllowSubscriptionsFrom<ParentOrSiblings>,
+	AllowTopLevelPaidExecutionFrom<Everything>,
+);
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
 
@@ -474,7 +498,7 @@ impl xcm_executor::Config for XcmConfig {
 	type IsReserve = MultiNativeAsset<AbsoluteReserveProvider>;
 	type IsTeleporter = ();
 	type UniversalLocation = UniversalLocation;
-	type Barrier = AllowAll;
+	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
 	type Trader = Trader; //?
 	type ResponseHandler = XcmExecutorHandler;


### PR DESCRIPTION
Introduce new struct `AllowKnownQueryResponsesSubstituteQuerierIfNone`
that replace querier if it is None to current parachain location.
 
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

