### PR TITLE
feat: Add HashedDescription XCM converter and remove TinkernetMultisig configs

### DIFF
--- a/code/Cargo.lock
+++ b/code/Cargo.lock
@@ -1721,6 +1721,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "ibc 0.43.1",
+ "impl-trait-for-tuples",
  "num-traits",
  "orml-tokens",
  "orml-traits",
@@ -8305,26 +8306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "orml-xcm-builder-kusama"
-version = "0.9.43"
-source = "git+https://github.com/open-web3-stack/orml-xcm-builder?branch=polkadot-v0.9.43#ce8b0f27860149d3ad31d77d44ee2343f54a32bc"
-dependencies = [
- "frame-support",
- "frame-system",
- "log 0.4.19",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic",
- "sp-core",
- "sp-io",
- "sp-runtime",
- "sp-std 5.0.0",
- "sp-weights",
- "xcm",
- "xcm-executor",
-]
-
-[[package]]
 name = "orml-xcm-support"
 version = "0.4.1-dev"
 source = "git+https://github.com/open-web3-stack/open-runtime-module-library?rev=7ecebeab7e3dbc2226ed58d32ee159271a8176ae#7ecebeab7e3dbc2226ed58d32ee159271a8176ae"
@@ -10348,7 +10329,6 @@ dependencies = [
  "orml-tokens",
  "orml-traits",
  "orml-unknown-tokens",
- "orml-xcm-builder-kusama",
  "orml-xcm-support",
  "orml-xtokens",
  "pablo-runtime-api",

--- a/code/Cargo.toml
+++ b/code/Cargo.toml
@@ -348,8 +348,6 @@ prost-build = "0.11.9"
 
 parity-scale-codec = { version = "3.5.0", default-features = false }
 
-orml-xcm-builder-kusama = { git = "https://github.com/open-web3-stack/orml-xcm-builder", branch = "polkadot-v0.9.43", default-features = false }
-
 
 wasm-instrument = { version = "0.4.0", default-features = false }
 wasmi = { version = "0.30.0", default-features = false }

--- a/code/parachain/runtime/common/Cargo.toml
+++ b/code/parachain/runtime/common/Cargo.toml
@@ -65,6 +65,8 @@ derive_more = "0.99.17"
 blake2-rfc = { version = "0.2.18", default-features = false }
 bs58 = { version = "0.5.0", default-features = false, features = ["alloc"] }
 
+impl-trait-for-tuples = "0.2.2"
+
 [dev-dependencies]
 authorship = { default-features = false, workspace = true }
 orml-tokens = { workspace = true, default-features = false }

--- a/code/parachain/runtime/common/src/xcmp.rs
+++ b/code/parachain/runtime/common/src/xcmp.rs
@@ -293,3 +293,127 @@ impl xcm_executor::traits::FilterAssetLocation for RelayReserveFromParachain {
 parameter_types! {
 	pub const ThisLocal: MultiLocation = primitives::topology::this::LOCAL;
 }
+
+// TODO: Remove after upgrading to `polkadot-v1.2.0` and replace types from xcm-builder.
+
+use codec::{Compact, Encode};
+use sp_io::hashing::blake2_256;
+use xcm_executor::traits::Convert as XcmConvert;
+
+/// Means of converting a location into a stable and unique descriptive identifier.
+pub trait DescribeLocation {
+	/// Create a description of the given `location` if possible. No two locations should have the
+	/// same descriptor.
+	fn describe_location(location: &MultiLocation) -> Option<Vec<u8>>;
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(30)]
+impl DescribeLocation for Tuple {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		for_tuples!( #(
+			match Tuple::describe_location(l) {
+				Some(result) => return Some(result),
+				None => {},
+			}
+		)* );
+		None
+	}
+}
+
+pub struct DescribeTerminus;
+impl DescribeLocation for DescribeTerminus {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, Here) => Some(Vec::new()),
+			_ => return None,
+		}
+	}
+}
+
+pub struct DescribePalletTerminal;
+impl DescribeLocation for DescribePalletTerminal {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, X1(PalletInstance(i))) =>
+				Some((b"Pallet", Compact::<u32>::from(*i as u32)).encode()),
+			_ => return None,
+		}
+	}
+}
+
+pub struct DescribeAccountId32Terminal;
+impl DescribeLocation for DescribeAccountId32Terminal {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, X1(AccountId32 { id, .. })) => Some((b"AccountId32", id).encode()),
+			_ => return None,
+		}
+	}
+}
+
+pub struct DescribeAccountKey20Terminal;
+impl DescribeLocation for DescribeAccountKey20Terminal {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, X1(AccountKey20 { key, .. })) => Some((b"AccountKey20", key).encode()),
+			_ => return None,
+		}
+	}
+}
+
+pub type DescribeAccountIdTerminal = (DescribeAccountId32Terminal, DescribeAccountKey20Terminal);
+
+pub struct DescribeBodyTerminal;
+impl DescribeLocation for DescribeBodyTerminal {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, &l.interior) {
+			(0, X1(Plurality { id, part })) => Some((b"Body", id, part).encode()),
+			_ => return None,
+		}
+	}
+}
+
+pub type DescribeAllTerminal = (
+	DescribeTerminus,
+	DescribePalletTerminal,
+	DescribeAccountId32Terminal,
+	DescribeAccountKey20Terminal,
+	DescribeBodyTerminal,
+);
+
+pub struct DescribeFamily<DescribeInterior>(PhantomData<DescribeInterior>);
+impl<Suffix: DescribeLocation> DescribeLocation for DescribeFamily<Suffix> {
+	fn describe_location(l: &MultiLocation) -> Option<Vec<u8>> {
+		match (l.parents, l.interior.first()) {
+			(0, Some(Parachain(index))) => {
+				let tail = l.interior.split_first().0;
+				let interior = Suffix::describe_location(&tail.into())?;
+				Some((b"ChildChain", Compact::<u32>::from(*index), interior).encode())
+			},
+			(1, Some(Parachain(index))) => {
+				let tail = l.interior.split_first().0;
+				let interior = Suffix::describe_location(&tail.into())?;
+				Some((b"SiblingChain", Compact::<u32>::from(*index), interior).encode())
+			},
+			(1, _) => {
+				let tail = l.interior.into();
+				let interior = Suffix::describe_location(&tail)?;
+				Some((b"ParentChain", interior).encode())
+			},
+			_ => return None,
+		}
+	}
+}
+
+pub struct HashedDescription<AccountId, Describe>(PhantomData<(AccountId, Describe)>);
+impl<AccountId: From<[u8; 32]> + Clone, Describe: DescribeLocation>
+	XcmConvert<MultiLocation, AccountId> for HashedDescription<AccountId, Describe>
+{
+	fn convert(value: MultiLocation) -> Result<AccountId, MultiLocation> {
+		if let Some(description) = Describe::describe_location(&value) {
+			Ok(blake2_256(&description).into())
+		} else {
+			Err(value)
+		}
+	}
+}

