### PR TITLE
fix(lsd-relayblock): take relay block number from validation data

### DIFF
--- a/code/parachain/frame/liquid-staking/src/lib.rs
+++ b/code/parachain/frame/liquid-staking/src/lib.rs
@@ -1840,7 +1840,9 @@ pub mod pallet {
 				&offset,
 			);
 
-			EraStartBlock::<T>::put(T::RelayChainValidationDataProvider::current_block_number());
+			let relay_block_number: BlockNumberFor<T> =
+				ValidationData::<T>::get().map(|i| i.relay_parent_number).unwrap_or(0).into();
+			EraStartBlock::<T>::put(relay_block_number);
 			CurrentEra::<T>::mutate(|e| *e = e.saturating_add(offset));
 
 			// ignore error

--- a/code/parachain/frame/liquid-staking/src/tests.rs
+++ b/code/parachain/frame/liquid-staking/src/tests.rs
@@ -705,7 +705,8 @@ fn test_on_initialize_work() {
 		LiquidStaking::on_finalize(System::block_number());
 		System::set_block_number(System::block_number() + 1);
 		LiquidStaking::on_initialize(System::block_number());
-		assert_eq!(EraStartBlock::<Test>::get(), total_era_blocknumbers);
+		let current_era: u64 = CurrentEra::<Test>::get() as u64;
+		assert_eq!(EraStartBlock::<Test>::get(), total_era_blocknumbers * current_era);
 		// ValidationDataProvider return relay_parent_number = 100
 		// total_era_blocknumbers  = 10 so the current era is 10
 		assert_eq!(CurrentEra::<Test>::get(), 10);


### PR DESCRIPTION
Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](github.com/ComposableFi/env/terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

