### PR TITLE
fix(devnet): set cw genesis contracts to empty vec

### DIFF
--- a/code/parachain/node/src/chain_spec/picasso.rs
+++ b/code/parachain/node/src/chain_spec/picasso.rs
@@ -26,19 +26,7 @@ pub fn genesis_config(
 	existential_deposit: Balance,
 	treasury: AccountId,
 ) -> picasso_runtime::GenesisConfig {
-	let contracts =
-		[option_env!("CW_CVM_OUTPOST_WASM_PATH"), option_env!("CW_CVM_EXECUTOR_WASM_PATH")]
-			.into_iter()
-			.flatten()
-			.map(|path| match std::fs::read(path).map(|bytes| bytes.try_into()) {
-				Ok(Ok(data)) => data,
-				Ok(Err(_err)) => panic!("{path}: wasm file is over size limit"),
-				Err(err) => panic!("{path}: {err}"),
-			})
-			.map(|contract| (root.clone(), contract))
-			.collect();
 
-	let cosmwasm = picasso_runtime::CosmwasmConfig { contracts };
 	let dex = picasso_runtime::PabloConfig {
 		pools: vec![
 			(root.clone(), CurrencyId(1), CurrencyId(4)),
@@ -106,7 +94,7 @@ pub fn genesis_config(
 			assets: primitives::topology::Picasso::assets(),
 			phantom: Default::default(),
 		},
-		cosmwasm,
+		cosmwasm: Default::default(),
 		pablo: dex,
 
 		tokens: Default::default(),

--- a/code/parachain/node/src/chain_spec/picasso.rs
+++ b/code/parachain/node/src/chain_spec/picasso.rs
@@ -26,7 +26,6 @@ pub fn genesis_config(
 	existential_deposit: Balance,
 	treasury: AccountId,
 ) -> picasso_runtime::GenesisConfig {
-
 	let dex = picasso_runtime::PabloConfig {
 		pools: vec![
 			(root.clone(), CurrencyId(1), CurrencyId(4)),


### PR DESCRIPTION
set cw genesis contracts to empty vec

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](github.com/ComposableFi/env/terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