--- a/code/parachain/runtime/picasso/Cargo.toml
+++ b/code/parachain/runtime/picasso/Cargo.toml
@@ -134,8 +134,6 @@ ibc-primitives = { workspace = true, default-features = false }
 ibc-runtime-api = { workspace = true, default-features = false }
 pallet-ibc = { workspace = true, default-features = false }
 
-orml-xcm-builder-kusama = { workspace = true, default-features = false }
-
 serde-json-wasm = { workspace = true, default-features = false }
 
 cosmwasm-vm = { workspace = true, default-features = false, features = [
@@ -240,7 +238,6 @@ std = [
 	"orml-tokens/std",
 	"orml-traits/std",
 	"orml-unknown-tokens/std",
-	"orml-xcm-builder-kusama/std",
 	"orml-xcm-support/std",
 	"orml-xtokens/std",
 	"pablo-runtime-api/std",

--- a/code/parachain/runtime/picasso/src/xcmp.rs
+++ b/code/parachain/runtime/picasso/src/xcmp.rs
@@ -93,11 +93,7 @@ pub type Barrier = (
 	AllowSubscriptionsFrom<ParentOrSiblings>,
 	AllowTopLevelPaidExecutionFrom<Everything>,
 	TakeWeightCredit,
-	WithComputedOrigin<
-		AllowTopLevelPaidExecutionFrom<orml_xcm_builder_kusama::TinkernetMultisigMultiLocation>,
-		UniversalLocation,
-		ConstU32<8>,
-	>,
+	WithComputedOrigin<AllowTopLevelPaidExecutionFrom<Everything>, UniversalLocation, ConstU32<8>>,
 );
 
 pub type LocalOriginToLocation = SignedToAccountId32<RuntimeOrigin, AccountId, RelayNetwork>;
@@ -121,8 +117,8 @@ pub type LocationToAccountId = (
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	// Straight up local `AccountId32` origins just alias directly to `AccountId`.
 	AccountId32Aliases<RelayNetwork, AccountId>,
-	// Mapping Tinkernet multisig to the correctly derived AccountId32.
-	orml_xcm_builder_kusama::TinkernetMultisigAsAccountId<AccountId>,
+	// Foreign locations alias into accounts according to a hash of their standard description.
+	HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
 	AccountId32MultihopTx<AccountId>,
 );
 
@@ -220,7 +216,6 @@ pub type XcmOriginToTransactDispatchOrigin = (
 	// Native signed account converter; this just converts an `AccountId32` origin into a normal
 	// `Origin::Signed` origin of the same 32-byte value.
 	SignedAccountId32AsNative<RelayNetwork, RuntimeOrigin>,
-	orml_xcm_builder_kusama::TinkernetMultisigAsNativeOrigin<RuntimeOrigin>,
 	// Xcm origins can be represented natively under the Xcm pallet's Xcm origin.
 	XcmPassthrough<RuntimeOrigin>,
 );


### PR DESCRIPTION
This PR adds the common XCM location converter HashedDescription, which is used across the ecosystem, to Picasso.
Since the current Polkadot SDK version in use does not contain these configs, they are temporarily pulled locally into `parachains/runtime/common` and added to the Picasso runtime from the `common` local crate.

For reference, chains using HashedDescription include the [relay chain](https://github.com/polkadot-fellows/runtimes/blob/main/relay/kusama/src/xcm_config.rs#L76) and system parachains like the [Asset Hub](https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs#L93).

Another chain also using HashedDescription but pulling it from a later Polkadot SDK version is [Astar](https://github.com/AstarNetwork/Astar/blob/master/primitives/src/xcm/mod.rs#L277-L390)


Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](github.com/ComposableFi/env/terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

