### PR TITLE
feat(oracle): run multiple offchain workers on one node

### DIFF
--- a/code/parachain/frame/oracle/src/lib.rs
+++ b/code/parachain/frame/oracle/src/lib.rs
@@ -1282,7 +1282,7 @@ pub mod pallet {
 			let public_keys: Vec<sp_core::sr25519::Public> =
 				sp_io::crypto::sr25519_public_keys(CRYPTO_KEY_TYPE);
 
-			if public_keys.len() == 0 {
+			if public_keys.is_empty() {
 				return Err("No public keys for crypto key type `orac`")
 			}
 

--- a/code/parachain/frame/oracle/src/lib.rs
+++ b/code/parachain/frame/oracle/src/lib.rs
@@ -60,8 +60,8 @@ pub mod pallet {
 	};
 	use frame_system::{
 		offchain::{
-			AppCrypto, CreateSignedTransaction, SendSignedTransaction, SignedPayload, Signer,
-			SigningTypes,
+			Account, AppCrypto, CreateSignedTransaction, SendSignedTransaction, SignedPayload,
+			Signer, SigningTypes,
 		},
 		pallet_prelude::*,
 	};
@@ -72,15 +72,14 @@ pub mod pallet {
 		offchain::{http, Duration},
 		traits::{
 			AccountIdConversion, AtLeast32Bit, AtLeast32BitUnsigned, CheckedAdd, CheckedDiv,
-			CheckedMul, CheckedSub, Saturating, UniqueSaturatedInto as _, Zero,
+			CheckedMul, CheckedSub, IdentifyAccount, Saturating, UniqueSaturatedInto as _, Zero,
 		},
 		AccountId32, ArithmeticError, FixedPointNumber, FixedU128, KeyTypeId as CryptoKeyTypeId,
-		PerThing, Percent, RuntimeDebug,
+		PerThing, Percent, RuntimeAppPublic, RuntimeDebug,
 	};
 	use sp_std::{
 		borrow::ToOwned, collections::btree_set::BTreeSet, fmt::Debug, str, vec, vec::Vec,
 	};
-
 	// Key Id for location of signer key in keystore
 	pub const KEY_ID: [u8; 4] = *b"orac";
 	pub const KEY_TYPE: KeyTypeId = KeyTypeId(KEY_ID);
@@ -1272,46 +1271,70 @@ pub mod pallet {
 				)
 			}
 			// checks to make sure key from keystore has not already submitted price
-			let prices = PrePrices::<T>::get(*price_id);
-			let public_keys: Vec<sp_core::sr25519::Public> =
-				sp_io::crypto::sr25519_public_keys(CRYPTO_KEY_TYPE);
-			let account = AccountId32::new(
-				public_keys.first().ok_or("No public keys for crypto key type `orac`")?.0,
-			);
-			let mut to32 = AccountId32::as_ref(&account);
-			let address: T::AccountId =
-				T::AccountId::decode(&mut to32).map_err(|_| "Could not decode account")?;
-
+			let prices = PrePrices::<T>::get(*price_id)
+				.into_iter()
+				.map(|price| price.who)
+				.collect::<Vec<_>>();
 			if prices.len() as u32 >= asset_info.max_answers {
 				log::info!("Max answers reached");
 				return Err("Max answers reached")
 			}
+			let public_keys: Vec<sp_core::sr25519::Public> =
+				sp_io::crypto::sr25519_public_keys(CRYPTO_KEY_TYPE);
 
-			if prices.into_iter().any(|price| price.who == address) {
-				log::info!("Tx already submitted");
-				return Err("Tx already submitted")
+			if public_keys.len() == 0 {
+				return Err("No public keys for crypto key type `orac`")
 			}
-			// Make an external HTTP request to fetch the current price.
-			// Note this call will block until response is received.
-			let price = Self::fetch_price(price_id).map_err(|_| "Failed to fetch price")?;
-			log::info!("price {:#?}", price);
 
-			// Using `send_signed_transaction` associated type we create and submit a transaction
-			// representing the call, we've just created.
-			// Submit signed will return a vector of results for all accounts that were found in the
-			// local keystore with expected `KEY_TYPE`.
+			for public_key in public_keys {
+				let account = AccountId32::new(public_key.0);
+				let mut to32 = AccountId32::as_ref(&account);
+				let address: T::AccountId =
+					T::AccountId::decode(&mut to32).map_err(|_| "Could not decode account")?;
+				log::info!("\n\n\n address {:?}", public_key.0);
+				if prices.contains(&address) {
+					println!("Tx already submitted");
+					log::info!("Tx already submitted");
+				} else {
+					println!("lets find");
+					log::info!("lets find");
+					let mut accounts = <T::AuthorityId as AppCrypto<T::Public, T::Signature>>::RuntimeAppPublic::all().into_iter().enumerate().map(|(index, key)| {
+						let generic_public = <T::AuthorityId as AppCrypto<T::Public, T::Signature>>::GenericPublic::from(key);
+						let public: T::Public = generic_public.into();
+						let account_id = public.clone().into_account();
+						Account::<T>::new(index, account_id, public)
+					});
 
-			let results = signer.send_signed_transaction(|_account| {
-				// Received price is wrapped into a call to `submit_price` public function of this
-				// pallet. This means that the transaction, when executed, will simply call that
-				// function passing `price` as an argument.
-				Call::submit_price { price: price.into(), asset_id: *price_id }
-			});
-
-			for (acc, res) in &results {
-				match res {
-					Ok(()) => log::info!("[{:?}] Submitted price of {} cents", acc.id, price),
-					Err(e) => log::error!("[{:?}] Failed to submit transaction: {:?}", acc.id, e),
+					if let Some(account) = accounts.find(|x| x.id == address) {
+						log::info!("found account {:?}", account.id.clone());
+						// Make an external HTTP request to fetch the current price.
+						// Note this call will block until response is received.
+						let price =
+							Self::fetch_price(price_id).map_err(|_| "Failed to fetch price")?;
+						log::info!("price {:#?}", price);
+						let signer = Signer::<T, T::AuthorityId>::all_accounts();
+						let results = signer
+							.with_filter(vec![account.public])
+							.send_signed_transaction(|_account| {
+								// Received price is wrapped into a call to `submit_price` public
+								// function of this pallet. This means that the transaction, when
+								// executed, will simply call that function passing `price` as an
+								// argument.
+								Call::submit_price { price: price.into(), asset_id: *price_id }
+							});
+						for (acc, res) in &results {
+							match res {
+								Ok(()) =>
+									log::info!("[{:?}] Submitted price of {} cents", acc.id, price),
+								Err(e) => log::error!(
+									"[{:?}] Failed to submit transaction: {:?}",
+									acc.id,
+									e
+								),
+							}
+						}
+					}
+					log::info!("\n\n\n");
 				}
 			}
 

--- a/code/parachain/frame/oracle/src/lib.rs
+++ b/code/parachain/frame/oracle/src/lib.rs
@@ -1291,13 +1291,11 @@ pub mod pallet {
 				let mut to32 = AccountId32::as_ref(&account);
 				let address: T::AccountId =
 					T::AccountId::decode(&mut to32).map_err(|_| "Could not decode account")?;
-				log::info!("\n\n\n address {:?}", public_key.0);
+				log::info!("address {:?}", public_key.0);
 				if prices.contains(&address) {
-					println!("Tx already submitted");
 					log::info!("Tx already submitted");
 				} else {
-					println!("lets find");
-					log::info!("lets find");
+					log::info!("findind match among existing keys");
 					let mut accounts = <T::AuthorityId as AppCrypto<T::Public, T::Signature>>::RuntimeAppPublic::all().into_iter().enumerate().map(|(index, key)| {
 						let generic_public = <T::AuthorityId as AppCrypto<T::Public, T::Signature>>::GenericPublic::from(key);
 						let public: T::Public = generic_public.into();
@@ -1306,7 +1304,7 @@ pub mod pallet {
 					});
 
 					if let Some(account) = accounts.find(|x| x.id == address) {
-						log::info!("found account {:?}", account.id.clone());
+						log::info!("found account");
 						// Make an external HTTP request to fetch the current price.
 						// Note this call will block until response is received.
 						let price =
@@ -1334,7 +1332,6 @@ pub mod pallet {
 							}
 						}
 					}
-					log::info!("\n\n\n");
 				}
 			}
 


### PR DESCRIPTION
This feature allows users running multiple oracles on the same node to not pay extra fee. Previously, offchain worker was checking if only one key had submitted price, resulting in additional transaction submission for other oracles, which resulted in extra fee because we dont allow submit price for the the same asset many times as anti spam. solution for this problem is

1) for every key in storage check that price hasnt been subimtted
2) if no, then submit individually for that key
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

