### PR TITLE
docs(readme): fix link to RELEASE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Refer to the [Releases](https://github.com/ComposableFi/composable/releases) pag
 
 ### Release Process
 
-Refer to [RELEASE.md](./RELEASE.MD).
+Refer to [RELEASE.md](./RELEASE.md).
 
 ## Nix
 


### PR DESCRIPTION
I noticed a link was broken while reading through the docs, so I fixed it.

Required for merge:
- [ ] `pr-workflow-check / draft-release-check` is ✅ success
- Other rules GitHub shows you, or can be read in [configuration](github.com/ComposableFi/env/terraform/github.com/branches.tf) 

Makes review faster:
- [x] PR title is my best effort to provide summary of changes and has clear text to be part of release notes 
- [ ] I marked PR by `misc` label if it should not be in release notes
- [ ] Linked Zenhub/Github/Slack/etc reference if one exists
- [ ] I was clear on what type of deployment required to release my changes (node, runtime, contract, indexer, on chain operation, frontend, infrastructure) if any in PR title or description
- [ ] Added reviewer into `Reviewers`
- [ ] I tagged(`@`) or used other form of notification of one person who I think can handle best review of this PR
- [ ] I have proved that PR has no general regressions of relevant features and processes required to release into production
- [ ] Any dependency updates made, was done according guides from relevant dependency
- Clicking all checkboxes 
- Adding detailed description of changes when it feels appropriate (for example when PR is big)

