### PR TITLE
feat(defaultfee): Specify default fee for network

### DIFF
--- a/code/parachain/runtime/composable/src/fees.rs
+++ b/code/parachain/runtime/composable/src/fees.rs
@@ -67,6 +67,8 @@ impl asset_tx_payment::HandleCredit<AccountId, Tokens> for TransferToTreasuryOrD
 
 parameter_types! {
 	pub AssetConfigHoldIdentifier: TemporalHoldIdentifier = ();
+	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
+	pub DefaultFeeAsset: CurrencyId = CurrencyId::DOT;
 }
 
 impl asset_tx_payment::Config for Runtime {
@@ -91,4 +93,7 @@ impl asset_tx_payment::Config for Runtime {
 	type HoldIdentifierValue = AssetConfigHoldIdentifier;
 
 	type HoldIdentifier = TemporalHoldIdentifier;
+
+	type NativeAssetId = NativeAssetId;
+	type DefaultFeeAsset = DefaultFeeAsset;
 }

--- a/code/parachain/runtime/composable/src/fees.rs
+++ b/code/parachain/runtime/composable/src/fees.rs
@@ -67,8 +67,8 @@ impl asset_tx_payment::HandleCredit<AccountId, Tokens> for TransferToTreasuryOrD
 
 parameter_types! {
 	pub AssetConfigHoldIdentifier: TemporalHoldIdentifier = ();
-	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
-	pub DefaultFeeAsset: CurrencyId = CurrencyId::DOT;
+	pub NativeAssetId: CurrencyId = CurrencyId::COMPOSABLE_LAYR;
+	pub DefaultFeeAsset: CurrencyId = CurrencyId::COMPOSABLE_DOT;
 }
 
 impl asset_tx_payment::Config for Runtime {

--- a/code/parachain/runtime/picasso/src/fees.rs
+++ b/code/parachain/runtime/picasso/src/fees.rs
@@ -61,6 +61,11 @@ impl asset_tx_payment::HandleCredit<AccountId, Tokens> for TransferToTreasuryOrD
 	}
 }
 
+parameter_types! {
+	pub NativeAssetId: CurrencyId = CurrencyId::PICA;
+	pub DefaultFeeAsset: CurrencyId = CurrencyId::PICA;
+}
+
 impl asset_tx_payment::Config for Runtime {
 	type Fungibles = Tokens;
 	type OnChargeAssetTransaction =
@@ -83,4 +88,7 @@ impl asset_tx_payment::Config for Runtime {
 	type HoldIdentifierValue = ();
 
 	type HoldIdentifier = ();
+
+	type NativeAssetId = NativeAssetId;
+	type DefaultFeeAsset = DefaultFeeAsset;
 }


### PR DESCRIPTION
added 2 fields to config: 

NativeAssetId to allow setting native token via set_payment_asset
DefaultFeeAsset which is used when PaymentAssets in asset-tx-payment is None

This way people who already set Dot to be fee asset will be able to use it, and new users wont need to set Dot to be default asset

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](github.com/ComposableFi/env/terraform/github.com/branches.tf) 

Makes review faster:
- [ ] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

