### PR TITLE
feat(revenue): send percentage of the revenue to ibc

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -9773,6 +9773,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-revenue-ibc"
+version = "1.0.0"
+dependencies = [
+ "bech32",
+ "common",
+ "composable-maths",
+ "composable-support",
+ "composable-traits",
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "ibc 0.43.1",
+ "ibc-primitives",
+ "pallet-ibc",
+ "parity-scale-codec",
+ "primitives",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 5.0.0",
+]
+
+[[package]]
 name = "pallet-scheduler"
 version = "4.0.0-dev"
 source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.43#5e49f6e44820affccaf517fd22af564f4b495d40"
@@ -10582,6 +10607,7 @@ dependencies = [
  "pallet-preimage",
  "pallet-proxy",
  "pallet-referenda",
+ "pallet-revenue-ibc",
  "pallet-scheduler",
  "pallet-session",
  "pallet-sudo",

--- a/code/parachain/frame/revenue-ibc/Cargo.toml
+++ b/code/parachain/frame/revenue-ibc/Cargo.toml
@@ -1,0 +1,68 @@
+[package]
+authors = ["Composable Developers"]
+edition = "2021"
+homepage = "https://composable.finance"
+name = "pallet-revenue-ibc"
+version = "1.0.0"
+
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+# alias "parity-scale-code" to "codec"
+[dependencies.codec]
+default-features = false
+features = ["derive"]
+package = "parity-scale-codec"
+version = "3.0.0"
+
+[dependencies]
+composable-maths = { path = "../composable-maths", default-features = false }
+composable-support = { path = "../composable-support", default-features = false }
+composable-traits = { path = "../composable-traits", default-features = false }
+frame-benchmarking = { default-features = false, optional = true, workspace = true }
+frame-support = { default-features = false, workspace = true }
+frame-system = { default-features = false, workspace = true }
+scale-info = { version = "2.1.1", default-features = false, features = [
+  "derive",
+] }
+sp-arithmetic = { default-features = false, workspace = true }
+sp-core = { default-features = false, workspace = true }
+sp-io = { default-features = false, workspace = true }
+sp-runtime = { default-features = false, workspace = true }
+sp-std = { default-features = false, workspace = true }
+pallet-ibc = { workspace = true, default-features = false }
+
+bech32-no_std = { workspace = true, default-features = false, features = [
+  "strict",
+] }
+
+common = { path = "../../runtime/common", default-features = false }
+
+ibc-primitives = { workspace = true, default-features = false }
+
+primitives = { path = "../../runtime/primitives", default-features = false }
+ibc-rs-scale = { workspace = true, default-features = false, features = [
+  "parity-scale-codec",
+  "serde",
+] }
+[features]
+default = ["std"]
+std = [
+  "common/std",
+  "codec/std",
+  "composable-support/std",
+  "composable-traits/std",
+  "frame-benchmarking/std",
+  "frame-support/std",
+  "frame-system/std",
+  "pallet-ibc/std",
+  "primitives/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "sp-std/std",
+]
+
+runtime-benchmarks = []

--- a/code/parachain/frame/revenue-ibc/Cargo.toml
+++ b/code/parachain/frame/revenue-ibc/Cargo.toml
@@ -65,4 +65,8 @@ std = [
   "sp-std/std",
 ]
 
-runtime-benchmarks = []
+runtime-benchmarks = [
+  "frame-benchmarking",
+  "frame-support/runtime-benchmarks",
+  "frame-system/runtime-benchmarks",
+]

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -547,7 +547,7 @@ pub mod pallet {
 											.replace("{centauri}", centauri.to_string().as_str());
 									}
 									Self::deposit_event(Event::<T>::Memo {
-										memo: replaced_memo.clone()
+										memo: replaced_memo.clone(),
 									});
 									<T as pallet_ibc::Config>::MemoMessage::from_str(&replaced_memo)
 										.ok()
@@ -555,7 +555,7 @@ pub mod pallet {
 								_ => None,
 							},
 							_ => None,
-						};						
+						};
 						let amount = T::Assets::reducible_balance(
 							asset_id.clone(),
 							&Self::pallet_account_id(),

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -533,7 +533,7 @@ pub mod pallet {
 						let memo = match Self::memo() {
 							Some(m) => match String::from_utf8(m.into()) {
 								Ok(m) => {
-									let mut replaced_memo = m.clone();
+									let mut replaced_memo = m;
 									if let Some(osmo_id) = CvmOsmoAddress::<T>::get(&asset_id) {
 										replaced_memo = replaced_memo
 											.replace("{osmo}", osmo_id.to_string().as_str());
@@ -562,7 +562,7 @@ pub mod pallet {
 								transfer_params.clone(),
 								asset_id.clone(),
 								amount,
-								memo.clone(),
+								memo,
 							);
 							if result.is_err() {
 								Self::deposit_event(Event::<T>::TransferFailed {

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -189,6 +189,9 @@ pub mod pallet {
 			asset_id: AssetIdOf<T>,
 			cvm_centauri: u128,
 		},
+		Memo {
+			memo: String,
+		},
 		RevenueCalcutions,
 		SetAllowed,
 		AddAllowed,
@@ -543,13 +546,16 @@ pub mod pallet {
 										replaced_memo = replaced_memo
 											.replace("{centauri}", centauri.to_string().as_str());
 									}
+									Self::deposit_event(Event::<T>::Memo {
+										memo: replaced_memo.clone()
+									});
 									<T as pallet_ibc::Config>::MemoMessage::from_str(&replaced_memo)
 										.ok()
 								},
 								_ => None,
 							},
 							_ => None,
-						};
+						};						
 						let amount = T::Assets::reducible_balance(
 							asset_id.clone(),
 							&Self::pallet_account_id(),

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -37,6 +37,7 @@ pub use pallet::*;
 
 pub mod weights;
 pub use sp_std::str::FromStr;
+pub use composable_traits::prelude::ToString;
 
 #[frame_support::pallet]
 pub mod pallet {

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -119,7 +119,17 @@ pub mod pallet {
 			+ Inspect<AccountIdOf<Self>, Balance = BalanceOf<Self>, AssetId = AssetIdOf<Self>>;
 
 		#[pallet::constant]
-		type MaxStringSize: Get<u32>
+		type MaxStringSizeAddress: Get<u32>
+			+ TypeInfo
+			+ core::fmt::Debug
+			+ MaxEncodedLen
+			+ Copy
+			+ Clone
+			+ PartialEq
+			+ Eq;
+
+		#[pallet::constant]
+		type MaxStringSizeMemo: Get<u32>
 			+ TypeInfo
 			+ core::fmt::Debug
 			+ MaxEncodedLen
@@ -143,12 +153,12 @@ pub mod pallet {
 			period: T::BlockNumber,
 		},
 		MemoSet {
-			memo: BoundedVec<u8, T::MaxStringSize>,
+			memo: BoundedVec<u8, T::MaxStringSizeMemo>,
 		},
 		RevenueTransferred {
 			amount: BalanceOf<T>,
 			asset_id: AssetIdOf<T>,
-			memo: BoundedVec<u8, T::MaxStringSize>,
+			memo: BoundedVec<u8, T::MaxStringSizeMemo>,
 		},
 		TransferFailed {
 			asset_id: AssetIdOf<T>,
@@ -169,7 +179,7 @@ pub mod pallet {
 			channel: u64,
 		},
 		CentauriAddressSet {
-			address: BoundedVec<u8, T::MaxStringSize>,
+			address: BoundedVec<u8, T::MaxStringSizeAddress>,
 		},
 		CvmOsmoAddress {
 			asset_id: AssetIdOf<T>,
@@ -225,7 +235,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn centauri_address)]
 	pub type CentauriAddress<T: Config> =
-		StorageValue<_, BoundedVec<u8, T::MaxStringSize>, OptionQuery>;
+		StorageValue<_, BoundedVec<u8, T::MaxStringSizeAddress>, OptionQuery>;
 
 	#[pallet::storage]
 	#[pallet::getter(fn centauri_channel)]
@@ -246,7 +256,7 @@ pub mod pallet {
 	#[pallet::storage]
 	#[pallet::getter(fn memo)]
 	pub type ForwardMemo<T: Config> =
-		StorageValue<_, BoundedVec<u8, T::MaxStringSize>, OptionQuery>;
+		StorageValue<_, BoundedVec<u8, T::MaxStringSizeMemo>, OptionQuery>;
 
 	#[pallet::hooks]
 	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T>
@@ -351,7 +361,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::set_memo())]
 		pub fn set_memo(
 			origin: OriginFor<T>,
-			memo: BoundedVec<u8, T::MaxStringSize>,
+			memo: BoundedVec<u8, T::MaxStringSizeMemo>,
 		) -> DispatchResult {
 			T::Admin::ensure_origin(origin)?;
 			ForwardMemo::<T>::set(Some(memo.clone()));
@@ -462,7 +472,7 @@ pub mod pallet {
 		#[pallet::weight(<T as Config>::WeightInfo::set_address())]
 		pub fn set_address(
 			origin: OriginFor<T>,
-			address: BoundedVec<u8, T::MaxStringSize>,
+			address: BoundedVec<u8, T::MaxStringSizeAddress>,
 		) -> DispatchResult {
 			T::Admin::ensure_origin(origin)?;
 			CentauriAddress::<T>::set(Some(address.clone()));

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -36,12 +36,11 @@ pub use codec::{Decode, Encode, FullCodec};
 pub use pallet::*;
 
 pub mod weights;
-pub use sp_std::str::FromStr;
-pub use composable_traits::prelude::ToString;
 
 #[frame_support::pallet]
 pub mod pallet {
 	pub use crate::weights::WeightInfo;
+	pub use composable_traits::prelude::ToString;
 
 	use composable_traits::{
 		currency::AssetExistentialDepositInspect,

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -1,0 +1,463 @@
+#![cfg_attr(
+	not(test),
+	deny(
+		clippy::disallowed_methods,
+		clippy::disallowed_types,
+		clippy::indexing_slicing,
+		clippy::todo,
+		clippy::unwrap_used,
+		clippy::panic
+	)
+)]
+#![deny(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
+#![warn(bad_style, trivial_numeric_casts)]
+#![allow(clippy::let_unit_value)]
+#![deny(
+	bare_trait_objects,
+	improper_ctypes,
+	no_mangle_generic_items,
+	non_shorthand_field_patterns,
+	overflowing_literals,
+	path_statements,
+	patterns_in_fns_without_body,
+	private_in_public,
+	trivial_casts,
+	unconditional_recursion,
+	unused_allocation,
+	unused_comparisons,
+	unused_extern_crates,
+	// unused_imports,
+	unused_parens,
+	while_true
+)]
+#![cfg_attr(not(feature = "std"), no_std)]
+#![feature(more_qualified_paths)]
+pub use codec::{Decode, Encode, FullCodec};
+pub use pallet::*;
+
+pub use sp_std::str::FromStr;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use bech32_no_std::u5;
+	use common::ibc::RawMemo;
+	use composable_support::{
+		collections::vec::bounded::{bi_bounded_vec::BiBoundedVecOutOfBounds, BiBoundedVec},
+		math::safe::{SafeArithmetic, SafeSub},
+	};
+	use composable_traits::{
+		assets::AssetInfo,
+		currency::{AssetExistentialDepositInspect, BalanceLike},
+		dex::{AssetAmount, FeeConfig, SwapResult},
+		prelude::{String, Vec},
+		xcm::assets::RemoteAssetRegistryInspect,
+	};
+	use core::fmt::Debug;
+	use frame_support::{
+		pallet_prelude::*,
+		storage::with_transaction,
+		traits::{
+			fungibles::{Inspect, Mutate},
+			tokens::Preservation,
+			Time,
+		},
+		transactional, BoundedBTreeMap, PalletId, RuntimeDebug,
+	};
+	use frame_system::{ensure_root, ensure_signed, pallet_prelude::OriginFor, RawOrigin};
+	use ibc_primitives::Timeout as IbcTimeout;
+	use ibc_rs_scale::{
+		applications::transfer::TracePrefix,
+		core::ics24_host::identifier::{ChannelId, PortId},
+	};
+	use pallet_ibc::{
+		ics20::ValidateMemo, ics20_fee::FlatFeeConverter, DenomToAssetId, MultiAddress,
+		TransferParams,
+	};
+	use primitives::currency::ForeignAssetId;
+	use sp_arithmetic::FixedPointOperand;
+	use sp_runtime::{
+		traits::{AccountIdConversion, Convert, IdentifyAccount, One, Saturating, Zero},
+		AccountId32, ArithmeticError, BoundedBTreeSet, FixedPointNumber, Perbill, Permill,
+		TransactionOutcome,
+	};
+	use sp_std::{boxed::Box, collections::btree_map::BTreeMap};
+	pub use sp_std::{prelude::*, str::FromStr, vec};
+
+	pub(crate) type AssetIdOf<T> = <T as pallet_ibc::Config>::AssetId;
+	pub(crate) type BalanceOf<T> = <T as pallet_ibc::Config>::Balance;
+
+	pub(crate) type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config + pallet_ibc::Config {
+		#[allow(missing_docs)]
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		// treasury account
+		#[pallet::constant]
+		type FromPalletId: Get<PalletId>;
+
+		// every period, funds to transfer are sent to IntermediatePalletId, then from it they are
+		// send further In case of failure funds come back to this account and revenue calculation
+		// for treasury will stay untouched
+		#[pallet::constant]
+		type IntermediatePalletId: Get<PalletId>;
+
+		// token locationtype
+		type ForeignAssetId: codec::FullCodec
+			+ Eq
+			+ PartialEq
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ Clone
+			+ TypeInfo
+			+ MaxEncodedLen;
+		type AssetId: codec::FullCodec
+			+ MaxEncodedLen
+			+ Eq
+			+ PartialEq
+			+ Copy
+			+ Clone
+			+ MaybeSerializeDeserialize
+			+ Debug
+			+ Default
+			+ TypeInfo
+			+ From<u128>
+			+ Into<u128>
+			+ Ord;
+		// get access to tokens location
+		type AssetsRegistry: RemoteAssetRegistryInspect<
+				AssetId = AssetIdOf<Self>,
+				AssetNativeLocation = Self::ForeignAssetId,
+			> + AssetExistentialDepositInspect<AssetId = AssetIdOf<Self>, Balance = BalanceOf<Self>>;
+
+		type Assets: Mutate<AccountIdOf<Self>, Balance = BalanceOf<Self>, AssetId = AssetIdOf<Self>>
+			+ Inspect<AccountIdOf<Self>, Balance = BalanceOf<Self>, AssetId = AssetIdOf<Self>>;
+
+		#[pallet::constant]
+		type MaxStringSize: Get<u32>
+			+ TypeInfo
+			+ core::fmt::Debug
+			+ MaxEncodedLen
+			+ Copy
+			+ Clone
+			+ PartialEq
+			+ Eq;
+
+		// root and council
+		type Admin: EnsureOrigin<<Self as frame_system::Config>::RuntimeOrigin>;
+	}
+
+	// The pallet's events
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event<T: Config> {
+		PeriodSet {
+			period: T::BlockNumber,
+		},
+		MemoSet {
+			memo: BoundedVec<u8, T::MaxStringSize>,
+		},
+		RevenueTransferred {
+			amount: BalanceOf<T>,
+			asset_id: AssetIdOf<T>,
+			memo: BoundedVec<u8, T::MaxStringSize>,
+		},
+		TransferFailed {
+			asset_id: AssetIdOf<T>,
+		},
+		SkipAsset {
+			asset_id: AssetIdOf<T>,
+		},
+		TransferSuccess {
+			asset_id: AssetIdOf<T>,
+			amount: BalanceOf<T>,
+		},
+		TransferFail {
+			asset_id: AssetIdOf<T>,
+			amount: BalanceOf<T>,
+		},
+		RevenueCalcutions,
+	}
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::storage]
+	#[pallet::getter(fn allowed_assets)]
+	pub type AllowedAssets<T: Config> =
+		StorageMap<_, Blake2_128Concat, AssetIdOf<T>, (), ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn disallowed_assets)]
+	pub type DisallowedAssets<T: Config> =
+		StorageMap<_, Blake2_128Concat, AssetIdOf<T>, (), ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn tokens_prev_amount)]
+	pub type TokenPrevPeriodBalance<T: Config> =
+		StorageMap<_, Blake2_128Concat, AssetIdOf<T>, BalanceOf<T>, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn period)]
+	pub type Period<T: Config> = StorageValue<_, T::BlockNumber, ValueQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn centauri_address)]
+	pub type CentauriAddress<T: Config> =
+		StorageValue<_, BoundedVec<u8, T::MaxStringSize>, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn centauri_channel)]
+	pub type CentauriChannel<T: Config> = StorageValue<_, u64, OptionQuery>;
+
+	#[pallet::storage]
+	#[pallet::getter(fn memo)]
+	pub type ForwardMemo<T: Config> =
+		StorageValue<_, BoundedVec<u8, T::MaxStringSize>, OptionQuery>;
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<T::BlockNumber> for Pallet<T>
+	where
+		T: Send + Sync,
+		AccountId32: From<<T as frame_system::Config>::AccountId>,
+		u32: From<<T as frame_system::Config>::BlockNumber>,
+	{
+		fn on_initialize(now: T::BlockNumber) -> Weight {
+			if Self::period() != sp_runtime::traits::Zero::zero() &&
+				now % Self::period() == Zero::zero()
+			{
+				let mut count: u32 = 0;
+				Self::deposit_event(Event::<T>::RevenueCalcutions);
+				Self::get_ibc_assets().iter().for_each(|asset_id| {
+					let percentage = Perbill::from_rational(200_u32, 1000_u32);
+					let new_balance = T::Assets::reducible_balance(
+						asset_id.clone(),
+						&Self::treasury_account_id(),
+						Preservation::Expendable,
+						frame_support::traits::tokens::Fortitude::Polite,
+					);
+					let old_balance = TokenPrevPeriodBalance::<T>::get(asset_id);
+					let asset_ed_res = T::AssetsRegistry::existential_deposit(asset_id.clone());
+					if let Ok(asset_ed) = asset_ed_res {
+						if new_balance > old_balance &&
+							percentage * (new_balance - old_balance) > asset_ed
+						{
+							let amount = percentage * (new_balance - old_balance);
+							match T::Assets::transfer(
+								asset_id.clone(),
+								&Self::treasury_account_id(),
+								&Self::pallet_account_id(),
+								percentage * (new_balance - old_balance),
+								Preservation::Expendable,
+							) {
+								Ok(_) => Self::deposit_event(Event::<T>::TransferSuccess {
+									asset_id: asset_id.clone(),
+									amount,
+								}),
+								Err(_) => Self::deposit_event(Event::<T>::TransferFail {
+									asset_id: asset_id.clone(),
+									amount,
+								}),
+							};
+							TokenPrevPeriodBalance::<T>::insert(asset_id, new_balance - amount);
+						}
+					}
+					Self::deposit_event(Event::<T>::SkipAsset { asset_id: asset_id.clone() });
+				});
+
+				// T::WeightInfo::on_initialize(count)
+				Weight::zero()
+			} else {
+				Weight::zero()
+			}
+		}
+	}
+
+	// The pallet's dispatchable functions.
+	#[pallet::call]
+	impl<T: Config> Pallet<T>
+	where
+		T: Send + Sync,
+		AccountId32: From<<T as frame_system::Config>::AccountId>,
+		u32: From<<T as frame_system::Config>::BlockNumber>,
+	{
+		#[pallet::call_index(0)]
+		#[pallet::weight(100_000)]
+		pub fn set_period(origin: OriginFor<T>, period: T::BlockNumber) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			// stop sharing
+			if period == Zero::zero() {
+				TokenPrevPeriodBalance::<T>::drain();
+			}
+			// save current values
+			if Self::period() == Zero::zero() {
+				Self::get_ibc_assets().iter().for_each(|asset_id| {
+					TokenPrevPeriodBalance::<T>::insert(
+						asset_id,
+						T::Assets::reducible_balance(
+							asset_id.clone(),
+							&Self::treasury_account_id(),
+							Preservation::Expendable,
+							frame_support::traits::tokens::Fortitude::Polite,
+						),
+					);
+				})
+			}
+			Period::<T>::set(period);
+			Self::deposit_event(Event::<T>::PeriodSet { period });
+			Ok(())
+		}
+
+		#[pallet::call_index(1)]
+		#[pallet::weight(100_000)]
+		pub fn set_memo(
+			origin: OriginFor<T>,
+			memo: BoundedVec<u8, T::MaxStringSize>,
+		) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			ForwardMemo::<T>::set(Some(memo.clone()));
+			Self::deposit_event(Event::<T>::MemoSet { memo });
+			Ok(())
+		}
+
+		#[pallet::call_index(2)]
+		#[pallet::weight(100_000)]
+		pub fn trigger_transfer(origin: OriginFor<T>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			Self::transfer_from_intermediate()?;
+			Ok(())
+		}
+
+		#[pallet::call_index(3)]
+		#[pallet::weight(100_000)]
+		pub fn set_allowed(origin: OriginFor<T>, assets: Vec<AssetIdOf<T>>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			AllowedAssets::<T>::drain();
+			assets.iter().for_each(|asset| AllowedAssets::<T>::insert(asset, ()));
+			Ok(())
+		}
+
+		#[pallet::call_index(4)]
+		#[pallet::weight(100_000)]
+		pub fn add_allowed(origin: OriginFor<T>, asset: AssetIdOf<T>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			AllowedAssets::<T>::insert(asset, ());
+			Ok(())
+		}
+
+		#[pallet::call_index(5)]
+		#[pallet::weight(100_000)]
+		pub fn remove_allowed(origin: OriginFor<T>, asset: AssetIdOf<T>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			AllowedAssets::<T>::remove(asset);
+			Ok(())
+		}
+
+		#[pallet::call_index(6)]
+		#[pallet::weight(100_000)]
+		pub fn set_disallowed(origin: OriginFor<T>, assets: Vec<AssetIdOf<T>>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			assets.iter().for_each(|asset| DisallowedAssets::<T>::insert(asset, ()));
+			Ok(())
+		}
+
+		#[pallet::call_index(7)]
+		#[pallet::weight(100_000)]
+		pub fn add_disallowed(origin: OriginFor<T>, asset: AssetIdOf<T>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			DisallowedAssets::<T>::insert(asset, ());
+			Ok(())
+		}
+
+		#[pallet::call_index(8)]
+		#[pallet::weight(100_000)]
+		pub fn remove_disallowed(origin: OriginFor<T>, asset: AssetIdOf<T>) -> DispatchResult {
+			T::Admin::ensure_origin(origin)?;
+			DisallowedAssets::<T>::remove(asset);
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T>
+	where
+		T: Send + Sync,
+		AccountId32: From<<T as frame_system::Config>::AccountId>,
+		u32: From<<T as frame_system::Config>::BlockNumber>,
+	{
+		pub fn treasury_account_id() -> T::AccountId {
+			T::FromPalletId::get().into_account_truncating()
+		}
+
+		pub fn pallet_account_id() -> T::AccountId {
+			T::IntermediatePalletId::get().into_account_truncating()
+		}
+
+		fn transfer_from_intermediate() -> DispatchResult {
+			if let Some(channel_id) = Self::centauri_channel() {
+				if let Some(centauri_address) = Self::centauri_address() {
+					let transfer_params: TransferParams<T::AccountId> =
+						TransferParams::<T::AccountId> {
+							to: MultiAddress::<T::AccountId>::Raw(centauri_address.into()),
+							source_channel: channel_id,
+							timeout: IbcTimeout::Offset {
+								timestamp: Some(6_000_000_000_000),
+								height: Some(1000),
+							},
+						};
+					let memo = match Self::memo().clone() {
+						Some(m) => match String::from_utf8(m.into()) {
+							Ok(m) => <T as pallet_ibc::Config>::MemoMessage::from_str(&m).ok(),
+							_ => None,
+						},
+						_ => None,
+					};
+					Self::get_ibc_assets().into_iter().for_each(|asset_id| {
+						let result = pallet_ibc::Pallet::<T>::transfer(
+							frame_system::RawOrigin::Signed(Self::pallet_account_id()).into(),
+							transfer_params.clone(),
+							asset_id.clone(),
+							T::Assets::reducible_balance(
+								asset_id.clone(),
+								&Self::pallet_account_id(),
+								Preservation::Expendable,
+								frame_support::traits::tokens::Fortitude::Polite,
+							),
+							memo.clone(),
+						);
+						if let Err(e) = result {
+							Self::deposit_event(Event::<T>::TransferFailed { asset_id });
+						}
+					});
+					Ok(())
+				} else {
+					Err(DispatchError::Other("Centauri Address is not Specified"))
+				}
+			} else {
+				Err(DispatchError::Other("Channel Id Not Specified"))
+			}
+		}
+
+		fn get_ibc_assets() -> Vec<AssetIdOf<T>> {
+			let disallowed = DisallowedAssets::<T>::iter_keys().collect::<Vec<AssetIdOf<T>>>();
+			let mut allowed = AllowedAssets::<T>::iter_keys().collect::<Vec<AssetIdOf<T>>>();
+			<T::AssetsRegistry as RemoteAssetRegistryInspect>::get_foreign_assets_list()
+				.iter()
+				.for_each(|asset| {
+					if let Ok(ForeignAssetId::IbcIcs20(denom)) =
+						ForeignAssetId::decode(&mut asset.foreign_id.clone().encode().as_slice())
+					{
+						if denom
+							.0
+							.trace_path
+							.starts_with(&TracePrefix::new(PortId::transfer(), ChannelId::new(15))) &&
+							!disallowed.contains(&asset.id)
+						{
+							allowed.push(asset.id.clone())
+						}
+					}
+				});
+			allowed
+		}
+	}
+}

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -79,7 +79,7 @@ pub mod pallet {
 
 		// treasury account
 		#[pallet::constant]
-		type FromPalletId: Get<PalletId>;
+		type FeeAccount: Get<AccountIdOf<Self>>;
 
 		// every period, funds to transfer are sent to IntermediatePalletId, then from it they are
 		// send further In case of failure funds come back to this account and revenue calculation
@@ -279,7 +279,7 @@ pub mod pallet {
 					let percentage = Perbill::from_rational(200_u32, 1000_u32);
 					let new_balance = T::Assets::reducible_balance(
 						asset_id.clone(),
-						&Self::treasury_account_id(),
+						&<T as Config>::FeeAccount::get(),
 						Preservation::Expendable,
 						frame_support::traits::tokens::Fortitude::Polite,
 					);
@@ -292,7 +292,7 @@ pub mod pallet {
 							let amount = percentage * (new_balance - old_balance);
 							match T::Assets::transfer(
 								asset_id.clone(),
-								&Self::treasury_account_id(),
+								&<T as Config>::FeeAccount::get(),
 								&Self::pallet_account_id(),
 								percentage * (new_balance - old_balance),
 								Preservation::Expendable,
@@ -345,7 +345,7 @@ pub mod pallet {
 						asset_id,
 						T::Assets::reducible_balance(
 							asset_id.clone(),
-							&Self::treasury_account_id(),
+							&<T as Config>::FeeAccount::get(),
 							Preservation::Expendable,
 							frame_support::traits::tokens::Fortitude::Polite,
 						),
@@ -392,7 +392,7 @@ pub mod pallet {
 					asset,
 					T::Assets::reducible_balance(
 						asset.clone(),
-						&Self::treasury_account_id(),
+						&<T as Config>::FeeAccount::get(),
 						Preservation::Expendable,
 						frame_support::traits::tokens::Fortitude::Polite,
 					),
@@ -412,7 +412,7 @@ pub mod pallet {
 				&asset,
 				T::Assets::reducible_balance(
 					asset.clone(),
-					&Self::treasury_account_id(),
+					&<T as Config>::FeeAccount::get(),
 					Preservation::Expendable,
 					frame_support::traits::tokens::Fortitude::Polite,
 				),
@@ -513,10 +513,6 @@ pub mod pallet {
 		AccountId32: From<<T as frame_system::Config>::AccountId>,
 		u32: From<<T as frame_system::Config>::BlockNumber>,
 	{
-		pub fn treasury_account_id() -> T::AccountId {
-			T::FromPalletId::get().into_account_truncating()
-		}
-
 		pub fn pallet_account_id() -> T::AccountId {
 			T::IntermediatePalletId::get().into_account_truncating()
 		}

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -496,7 +496,7 @@ pub mod pallet {
 						_ => None,
 					};
 					Self::get_ibc_assets().into_iter().for_each(|asset_id| {
-						let amount =T::Assets::reducible_balance(
+						let amount = T::Assets::reducible_balance(
 							asset_id.clone(),
 							&Self::pallet_account_id(),
 							Preservation::Expendable,
@@ -511,7 +511,10 @@ pub mod pallet {
 								memo.clone(),
 							);
 							if let Err(e) = result {
-								Self::deposit_event(Event::<T>::TransferFailed { asset_id, amount });
+								Self::deposit_event(Event::<T>::TransferFailed {
+									asset_id,
+									amount,
+								});
 							}
 						}
 					});

--- a/code/parachain/frame/revenue-ibc/src/lib.rs
+++ b/code/parachain/frame/revenue-ibc/src/lib.rs
@@ -11,10 +11,7 @@
 )]
 #![deny(clippy::unseparated_literal_suffix, clippy::disallowed_types)]
 #![warn(bad_style, trivial_numeric_casts)]
-#![allow(
-	clippy::let_unit_value,
-	clippy::unused_unit
-)]
+#![allow(clippy::let_unit_value, clippy::unused_unit)]
 #![deny(
 	bare_trait_objects,
 	improper_ctypes,
@@ -491,10 +488,10 @@ pub mod pallet {
 		pub fn set_cvm_centauri_address(
 			origin: OriginFor<T>,
 			asset_id: AssetIdOf<T>,
-			cvm_centauri: u128
+			cvm_centauri: u128,
 		) -> DispatchResult {
 			T::Admin::ensure_origin(origin)?;
-			CvmCentauriAddress::<T>::insert(&asset_id,  cvm_centauri);
+			CvmCentauriAddress::<T>::insert(&asset_id, cvm_centauri);
 			Self::deposit_event(Event::<T>::CvmCentauriAddress { asset_id, cvm_centauri });
 			Ok(())
 		}
@@ -548,7 +545,7 @@ pub mod pallet {
 								amount,
 								memo.clone(),
 							);
-							if  result.is_err() {
+							if result.is_err() {
 								Self::deposit_event(Event::<T>::TransferFailed {
 									asset_id,
 									amount,
@@ -585,7 +582,6 @@ pub mod pallet {
 			// 			}
 			// 		}
 			// 	});
-
 		}
 	}
 }

--- a/code/parachain/frame/revenue-ibc/src/weights.rs
+++ b/code/parachain/frame/revenue-ibc/src/weights.rs
@@ -1,0 +1,117 @@
+#![allow(unused_parens, unused_imports, clippy::unnecessary_cast)]
+use frame_support::{
+	traits::Get,
+	weights::{constants::RocksDbWeight, Weight},
+};
+use sp_std::marker::PhantomData;
+
+// The weight info trait for `pallet_oracle`.
+pub trait WeightInfo {
+	fn on_initialize(c: usize) -> Weight;
+	fn set_period() -> Weight;
+	fn set_memo() -> Weight;
+	fn trigger_transfer() -> Weight;
+	fn set_allowed() -> Weight;
+	fn add_allowed() -> Weight;
+	fn remove_allowed() -> Weight;
+	fn set_disallowed() -> Weight;
+	fn add_disallowed() -> Weight;
+	fn remove_disallowed() -> Weight;
+	fn set_channel() -> Weight;
+	fn set_address() -> Weight;
+    fn set_cvm_osmo_address() -> Weight;
+    fn set_cvm_centauri_address() -> Weight;
+}
+
+/// Weights for pallet_oracle using the Substrate node and recommended hardware.
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
+	fn on_initialize(c: usize) -> Weight {
+		Weight::from_parts(100_000, 0).saturating_mul(c as u64)
+	}
+	fn set_period() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_memo() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn trigger_transfer() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn add_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn remove_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn add_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn remove_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_channel() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+    fn set_cvm_osmo_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+    fn set_cvm_centauri_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+}
+
+// For backwards compatibility and tests
+impl WeightInfo for () {
+	fn on_initialize(c: usize) -> Weight {
+		Weight::from_parts(100_000, 0).saturating_mul(c as u64)
+	}
+	fn set_period() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_memo() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn trigger_transfer() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn add_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn remove_allowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn add_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn remove_disallowed() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_channel() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+    fn set_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+	fn set_cvm_osmo_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+    fn set_cvm_centauri_address() -> Weight {
+		Weight::from_parts(100_000, 0)
+	}
+}

--- a/code/parachain/frame/revenue-ibc/src/weights.rs
+++ b/code/parachain/frame/revenue-ibc/src/weights.rs
@@ -19,8 +19,8 @@ pub trait WeightInfo {
 	fn remove_disallowed() -> Weight;
 	fn set_channel() -> Weight;
 	fn set_address() -> Weight;
-    fn set_cvm_osmo_address() -> Weight;
-    fn set_cvm_centauri_address() -> Weight;
+	fn set_cvm_osmo_address() -> Weight;
+	fn set_cvm_centauri_address() -> Weight;
 }
 
 /// Weights for pallet_oracle using the Substrate node and recommended hardware.
@@ -62,10 +62,10 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn set_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
-    fn set_cvm_osmo_address() -> Weight {
+	fn set_cvm_osmo_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
-    fn set_cvm_centauri_address() -> Weight {
+	fn set_cvm_centauri_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
 }
@@ -105,13 +105,13 @@ impl WeightInfo for () {
 	fn set_channel() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
-    fn set_address() -> Weight {
+	fn set_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
 	fn set_cvm_osmo_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
-    fn set_cvm_centauri_address() -> Weight {
+	fn set_cvm_centauri_address() -> Weight {
 		Weight::from_parts(100_000, 0)
 	}
 }

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -68,6 +68,7 @@ composable-support = { path = "../../frame/composable-support", default-features
 composable-traits = { path = "../../frame/composable-traits", default-features = false }
 crowdloan-rewards = { package = "pallet-crowdloan-rewards", path = "../../frame/crowdloan-rewards", default-features = false }
 pablo = { package = "pallet-pablo", path = "../../frame/pablo", default-features = false }
+revenue-ibc = { package = "pallet-revenue-ibc", path = "../../frame/revenue-ibc", default-features = false }
 oracle = { package = "pallet-oracle", path = "../../frame/oracle", default-features = false }
 primitives = { path = "../primitives", default-features = false }
 vesting = { package = "pallet-vesting", path = "../../frame/vesting", default-features = false }
@@ -246,6 +247,7 @@ std = [
   "orml-xtokens/std",
   "pablo-runtime-api/std",
   "pablo/std",
+  "revenue-ibc/std",
   "pallet-assets/std",
   "pallet-ibc/std",
   "pallet-multihop-xcm-ibc/std",

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -245,7 +245,7 @@ impl assets_registry::Config for Runtime {
 }
 
 parameter_types! {
-	pub const FromPalletId: PalletId = PalletId(*b"picatrsy");
+	pub const FromPalletId: PalletId = PalletId(*b"ics20fee");
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
 	pub const MaxStringSize: u32 = 100;

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -29,6 +29,7 @@ pub mod assets;
 mod contracts;
 mod fees;
 mod tracks;
+use hex_literal::hex;
 pub use pallet_custom_origins;
 pub use tracks::TracksInfo;
 pub mod governance;
@@ -38,13 +39,12 @@ mod prelude;
 pub mod version;
 mod weights;
 pub mod xcmp;
+pub use crate::fees::WellKnownForeignToNativePriceConverter;
 pub use common::xcmp::{MaxInstructions, UnitWeightCost};
 pub use fees::{AssetsPaymentHeader, FinalPriceConverter};
 use frame_support::dispatch::DispatchError;
 use version::{Version, VERSION};
 pub use xcmp::XcmConfig;
-
-pub use crate::fees::WellKnownForeignToNativePriceConverter;
 
 use common::{
 	fees::{multi_existential_deposits, NativeExistentialDeposit, WeightToFeeConverter},
@@ -245,7 +245,7 @@ impl assets_registry::Config for Runtime {
 }
 
 parameter_types! {
-	pub FeeAccount: AccountId32 = AccountId32::from(hex!("a72ef3ce1ecd46163bc5e23fd3e6a4623d9717c957fb59001a5d4cb949150f28"));
+	pub FeeAccount: sp_runtime::AccountId32 = sp_runtime::AccountId32::from(hex!("a72ef3ce1ecd46163bc5e23fd3e6a4623d9717c957fb59001a5d4cb949150f28"));
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
 	pub const MaxStringSizeAddress: u32 = 100;

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -69,6 +69,7 @@ use gates::*;
 use governance::*;
 use prelude::*;
 use primitives::currency::{CurrencyId, ValidateCurrencyId};
+use scale_info::TypeInfo;
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::{
@@ -80,7 +81,6 @@ use sp_runtime::{
 	ApplyExtrinsicResult, Either, FixedI128,
 };
 use sp_std::{collections::btree_map::BTreeMap, vec::Vec};
-
 // A few exports that help ease life for downstream crates.
 use codec::Encode;
 use frame_support::traits::{fungibles, EqualPrivilegeOnly, OnRuntimeUpgrade};
@@ -242,6 +242,25 @@ impl assets_registry::Config for Runtime {
 	type WeightInfo = weights::assets_registry::WeightInfo<Runtime>;
 	type Convert = ConvertInto;
 	type NetworkId = PicassoNetworkId;
+}
+
+parameter_types! {
+	pub const FromPalletId: PalletId = PalletId(*b"picatrsy");
+	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
+	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
+	pub const MaxStringSize: u32 = 100;
+}
+
+impl revenue_ibc::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type FromPalletId = FromPalletId;
+	type IntermediatePalletId = IntermediatePalletId;
+	type ForeignAssetId = primitives::currency::ForeignAssetId;
+	type AssetId = CurrencyId;
+	type AssetsRegistry = AssetsRegistry;
+	type Assets = Assets;
+	type MaxStringSize = MaxStringSize;
+	type Admin = EnsureRootOrTwoThirdNativeCouncil;
 }
 
 parameter_types! {
@@ -879,6 +898,8 @@ construct_runtime!(
 
 		Cosmwasm: cosmwasm = 180,
 
+
+
 		// IBC support
 		Ibc: pallet_ibc = 190,
 		Ics20Fee: pallet_ibc::ics20_fee = 191,
@@ -886,6 +907,7 @@ construct_runtime!(
 
 		PalletXcmHelper: pallet_xcm_helper = 194,
 		PalletLiquidStaking: pallet_liquid_staking = 195,
+		RevenueIbc: revenue_ibc = 200,
 	}
 );
 

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -248,7 +248,8 @@ parameter_types! {
 	pub const FromPalletId: PalletId = PalletId(*b"ics20fee");
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
-	pub const MaxStringSize: u32 = 100;
+	pub const MaxStringSizeAdress: u32 = 100;
+	pub const MaxStringSize: u32 = 1000;
 }
 
 impl revenue_ibc::Config for Runtime {
@@ -259,7 +260,8 @@ impl revenue_ibc::Config for Runtime {
 	type AssetId = CurrencyId;
 	type AssetsRegistry = AssetsRegistry;
 	type Assets = Assets;
-	type MaxStringSize = MaxStringSize;
+	type MaxStringSizeAdress = MaxStringSizeAdress;
+	type MaxStringSizeMemo = MaxStringSize;
 	type Admin = EnsureRootOrTwoThirdNativeCouncil;
 	type WeightInfo = ();
 }

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -261,6 +261,7 @@ impl revenue_ibc::Config for Runtime {
 	type Assets = Assets;
 	type MaxStringSize = MaxStringSize;
 	type Admin = EnsureRootOrTwoThirdNativeCouncil;
+	type WeightInfo = ();
 }
 
 parameter_types! {

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -245,7 +245,7 @@ impl assets_registry::Config for Runtime {
 }
 
 parameter_types! {
-	pub const FromPalletId: PalletId = PalletId(*b"ics20fee");
+	pub FeeAccount: AccountId32 = AccountId32::from(hex!("a72ef3ce1ecd46163bc5e23fd3e6a4623d9717c957fb59001a5d4cb949150f28"));
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
 	pub const MaxStringSizeAddress: u32 = 100;
@@ -255,7 +255,7 @@ parameter_types! {
 
 impl revenue_ibc::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type FromPalletId = FromPalletId;
+	type FeeAccount = FeeAccount;
 	type IntermediatePalletId = IntermediatePalletId;
 	type ForeignAssetId = primitives::currency::ForeignAssetId;
 	type AssetId = CurrencyId;

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -248,7 +248,7 @@ parameter_types! {
 	pub const FromPalletId: PalletId = PalletId(*b"ics20fee");
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
-	pub const MaxStringSizeAdress: u32 = 100;
+	pub const MaxStringSizeAddress: u32 = 100;
 	pub const MaxStringSize: u32 = 1000;
 }
 
@@ -260,7 +260,7 @@ impl revenue_ibc::Config for Runtime {
 	type AssetId = CurrencyId;
 	type AssetsRegistry = AssetsRegistry;
 	type Assets = Assets;
-	type MaxStringSizeAdress = MaxStringSizeAdress;
+	type MaxStringSizeAddress = MaxStringSizeAddress;
 	type MaxStringSizeMemo = MaxStringSize;
 	type Admin = EnsureRootOrTwoThirdNativeCouncil;
 	type WeightInfo = ();

--- a/code/parachain/runtime/picasso/src/lib.rs
+++ b/code/parachain/runtime/picasso/src/lib.rs
@@ -249,7 +249,8 @@ parameter_types! {
 	pub const IntermediatePalletId: PalletId = PalletId(*b"revenibc");
 	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
 	pub const MaxStringSizeAddress: u32 = 100;
-	pub const MaxStringSize: u32 = 1000;
+	#[derive(PartialEq, Eq, Copy, Clone, codec::Encode, codec::Decode, codec::MaxEncodedLen, Debug, TypeInfo)]
+	pub const MaxStringSizeMemo: u32 = 1000;
 }
 
 impl revenue_ibc::Config for Runtime {
@@ -261,7 +262,7 @@ impl revenue_ibc::Config for Runtime {
 	type AssetsRegistry = AssetsRegistry;
 	type Assets = Assets;
 	type MaxStringSizeAddress = MaxStringSizeAddress;
-	type MaxStringSizeMemo = MaxStringSize;
+	type MaxStringSizeMemo = MaxStringSizeMemo;
 	type Admin = EnsureRootOrTwoThirdNativeCouncil;
 	type WeightInfo = ();
 }

--- a/flake/process-compose.nix
+++ b/flake/process-compose.nix
@@ -109,16 +109,6 @@
             ${pkgs.lib.meta.getExe self'.packages.devnet-xc}
           '';
         };
-
-        devnet-xc-picasso-cosmos = pkgs.writeShellApplication {
-          runtimeInputs = devnetTools.withBaseContainerTools;
-          name = "devnet-xc-fresh";
-          text = ''
-            rm --force --recursive ${devnet-root-directory}             
-            mkdir --parents ${devnet-root-directory}
-            ${pkgs.lib.meta.getExe self'.packages.devnet-xc-picasso-cosmos}
-          '';
-        };
       };
       process-compose = rec {
         devnet-xc-background = devnet-xc // { tui = false; };

--- a/flake/process-compose.nix
+++ b/flake/process-compose.nix
@@ -207,7 +207,7 @@
           };
         };
 
-         devnet-xc = {
+        devnet-xc = {
           settings = {
             log_level = "trace";
             log_location = "/tmp/composable-devnet/pc.log";

--- a/flake/process-compose.nix
+++ b/flake/process-compose.nix
@@ -256,7 +256,7 @@
                 } // parachain-startup;
                 namespace = "polkadot";
               };
-         
+
               osmosis-centauri-hermes-init = {
                 command = self'.packages.osmosis-centauri-hermes-init;
                 depends_on = {

--- a/flake/process-compose.nix
+++ b/flake/process-compose.nix
@@ -202,66 +202,6 @@
             log_level = "trace";
             log_location = "/tmp/composable-devnet/pc.log";
             processes = {
-              eth-gen = {
-                command = self'.packages.eth-gen;
-                log_location = "${devnet-root-directory}/eth-gen.log";
-                availability = { restart = chain-restart; };
-                namespace = "ethereum";
-              };
-              eth-consensus-gen = {
-                command = self'.packages.eth-consensus-gen;
-                log_location = "${devnet-root-directory}/eth-consensus-gen.log";
-                availability = { restart = chain-restart; };
-                depends_on = {
-                  "eth-gen".condition = "process_completed_successfully";
-                };
-                namespace = "ethereum";
-              };
-              eth-executor-gen = {
-                command = self'.packages.eth-executor-gen;
-                log_location = "${devnet-root-directory}/eth-executor-gen.log";
-                availability = { restart = chain-restart; };
-                depends_on = {
-                  "eth-gen".condition = "process_completed_successfully";
-                };
-                namespace = "ethereum";
-              };
-              eth-executor = {
-                command = self'.packages.eth-executor;
-                log_location = "${devnet-root-directory}/eth-executor.log";
-                availability = { restart = chain-restart; };
-                depends_on = {
-                  "eth-executor-gen".condition =
-                    "process_completed_successfully";
-                };
-                readiness_probe = {
-                  exec.command = ''
-                    test -f ${devnet-root-directory}/eth/jwtsecret
-                  '';
-                } // parachain-startup;
-                namespace = "ethereum";
-              };
-              eth-consensus = {
-                command = self'.packages.eth-consensus;
-                log_location = "${devnet-root-directory}/eth-consensus.log";
-                availability = { restart = chain-restart; };
-                depends_on = {
-                  "eth-consensus-gen".condition =
-                    "process_completed_successfully";
-                  "eth-executor".condition = "process_healthy";
-                };
-                namespace = "ethereum";
-              };
-              eth-validator = {
-                command = self'.packages.eth-validator;
-                log_location = "${devnet-root-directory}/eth-validator.log";
-                availability = { restart = chain-restart; };
-                depends_on = {
-                  "eth-consensus-gen".condition =
-                    "process_completed_successfully";
-                };
-                namespace = "ethereum";
-              };
               centauri = {
                 command = pkgs.writeShellApplication {
                   runtimeInputs = devnetTools.withBaseContainerTools;
@@ -316,17 +256,7 @@
                 } // parachain-startup;
                 namespace = "polkadot";
               };
-              composable = {
-                command = self'.packages.zombienet-composable-westend-b;
-                availability = { restart = chain-restart; };
-                log_location = "${devnet-root-directory}/composable.log";
-                readiness_probe = {
-                  exec.command = ''
-                    curl --header "Content-Type: application/json" --data '{"id":1, "jsonrpc":"2.0", "method" : "assets_listAssets"}' http://localhost:29988
-                  '';
-                } // parachain-startup;
-                namespace = "polkadot";
-              };
+         
               osmosis-centauri-hermes-init = {
                 command = self'.packages.osmosis-centauri-hermes-init;
                 depends_on = {
@@ -396,61 +326,6 @@
                 availability = { restart = relay; };
               };
 
-              composable-picasso-ibc-init = {
-                command = self'.packages.composable-picasso-ibc-init;
-                log_location =
-                  "${devnet-root-directory}/composable-picasso-ibc-init.log";
-                depends_on = {
-                  "picasso-centauri-ibc-channels-init".condition =
-                    "process_completed_successfully";
-                  "composable".condition = "process_healthy";
-                  "picasso".condition = "process_healthy";
-                };
-                availability = { restart = relay; };
-              };
-              composable-picasso-ibc-connection-init = {
-                command = ''
-                  HOME="${devnet-root-directory}/composable-picasso-ibc"
-                  export HOME                
-                  RUST_LOG="hyperspace=info,hyperspace_parachain=debug,hyperspace_cosmos=debug"
-                  export RUST_LOG      
-                  ${self'.packages.hyperspace-composable-rococo-picasso-rococo}/bin/hyperspace create-connection --config-a ${devnet-root-directory}/composable-picasso-ibc/config-chain-a.toml --config-b ${devnet-root-directory}/composable-picasso-ibc/config-chain-b.toml --config-core ${devnet-root-directory}/composable-picasso-ibc/config-core.toml --delay-period 10
-                '';
-                log_location =
-                  "${devnet-root-directory}/composable-picasso-ibc-connection-init.log";
-                depends_on = {
-                  "composable-picasso-ibc-init".condition =
-                    "process_completed_successfully";
-                };
-                availability = { restart = relay; };
-              };
-
-              composable-picasso-ibc-channels-init = {
-                command = ''
-                  HOME="${devnet-root-directory}/composable-picasso-ibc"
-                  export HOME       
-                  RUST_LOG="hyperspace=info,hyperspace_parachain=debug,hyperspace_cosmos=debug"
-                  export RUST_LOG
-                  ${self'.packages.hyperspace-composable-rococo-picasso-rococo}/bin/hyperspace create-channel --config-a ${devnet-root-directory}/composable-picasso-ibc/config-chain-a.toml --config-b ${devnet-root-directory}/composable-picasso-ibc/config-chain-b.toml --config-core ${devnet-root-directory}/composable-picasso-ibc/config-core.toml --delay-period 10 --port-id transfer --version ics20-1 --order unordered
-                '';
-                log_location =
-                  "${devnet-root-directory}/composable-picasso-ibc-channels-init.log";
-                depends_on = {
-                  "composable-picasso-ibc-connection-init".condition =
-                    "process_completed_successfully";
-                };
-                availability = { restart = relay; };
-              };
-              composable-picasso-ibc-relay = {
-                command = self'.packages.composable-picasso-ibc-relay;
-                log_location =
-                  "${devnet-root-directory}/composable-picasso-ibc-relay.log";
-                depends_on = {
-                  "composable-picasso-ibc-channels-init".condition =
-                    "process_completed_successfully";
-                };
-                availability = { restart = relay; };
-              };
             };
           };
         };


### PR DESCRIPTION
This implementation is looking for:
1) add assets that will be transferred every PERIOD amount of blocks from picasso to centauri address with memo provided
2) on adding new asset to transfer and  on period initial set up, reset values of current treasury account to calculate the difference of 20% if new balance is large than the previous
3) use revenue-ibc pallet id as intermediate account, such that in case of ibc transfer failure, funds will come back to revenue-ibc pallet account and they will be resent at the end of the period with new funds, or triggered manually

Current implementation works for 1 asset since memo doesnt support templating. Asset will be added to AllowedAsset struct

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](../terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

