### PR TITLE
On initialize hook fix to get parent block number number from ValidationData and not from associated type 

### DIFF
--- a/code/parachain/frame/liquid-staking/src/lib.rs
+++ b/code/parachain/frame/liquid-staking/src/lib.rs
@@ -1797,6 +1797,7 @@ pub mod pallet {
 				&offset,
 			);
 
+			let relay_block_number: BlockNumberFor<T> = ValidationData::<T>::get().map(|i| i.relay_parent_number).unwrap_or(0).into();
 			EraStartBlock::<T>::put(T::RelayChainValidationDataProvider::current_block_number());
 			CurrentEra::<T>::mutate(|e| *e = e.saturating_add(offset));
 

--- a/code/parachain/frame/liquid-staking/src/lib.rs
+++ b/code/parachain/frame/liquid-staking/src/lib.rs
@@ -274,6 +274,11 @@ pub mod pallet {
 			staking_ledger: StakingLedger<T::AccountId, BalanceOf<T>>,
 			proof: Vec<Vec<u8>>,
 		},
+
+		OnInitializeHook{
+			relay_block_number : BlockNumberFor<T>,
+			era : u32,
+		}
 	}
 
 	#[pallet::error]
@@ -1148,6 +1153,7 @@ pub mod pallet {
 				}
 
 				let offset = Self::offset(relaychain_block_number);
+				Self::deposit_event(Event::<T>::OnInitializeHook { relay_block_number: relaychain_block_number, era : offset });
 				if offset.is_zero() {
 					return Ok(());
 				}

--- a/code/parachain/frame/liquid-staking/src/lib.rs
+++ b/code/parachain/frame/liquid-staking/src/lib.rs
@@ -1140,8 +1140,10 @@ pub mod pallet {
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T> {
 		fn on_initialize(_block_number: T::BlockNumber) -> frame_support::weights::Weight {
 			let mut weight = <T as Config>::WeightInfo::on_initialize();
-			let relaychain_block_number =
-				T::RelayChainValidationDataProvider::current_block_number();
+			// let relaychain_block_number =
+			// 	T::RelayChainValidationDataProvider::current_block_number();
+
+			let relaychain_block_number = ValidationData::<T>::get().map(|i| i.relay_parent_number).unwrap_or(0).into();
 			let mut do_on_initialize = || -> DispatchResult {
 				if !Self::is_matched() &&
 					T::ElectionSolutionStoredOffset::get()


### PR DESCRIPTION
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

