### PR TITLE
update xcmp config to use Custom AssetTrap instead of XcmPolkadot

### DIFF
--- a/code/parachain/runtime/composable/src/lib.rs
+++ b/code/parachain/runtime/composable/src/lib.rs
@@ -557,12 +557,7 @@ parameter_types! {
 	pub const RelayNetwork: xcm::v3::NetworkId = xcm::v3::NetworkId::Polkadot;
 	pub const XcmHelperPalletId: PalletId = PalletId(*b"com/fees");
 	pub const NotifyTimeout: BlockNumber = 100;
-	// pub TreasuryAccount: AccountId = TreasuryPalletId::get().into_account_truncating();
 	pub RefundLocation: AccountId = Utility::derivative_account_id(ParachainInfo::parachain_id().into_account_truncating(), u16::MAX);
-	// pub RelayCurrency: CurrencyId = DOT;
-	// pub RelayChainOrigin: RuntimeOrigin = cumulus_pallet_xcm::Origin::Relay.into();
-	// pub UniversalLocation: InteriorMultiLocation = X2(GlobalConsensus(RelayNetwork::get()), Parachain(ParachainInfo::parachain_id().into()));
-
 	pub const RelayCurrency: CurrencyId = CurrencyId::COMPOSABLE_DOT;
 }
 

--- a/code/parachain/runtime/composable/src/version.rs
+++ b/code/parachain/runtime/composable/src/version.rs
@@ -13,8 +13,8 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10041,
-	impl_version: 5,
+	spec_version: 10035,
+	impl_version: 3,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
 	state_version: 0,

--- a/code/parachain/runtime/composable/src/weights/collective.rs
+++ b/code/parachain/runtime/composable/src/weights/collective.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;

--- a/code/parachain/runtime/composable/src/weights/pallet_ibc.rs
+++ b/code/parachain/runtime/composable/src/weights/pallet_ibc.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;

--- a/code/parachain/runtime/composable/src/weights/tokens.rs
+++ b/code/parachain/runtime/composable/src/weights/tokens.rs
@@ -1,7 +1,6 @@
 #![allow(unused_parens)]
 #![allow(unused_imports)]
 #![allow(clippy::unnecessary_cast)]
-#![allow(deprecated)]
 
 use frame_support::{
 	traits::Get,

--- a/code/parachain/runtime/composable/src/weights/treasury.rs
+++ b/code/parachain/runtime/composable/src/weights/treasury.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;

--- a/code/parachain/runtime/composable/src/weights/utility.rs
+++ b/code/parachain/runtime/composable/src/weights/utility.rs
@@ -23,7 +23,6 @@
 #![cfg_attr(rustfmt, rustfmt_skip)]
 #![allow(unused_parens)]
 #![allow(unused_imports)]
-#![allow(deprecated)]
 
 use frame_support::{traits::Get, weights::Weight};
 use sp_std::marker::PhantomData;

--- a/code/parachain/runtime/composable/src/xcmp.rs
+++ b/code/parachain/runtime/composable/src/xcmp.rs
@@ -500,7 +500,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalLocation = UniversalLocation;
 	type Barrier = Barrier;
 	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type Trader = Trader; //?
+	type Trader = Trader;
 	type ResponseHandler = XcmExecutorHandler;
 	type SubscriptionService = PolkadotXcm;
 	type AssetClaims = PolkadotXcm;
@@ -513,7 +513,7 @@ impl xcm_executor::Config for XcmConfig {
 	type UniversalAliases = Nothing;
 	type CallDispatcher = RuntimeCall;
 	type SafeCallFilter = Everything;
-	type AssetTrap = PolkadotXcm;
+	type AssetTrap = CaptureAssetTrap;
 }
 
 parameter_type_with_key! {

--- a/code/parachain/runtime/picasso/src/version.rs
+++ b/code/parachain/runtime/picasso/src/version.rs
@@ -16,7 +16,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// The version of the runtime specification. A full node will not attempt to use its native
 	//   runtime in substitute for the on-chain Wasm runtime unless all of `spec_name`,
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
-	spec_version: 10041,
+	spec_version: 10035,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/code/parachain/runtime/primitives/src/currency.rs
+++ b/code/parachain/runtime/primitives/src/currency.rs
@@ -157,8 +157,6 @@ impl CurrencyId {
 		pub const LIQUID_STAKED_COMPOSABLE_DOT: CurrencyId = CurrencyId(79228162514264337593543950351);
 		pub const LIQUID_STAKED_PICASSO_KSM: CurrencyId = CurrencyId(20);
 
-		pub const BIFTOST_DOT: CurrencyId = CurrencyId(79228162514264337593543950369);
-
 		pub const KSM_USDT_LPT: CurrencyId = CurrencyId(105, None);
 		pub const PICA_USDT_LPT: CurrencyId = CurrencyId(106, None);
 		pub const PICA_KSM_LPT: CurrencyId = CurrencyId(107, None);


### PR DESCRIPTION
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

